### PR TITLE
Remove the PathEmpty ADT member

### DIFF
--- a/core/src/main/scala/org/http4s/rho/RouteExecutor.scala
+++ b/core/src/main/scala/org/http4s/rho/RouteExecutor.scala
@@ -116,18 +116,18 @@ trait ExecutableCompiler {
 
         case PathCapture(_, f, _) => f.parse(pop).map{ i => i::stack}
 
+        case PathMatch("") if currentPath.head.length == 0 => // Needs to be the empty path
+          pop
+          ParserSuccess(stack)
+
+
         case PathMatch("") => ParserSuccess(stack)    // "" is consider a NOOP
 
         case PathMatch(s) =>
           if (pop == s) ParserSuccess(stack)
           else null
 
-        case PathEmpty => // Needs to be the empty path
-          if (currentPath.head.length == 0) {
-            pop
-            ParserSuccess(stack)
-          }
-          else null
+
 
         case CaptureTail =>
           val p = currentPath

--- a/core/src/main/scala/org/http4s/rho/bits/PathAST.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/PathAST.scala
@@ -59,7 +59,7 @@ object PathAST {
 
   case object CaptureTail extends PathRule
 
-  case object PathEmpty extends PathRule
+//  case object PathEmpty extends PathRule
 
   case class MetaCons(path: PathRule, meta: Metadata) extends PathRule
 

--- a/core/src/main/scala/org/http4s/rho/bits/PathTree.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/PathTree.scala
@@ -105,12 +105,6 @@ trait PathTree {
         case CaptureTail =>
           val v = if (variadic != null) variadic ++ action else action
           clone(paths, v, end)
-
-        case PathEmpty if tail.isEmpty =>
-          // an empty path should be interpreted as '/'
-          append(List(PathMatch("")), action)
-
-        case PathEmpty => append(tail, action)
       }
 
       case Nil =>  // this is the end of the stack

--- a/core/src/main/scala/org/http4s/rho/bits/UriConverter.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/UriConverter.scala
@@ -21,10 +21,10 @@ object UriConverter {
       case Nil                         => acc
       case PathAnd(a, b) :: rs         => go(a :: b :: rs, acc)
       case PathOr(a, _) :: rs          => go(a :: rs, acc) // we decided to take the first root
+      case PathMatch("") :: rs         => go(rs, acc)
       case PathMatch(s) :: rs          => go(rs, PathElm(s) :: acc)
       case PathCapture(id, _, _) :: rs => go(rs, PathExp(id) :: acc)
       case CaptureTail :: rs         => go(rs, acc)
-      case PathEmpty :: rs             => go(rs, acc)
       case MetaCons(p, _) :: rs        => go(p::rs, acc)
     }
     Success(go(List(rule), Nil).reverse)

--- a/core/src/main/scala/org/http4s/rho/package.scala
+++ b/core/src/main/scala/org/http4s/rho/package.scala
@@ -15,12 +15,14 @@ package object rho extends Http4s with ResultSyntaxInstances {
 
   private val stringTag = implicitly[TypeTag[String]]
 
-  implicit def method(m: Method): PathBuilder[HNil] = new PathBuilder(m, PathEmpty)
+  implicit def method(m: Method): PathBuilder[HNil] = new PathBuilder(m, pathEmpty)
 
   implicit def pathMatch(s: String): TypedPath[HNil] = TypedPath(PathMatch(s))
 
   implicit def pathMatch(s: Symbol): TypedPath[String :: HNil] =
     TypedPath(PathCapture(s.name, StringParser.strParser, stringTag))
+
+  val pathEmpty: PathRule = PathMatch("")
 
   /**
    * Defines a parameter in query string that should be bound to a route definition.
@@ -56,7 +58,7 @@ package object rho extends Http4s with ResultSyntaxInstances {
    * val hello = Root / "hello"
    * }}}
    */
-  def root(): TypedPath[HNil] = TypedPath(PathEmpty)
+  def root(): TypedPath[HNil] = TypedPath(pathEmpty)
 
   def * : CaptureTail.type = CaptureTail
 

--- a/swagger/src/main/scala/org/http4s/rho/swagger/package.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/package.scala
@@ -4,7 +4,6 @@ import java.sql.Timestamp
 import java.util.Date
 import org.http4s.Method
 import org.http4s.rho.bits.{TextMetaData, PathAST}
-import org.http4s.rho.bits.PathAST.PathEmpty
 import shapeless.HNil
 
 import scala.reflect.runtime.universe._
@@ -18,7 +17,7 @@ package object swagger {
 
   /** Add support for adding documentation before a route using the ** operator */
   implicit class StrOps(description: String) {
-    def **(method: Method): PathBuilder[HNil] = **(new PathBuilder[HNil](method, PathEmpty))
+    def **(method: Method): PathBuilder[HNil] = **(new PathBuilder[HNil](method, pathEmpty))
 
     def **[T<: HNil](builder: PathBuilder[T]): PathBuilder[T] =
       new PathBuilder(builder.method, PathAST.MetaCons(builder.path, RouteDesc(description)))


### PR DESCRIPTION
I like this because it drops a member of the PathRule ADTs. The downside is that its a little less verbose, but I feel its good because there is always the corner case of `PathMatch("")` that we should be worrying about anyway.

If there are no objections, I'll merge this tomorrow afternoon (~2 or 3 EST).
