### PR TITLE
Regard PathInfo of a request when building an Uri or UriTemplate

### DIFF
--- a/core/src/main/scala/org/http4s/rho/PathBuilder.scala
+++ b/core/src/main/scala/org/http4s/rho/PathBuilder.scala
@@ -34,7 +34,6 @@ final class PathBuilder[T <: HList](val method: Method, val path: PathRule)
 
   def /(s: String): PathBuilder[T] = new PathBuilder(method, PathAnd(path, PathMatch(s)))
 
-
   def /(s: Symbol): PathBuilder[String :: T] = {
     val capture = PathCapture(s.name, StringParser.strParser, implicitly[TypeTag[String]])
     new PathBuilder(method, PathAnd(path, capture))
@@ -62,6 +61,10 @@ final class PathBuilder[T <: HList](val method: Method, val path: PathRule)
   override def makeAction[F](f: F, hf: HListToFunc[T, F]): RhoAction[T, F] =
     new RhoAction(Router(method, path, EmptyQuery, EmptyHeaderRule), f, hf)
 
-  override val asUriTemplate = for (p <- UriConverter.createPath(path)) yield UriTemplate(path = p)
+  private val uriTemplate =
+    for (p <- UriConverter.createPath(path))
+      yield UriTemplate(path = p)
 
+  override def asUriTemplate(request: Request) =
+    UriConvertible.respectPathInfo(uriTemplate, request)
 }

--- a/core/src/main/scala/org/http4s/rho/QueryBuilder.scala
+++ b/core/src/main/scala/org/http4s/rho/QueryBuilder.scala
@@ -28,9 +28,12 @@ case class QueryBuilder[T <: HList](method: Method,
 
   override def headers: HeaderRule = EmptyHeaderRule
 
-  override val asUriTemplate =
+  private val uriTemplate =
     for {
       p <- UriConverter.createPath(path)
       q <- UriConverter.createQuery(query)
     } yield UriTemplate(path = p, query = Some(q))
+
+  override def asUriTemplate(request: Request) =
+    UriConvertible.respectPathInfo(uriTemplate, request)
 }

--- a/core/src/main/scala/org/http4s/rho/TypedBuilder.scala
+++ b/core/src/main/scala/org/http4s/rho/TypedBuilder.scala
@@ -22,9 +22,12 @@ trait TypedBuilder[T <: HList] extends UriConvertible {
   /** Untyped AST representation of the [[Header]]s to operate on */
   def headers: HeaderRule
 
-  override def asUriTemplate =
+  private val uriTemplate =
     for {
       p <- UriConverter.createPath(path)
       q <- UriConverter.createQuery(query)
     } yield UriTemplate(path = p, query = Some(q))
+
+  override def asUriTemplate(request: Request) =
+    UriConvertible.respectPathInfo(uriTemplate, request)
 }

--- a/core/src/main/scala/org/http4s/rho/UriConvertible.scala
+++ b/core/src/main/scala/org/http4s/rho/UriConvertible.scala
@@ -13,9 +13,9 @@ trait UriConvertible {
    * multiple paths only one way will be resolved as instance of `Uri`.
    * If the route is a URI Template but not an URI `None` will be returned.
    */
-  def asUri: Try[Uri] =
+  def asUri(request: Request): Try[Uri] =
     for {
-      t <- asUriTemplate
+      t <- asUriTemplate(request)
       u <- t.toUriIfPossible
     } yield { u }
 
@@ -25,6 +25,26 @@ trait UriConvertible {
    * If the conversion fails `None` is returned. In case your route has
    * multiple paths only one way will be resolved as instance of `UriTemplate`.
    */
-  def asUriTemplate: Try[UriTemplate]
+  def asUriTemplate(request: Request): Try[UriTemplate]
+
+}
+
+object UriConvertible {
+
+  private[rho] def respectPathInfo(uriTemplate: Try[UriTemplate], request: Request): Try[UriTemplate] =
+    for (tpl <- uriTemplate)
+      yield UriConvertible.addPathInfo(request, tpl)
+
+  private[rho] def addPathInfo(request: Request, tpl: UriTemplate): UriTemplate = {
+    val caret = request.attributes.get(Request.Keys.PathInfoCaret).getOrElse(0)
+    if (caret == 0) tpl
+    else if (caret == 1 && request.scriptName == "/") tpl
+    else tpl.copy(path = UriTemplate.PathElm(removeSlash(request.scriptName)) :: tpl.path)
+  }
+
+  private[rho] def removeSlash(path: String): String = {
+    if (path.startsWith("/")) path.substring(1)
+    else path
+  }
 
 }

--- a/core/src/main/scala/org/http4s/rho/bits/PathAST.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/PathAST.scala
@@ -43,7 +43,12 @@ object PathAST {
     def +?[T1 <: HList](q: TypedQuery[T1])(implicit prep: Prepend[T1, T]): RequestLineBuilder[prep.Out] =
       RequestLineBuilder(rule, q.rule)
 
-    override val asUriTemplate = for (p <- UriConverter.createPath(rule)) yield UriTemplate(path = p)
+    private val uriTemplate =
+      for (p <- UriConverter.createPath(rule))
+        yield UriTemplate(path = p)
+
+    override def asUriTemplate(request: Request) =
+      UriConvertible.respectPathInfo(uriTemplate, request)
   }
 
   /** The root type of the parser AST */
@@ -58,8 +63,6 @@ object PathAST {
   case class PathCapture(name: String, parser: StringParser[_], m: TypeTag[_]) extends PathRule
 
   case object CaptureTail extends PathRule
-
-//  case object PathEmpty extends PathRule
 
   case class MetaCons(path: PathRule, meta: Metadata) extends PathRule
 

--- a/core/src/main/scala/org/http4s/rho/bits/QueryAST.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/QueryAST.scala
@@ -26,7 +26,12 @@ object QueryAST {
      */
     val names: List[String] = collectNames(rule)
 
-    override val asUriTemplate = for (q <- UriConverter.createQuery(rule)) yield UriTemplate(query = Some(q))
+    private val uriTemplate =
+      for (q <- UriConverter.createQuery(rule))
+        yield UriTemplate(query = Some(q))
+
+    override def asUriTemplate(request: Request) =
+      UriConvertible.respectPathInfo(uriTemplate, request)
   }
 
   sealed trait QueryRule

--- a/core/src/test/scala/org/http4s/rho/RouteAsUriTemplateSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/RouteAsUriTemplateSpec.scala
@@ -11,117 +11,119 @@ import bits.MethodAliases.GET
 
 class RouteAsUriTemplateSpec extends Specification {
 
-  "PathBuilder as UriTemplate" should {
+  val request = Request()
+
+  "PathBuilder.asUriTemplate" should {
     "convert to /hello" in {
       val route = GET / "hello"
-      route.asUriTemplate.get must equalTo(UriTemplate(path = List(PathElm("hello"))))
+      route.asUriTemplate(request).get must equalTo(UriTemplate(path = List(PathElm("hello"))))
     }
     "convert to /hello/world" in {
       val route = GET / "hello" / "world"
-      route.asUriTemplate.get must equalTo(UriTemplate(path = List(PathElm("hello"), PathElm("world"))))
+      route.asUriTemplate(request).get must equalTo(UriTemplate(path = List(PathElm("hello"), PathElm("world"))))
     }
     "convert to /hello{/world}" in {
       val route = GET / "hello" / 'world
-      route.asUriTemplate.get must equalTo(UriTemplate(path = List(PathElm("hello"), PathExp("world"))))
+      route.asUriTemplate(request).get must equalTo(UriTemplate(path = List(PathElm("hello"), PathExp("world"))))
     }
     "convert to /hello/world/next/time" in {
       val route1 = "hello" / "world"
       val route2 = "next" / "time"
       val route = GET / route1 / route2
-      route.asUriTemplate.get must equalTo(UriTemplate(path = List(PathElm("hello"), PathElm("world"), PathElm("next"), PathElm("time"))))
+      route.asUriTemplate(request).get must equalTo(UriTemplate(path = List(PathElm("hello"), PathElm("world"), PathElm("next"), PathElm("time"))))
     }
     "convert to {/id}" in {
       val route = GET / pathVar[Int]("id")
-      route.asUriTemplate.get must equalTo(UriTemplate(path = List(PathExp("id"))))
+      route.asUriTemplate(request).get must equalTo(UriTemplate(path = List(PathExp("id"))))
     }
     "convert pathVar[Int] to {/int}" in {
       val route = GET / pathVar[Int]
-      route.asUriTemplate.get must equalTo(UriTemplate(path = List(PathExp("int"))))
+      route.asUriTemplate(request).get must equalTo(UriTemplate(path = List(PathExp("int"))))
       true
     }
     "convert to /orders{/id}/items" in {
       val route = GET / "orders" / pathVar[Int]("id") / "items"
-      route.asUriTemplate.get must equalTo(UriTemplate(path = List(PathElm("orders"), PathExp("id"), PathElm("items"))))
+      route.asUriTemplate(request).get must equalTo(UriTemplate(path = List(PathElm("orders"), PathExp("id"), PathElm("items"))))
     }
   }
 
-  "QueryBuilder as UriTemplate" should {
+  "QueryBuilder.asUriTemplate" should {
     "convert to /hello{?world}" in {
       val route = GET / "hello" +? param[Int]("world")
       val p = List(PathElm("hello"))
       val q = Some(List(ParamExp("world")))
-      route.asUriTemplate.get must equalTo(UriTemplate(path = p, query = q))
+      route.asUriTemplate(request).get must equalTo(UriTemplate(path = p, query = q))
     }
     "convert to /hello/world{?start}{&start}" in {
       val route = GET / "hello" / "world" +? param[Int]("start") & param[Int]("limit")
       val p = List(PathElm("hello"), PathElm("world"))
       val q = Some(List(ParamExp("start"), ParamExp("limit")))
-      route.asUriTemplate.get must equalTo(UriTemplate(path = p, query = q))
+      route.asUriTemplate(request).get must equalTo(UriTemplate(path = p, query = q))
     }
   }
 
-  "RequestLineBuilder as UriTemplate" should {
+  "RequestLineBuilder.asUriTemplate" should {
     "convert to /hello{/world}" in {
       val requestLine = "hello" / pathVar[String]("world")
       val p = List(PathElm("hello"), PathExp("world"))
-      requestLine.asUriTemplate.get must equalTo(UriTemplate(path = p))
+      requestLine.asUriTemplate(request).get must equalTo(UriTemplate(path = p))
     }
     "convert to /hello{/world}/test" in {
       val requestLine = "hello" / pathVar[String]("world") / "user"
       val p = List(PathElm("hello"), PathExp("world"), PathElm("user"))
-      requestLine.asUriTemplate.get must equalTo(UriTemplate(path = p))
+      requestLine.asUriTemplate(request).get must equalTo(UriTemplate(path = p))
     }
     "convert to /hello{?world}" in {
       val requestLine = "hello" +? param[Int]("world")
       val p = List(PathElm("hello"))
       val q = Some(List(ParamExp("world")))
-      requestLine.asUriTemplate.get must equalTo(UriTemplate(path = p, query = q))
+      requestLine.asUriTemplate(request).get must equalTo(UriTemplate(path = p, query = q))
     }
     "convert to /hello/world{?start}{&limit}" in {
       val requestLine = "hello" / "world" +? param[Int]("start") & param[Int]("limit")
       val p = List(PathElm("hello"), PathElm("world"))
       val q = Some(List(ParamExp("start"), ParamExp("limit")))
-      requestLine.asUriTemplate.get must equalTo(UriTemplate(path = p, query = q))
+      requestLine.asUriTemplate(request).get must equalTo(UriTemplate(path = p, query = q))
     }
     "convert to /hello{/world}{?start}{&limit}" in {
       val requestLine = "hello" / pathVar[String]("world") +? param[Int]("start") & param[Int]("limit")
       val p = List(PathElm("hello"), PathExp("world"))
       val q = Some(List(ParamExp("start"), ParamExp("limit")))
-      requestLine.asUriTemplate.get must equalTo(UriTemplate(path = p, query = q))
+      requestLine.asUriTemplate(request).get must equalTo(UriTemplate(path = p, query = q))
     }
   }
 
-  "TypedPath as UriTemplate" should {
+  "TypedPath.asUriTemplate" should {
     "convert to /hello" in {
       val route = GET / "hello"
-      route.asUriTemplate.get must equalTo(UriTemplate(path = List(PathElm("hello"))))
+      route.asUriTemplate(request).get must equalTo(UriTemplate(path = List(PathElm("hello"))))
     }
     "convert to /hello/world" in {
       val route = "hello" / "world"
-      route.asUriTemplate.get must equalTo(UriTemplate(path = List(PathElm("hello"), PathElm("world"))))
+      route.asUriTemplate(request).get must equalTo(UriTemplate(path = List(PathElm("hello"), PathElm("world"))))
     }
     "convert to /hello{/world}" in {
       val route = "hello" / 'world
-      route.asUriTemplate.get must equalTo(UriTemplate(path = List(PathElm("hello"), PathExp("world"))))
+      route.asUriTemplate(request).get must equalTo(UriTemplate(path = List(PathElm("hello"), PathExp("world"))))
     }
     "convert to /hello/world/next/time" in {
       val route1 = "hello" / "world"
       val route2 = "next" / "time"
       val route = route1 && route2
-      route.asUriTemplate.get must equalTo(UriTemplate(path = List(PathElm("hello"), PathElm("world"), PathElm("next"), PathElm("time"))))
+      route.asUriTemplate(request).get must equalTo(UriTemplate(path = List(PathElm("hello"), PathElm("world"), PathElm("next"), PathElm("time"))))
     }
     "convert to {/id}" in {
       val route = pathVar[Int]("id")
-      route.asUriTemplate.get must equalTo(UriTemplate(path = List(PathExp("id"))))
+      route.asUriTemplate(request).get must equalTo(UriTemplate(path = List(PathExp("id"))))
     }
     "convert pathVar[Int] to {/int}" in {
       val route = pathVar[Int]
-      route.asUriTemplate.get must equalTo(UriTemplate(path = List(PathExp("int"))))
+      route.asUriTemplate(request).get must equalTo(UriTemplate(path = List(PathExp("int"))))
       true
     }
     "convert to /orders{/id}/items" in {
       val route = "orders" / pathVar[Int]("id") / "items"
-      route.asUriTemplate.get must equalTo(UriTemplate(path = List(PathElm("orders"), PathExp("id"), PathElm("items"))))
+      route.asUriTemplate(request).get must equalTo(UriTemplate(path = List(PathElm("orders"), PathExp("id"), PathElm("items"))))
     }
   }
 

--- a/core/src/test/scala/org/http4s/rho/UriConvertibleSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/UriConvertibleSpec.scala
@@ -1,0 +1,64 @@
+package org.http4s
+package rho
+
+import org.specs2.mutable.Specification
+import UriTemplate._
+import scala.util.Success
+import scala.util.Failure
+
+object UriConvertibleSpec extends Specification {
+
+  "UriConvertible.respectPathInfo" should {
+    "respect if URI template is available" in {
+      val request = Request(
+        uri = Uri(path = "/some"),
+        attributes = AttributeMap(AttributeEntry(Request.Keys.PathInfoCaret, 5)))
+      val path = List(PathElm("here"))
+      val query = Some(List(ParamVarExp("ref", "path")))
+      val tpl = UriTemplate(path = path, query = query)
+      UriConvertible.respectPathInfo(Success(tpl), request).get.toString must equalTo("/some/here?ref={path}")
+    }
+    "do nothing if URI template is not available" in {
+      val request = Request()
+      UriConvertible.respectPathInfo(Failure(new Exception("URI not available")), request).isFailure must_== true
+    }
+  }
+
+  "UriConvertible.addPathInfo" should {
+    "keep the path if PathInfoCaret is not available" in {
+      val request = Request(uri = Uri(path = "/some"))
+      val path = List(PathElm("here"))
+      val query = Some(List(ParamVarExp("ref", "path")))
+      val tpl = UriTemplate(path = path, query = query)
+      UriConvertible.addPathInfo(request, tpl).toString must equalTo("/here?ref={path}")
+    }
+    "keep the path if PathInfoCaret is 0" in {
+      val request = Request(
+        uri = Uri(path = "/some"),
+        attributes = AttributeMap(AttributeEntry(Request.Keys.PathInfoCaret, 0)))
+      val path = List(PathElm("here"))
+      val query = Some(List(ParamVarExp("ref", "path")))
+      val tpl = UriTemplate(path = path, query = query)
+      UriConvertible.addPathInfo(request, tpl).toString must equalTo("/here?ref={path}")
+    }
+    "keep the path if PathInfoCaret is 1" in {
+      val request = Request(
+        uri = Uri(path = "/some"),
+        attributes = AttributeMap(AttributeEntry(Request.Keys.PathInfoCaret, 1)))
+      val path = List(PathElm("here"))
+      val query = Some(List(ParamVarExp("ref", "path")))
+      val tpl = UriTemplate(path = path, query = query)
+      UriConvertible.addPathInfo(request, tpl).toString must equalTo("/here?ref={path}")
+    }
+    "manipulate the path if PathInfoCaret greater than 1" in {
+      val request = Request(
+        uri = Uri(path = "/some"),
+        attributes = AttributeMap(AttributeEntry(Request.Keys.PathInfoCaret, 5)))
+      val path = List(PathElm("here"))
+      val query = Some(List(ParamVarExp("ref", "path")))
+      val tpl = UriTemplate(path = path, query = query)
+      UriConvertible.addPathInfo(request, tpl).toString must equalTo("/some/here?ref={path}")
+    }
+  }
+
+}

--- a/core/src/test/scala/org/http4s/rho/bits/TypedQuerySpec.scala
+++ b/core/src/test/scala/org/http4s/rho/bits/TypedQuerySpec.scala
@@ -9,16 +9,18 @@ import UriTemplate.PathExp
 
 class TypedQuerySpec extends Specification {
 
+  val request = Request()
+
   "TypedQuery.asUriTemplate" should {
     "convert to {?world}" in {
       val route = param[Int]("world")
       val q = Some(List(ParamExp("world")))
-      route.asUriTemplate.get must equalTo(UriTemplate(query = q))
+      route.asUriTemplate(request).get must equalTo(UriTemplate(query = q))
     }
     "convert to {?start}{&start}" in {
       val route = param[Int]("start", 0) && param[Int]("limit", 10)
       val q = Some(List(ParamExp("start"), ParamExp("limit")))
-      route.asUriTemplate.get must equalTo(UriTemplate(query = q))
+      route.asUriTemplate(request).get must equalTo(UriTemplate(query = q))
     }
   }
 

--- a/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/RestService.scala
+++ b/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/RestService.scala
@@ -33,19 +33,18 @@ class RestService(val businessLayer: BusinessLayer) extends RhoService with Swag
 
   val browsers = "browsers"
   GET / browsers +? firstResult & maxResults |>> { (request: Request, first: Int, max: Int) =>
-    val self = request.uri
     val configurations = businessLayer.findBrowsers(first, max)
     val total = businessLayer.countBrowsers
-    val hal = browsersAsResource(self, first, max, configurations, total)
+    val hal = browsersAsResource(request, first, max, configurations, total)
     Ok(hal.build)
   }
 
   val browserById = browsers / id
-  GET / browserById |>> { id: Int =>
+  GET / browserById |>> { (request: Request, id: Int) =>
     val found = for { browser <- businessLayer.findBrowser(id) } yield {
-      val b = browserAsResourceObject(browser)
+      val b = browserAsResourceObject(browser, request)
       if (businessLayer.hasOperatingSystemsByBrowserId(browser.id))
-        for (tpl <- operatingSystemsByBrowser.asUriTemplate)
+        for (tpl <- operatingSystemsByBrowser.asUriTemplate(request))
           b.link("operating-systems", tpl.expandPath("id", browser.id).toUriIfPossible.get)
 
       \/-(Ok(b.build))
@@ -55,27 +54,25 @@ class RestService(val businessLayer: BusinessLayer) extends RhoService with Swag
 
   val browserPatternsById = browsers / id / "patterns"
   GET / browserPatternsById |>> { (request: Request, id: Int) =>
-    val self = request.uri
     val found = for { patterns <- businessLayer.findBrowserPatternsByBrowserId(id) }
-      yield \/-(Ok(browserPatternsAsResource(self, 0, Int.MaxValue, patterns, patterns.size).build))
+      yield \/-(Ok(browserPatternsAsResource(request, 0, Int.MaxValue, patterns, patterns.size).build))
     found getOrElse -\/(NotFound(warning(s"Browser $id not found").asInstanceOf[ResourceObject[Browser, Nothing]]))
   }
 
   val browserPatterns = "browser-patterns"
   GET / browserPatterns +? firstResult & maxResults |>> { (request: Request, first: Int, max: Int) =>
-    val self = request.uri
     val patterns = businessLayer.findBrowserPatterns(first, max)
     val total = businessLayer.countBrowsers
-    val hal = browserPatternsAsResource(self, first, max, patterns, total)
+    val hal = browserPatternsAsResource(request, first, max, patterns, total)
     Ok(hal.build)
   }
 
   val browserPatternById = browserPatterns / id
-  GET / browserPatternById |>> { id: Int =>
+  GET / browserPatternById |>> { (request: Request, id: Int) =>
     val found = for { pattern <- businessLayer.findBrowserPattern(id) } yield {
-      val b = browserPatternAsResourceObject(pattern)
+      val b = browserPatternAsResourceObject(pattern, request)
       for {
-        tpl <- browserById.asUriTemplate
+        tpl <- browserById.asUriTemplate(request)
         browserId <- businessLayer.findBrowserIdByPatternId(pattern.id)
       } b.link("browser", tpl.expandPath("id", browserId).toUriIfPossible.get)
       \/-(Ok(b.build))
@@ -85,18 +82,17 @@ class RestService(val businessLayer: BusinessLayer) extends RhoService with Swag
 
   val browserTypes = "browser-types"
   GET / browserTypes |>> { (request: Request) =>
-    val self = request.uri
     val types = businessLayer.findBrowserTypes
-    val hal = browserTypesAsResource(self, types)
+    val hal = browserTypesAsResource(request, types)
     Ok(hal.build)
   }
 
   val browserTypeById = browserTypes / id
-  GET / browserTypeById |>> { id: Int =>
+  GET / browserTypeById |>> { (request: Request, id: Int) =>
     val found = for { browserType <- businessLayer.findBrowserType(id) } yield {
-      val b = browserTypeAsResourceObject(browserType)
+      val b = browserTypeAsResourceObject(browserType, request)
       for {
-        tpl <- browsersByBrowserTypeId.asUriTemplate
+        tpl <- browsersByBrowserTypeId.asUriTemplate(request)
       } b.link("browsers", tpl.expandPath("id", browserType.id).toUriIfPossible.get)
       \/-(Ok(b.build))
     }
@@ -105,30 +101,28 @@ class RestService(val businessLayer: BusinessLayer) extends RhoService with Swag
 
   val browsersByBrowserTypeId = browserTypes / id / "browsers"
   GET / browsersByBrowserTypeId +? firstResult & maxResults |>> { (request: Request, id: Int, first: Int, max: Int) =>
-    val self = request.uri
     val browsers = businessLayer.findBrowsersByBrowserTypeId(id, first, max)
     val total = businessLayer.countBrowsersByBrowserTypeId(id)
     if (browsers.nonEmpty)
-      \/-(Ok(browsersAsResource(self, first, max, browsers, total).build))
+      \/-(Ok(browsersAsResource(request, first, max, browsers, total).build))
     else
       -\/(NotFound(warning(s"No browsers for type $id found").asInstanceOf[ResourceObject[BrowserType, Nothing]]))
   }
 
   val operatingSystems = "operating-systems"
   GET / operatingSystems +? firstResult & maxResults |>> { (request: Request, first: Int, max: Int) =>
-    val self = request.uri
     val configurations = businessLayer.findOperatingSystems(first, max)
     val total = businessLayer.countOperatingSystems
-    val hal = operatingSystemsAsResource(self, first, max, configurations, total)
+    val hal = operatingSystemsAsResource(request, first, max, configurations, total)
     Ok(hal.build)
   }
 
   val operatingSystemById = operatingSystems / id
-  GET / operatingSystemById |>> { id: Int =>
+  GET / operatingSystemById |>> { (request: Request, id: Int) =>
     val found = for { operatingSystem <- businessLayer.findOperatingSystem(id) } yield {
-      val b = operatingSystemAsResourceObject(operatingSystem)
+      val b = operatingSystemAsResourceObject(operatingSystem, request)
       if (businessLayer.hasBrowsersByOperatingSystemId(operatingSystem.id))
-        for (tpl <- browsersByOperatingSystem.asUriTemplate)
+        for (tpl <- browsersByOperatingSystem.asUriTemplate(request))
           b.link("browsers", tpl.expandPath("id", operatingSystem.id).toUriIfPossible.get)
       \/-(Ok(b.build))
     }
@@ -137,20 +131,18 @@ class RestService(val businessLayer: BusinessLayer) extends RhoService with Swag
 
   val browsersByOperatingSystem = operatingSystemById / "browsers"
   GET / browsersByOperatingSystem |>> { (request: Request, id: Int) =>
-    val self = request.uri
     val browsers = businessLayer.findBrowsersByOperatingSystemId(id)
     if (browsers.nonEmpty)
-      \/-(Ok(browsersAsResource(self, 0, Int.MaxValue, browsers, browsers.size).build))
+      \/-(Ok(browsersAsResource(request, 0, Int.MaxValue, browsers, browsers.size).build))
     else
       -\/(NotFound(warning(s"No Browsers for operating system $id found").asInstanceOf[ResourceObject[Nothing, Browser]]))
   }
 
   val operatingSystemsByBrowser = browserById / "operating-systems"
   GET / operatingSystemsByBrowser |>> { (request: Request, id: Int) =>
-    val self = request.uri
     val operatingSystems = businessLayer.findOperatingSystemsByBrowserId(id)
     if (operatingSystems.nonEmpty)
-      \/-(Ok(operatingSystemsAsResource(self, 0, Int.MaxValue, operatingSystems, operatingSystems.size).build))
+      \/-(Ok(operatingSystemsAsResource(request, 0, Int.MaxValue, operatingSystems, operatingSystems.size).build))
     else
       -\/(NotFound(warning(s"No operating systems for browser $id found").asInstanceOf[ResourceObject[Nothing, OperatingSystem]]))
   }
@@ -158,16 +150,17 @@ class RestService(val businessLayer: BusinessLayer) extends RhoService with Swag
   GET / "" |>> { request: Request =>
     val b = new ResObjBuilder[Nothing, Nothing]()
     b.link("self", request.uri)
-    for (uri <- browsers.asUri) b.link(browsers, uri.toString, "Lists browsers")
-    for (uri <- browserPatterns.asUri) b.link(browserPatterns, uri.toString, "Lists browser patterns")
-    for (uri <- browserTypes.asUri) b.link(browserTypes, uri.toString, "Lists browser types")
-    for (uri <- operatingSystems.asUri) b.link(operatingSystems, uri.toString, "Lists operating systems")
+    for (uri <- browsers.asUri(request)) b.link(browsers, uri.toString, "Lists browsers")
+    for (uri <- browserPatterns.asUri(request)) b.link(browserPatterns, uri.toString, "Lists browser patterns")
+    for (uri <- browserTypes.asUri(request)) b.link(browserTypes, uri.toString, "Lists browser types")
+    for (uri <- operatingSystems.asUri(request)) b.link(operatingSystems, uri.toString, "Lists operating systems")
     Ok(b.build)
   }
 
   // # JSON HAL helpers
 
-  def browsersAsResource(self: Uri, first: Int, max: Int, browsers: Seq[Browser], total: Int): ResObjBuilder[(String, Long), Browser] = {
+  def browsersAsResource(request: Request, first: Int, max: Int, browsers: Seq[Browser], total: Int): ResObjBuilder[(String, Long), Browser] = {
+    val self = request.uri
     val hal = new ResObjBuilder[(String, Long), Browser]()
     hal.link("self", selfWithFirstAndMax(self, first, max))
     hal.content("total", total)
@@ -179,23 +172,24 @@ class RestService(val businessLayer: BusinessLayer) extends RhoService with Swag
     }
     val res = ListBuffer[ResourceObject[Browser, Nothing]]()
     browsers.foreach { browser =>
-      res.append(browserAsResourceObject(browser).build)
+      res.append(browserAsResourceObject(browser, request).build)
     }
     hal.resources("browsers", res.toList)
   }
 
-  def browserAsResourceObject(browser: Browser): ResObjBuilder[Browser, Nothing] = {
+  def browserAsResourceObject(browser: Browser, request: Request): ResObjBuilder[Browser, Nothing] = {
     val b = new ResObjBuilder[Browser, Nothing]()
-    for (tpl <- browserById.asUriTemplate)
+    for (tpl <- browserById.asUriTemplate(request))
       b.link("self", tpl.expandPath("id", browser.id).toUriIfPossible.get)
-    for (tpl <- browserPatternsById.asUriTemplate)
+    for (tpl <- browserPatternsById.asUriTemplate(request))
       b.link("patterns", tpl.expandPath("id", browser.id).toUriIfPossible.get)
-    for (tpl <- browserTypeById.asUriTemplate)
+    for (tpl <- browserTypeById.asUriTemplate(request))
       b.link("type", tpl.expandPath("id", browser.typeId).toUriIfPossible.get)
     b.content(browser)
   }
 
-  def browserPatternsAsResource(self: Uri, first: Int, max: Int, browserPatterns: Seq[BrowserPattern], total: Int): ResObjBuilder[(String, Long), BrowserPattern] = {
+  def browserPatternsAsResource(request: Request, first: Int, max: Int, browserPatterns: Seq[BrowserPattern], total: Int): ResObjBuilder[(String, Long), BrowserPattern] = {
+    val self = request.uri
     val hal = new ResObjBuilder[(String, Long), BrowserPattern]()
     hal.link("self", selfWithFirstAndMax(self, first, max))
     hal.content("total", total)
@@ -207,36 +201,38 @@ class RestService(val businessLayer: BusinessLayer) extends RhoService with Swag
     }
     val res = ListBuffer[ResourceObject[BrowserPattern, Nothing]]()
     browserPatterns.foreach { browserPattern =>
-      res.append(browserPatternAsResourceObject(browserPattern).build)
+      res.append(browserPatternAsResourceObject(browserPattern, request).build)
     }
     hal.resources("browserPatterns", res.toList)
   }
 
-  def browserPatternAsResourceObject(browserPattern: BrowserPattern): ResObjBuilder[BrowserPattern, Nothing] = {
+  def browserPatternAsResourceObject(browserPattern: BrowserPattern, request: Request): ResObjBuilder[BrowserPattern, Nothing] = {
     val b = new ResObjBuilder[BrowserPattern, Nothing]()
-    for (tpl <- browserPatternById.asUriTemplate)
+    for (tpl <- browserPatternById.asUriTemplate(request))
       b.link("self", tpl.expandPath("id", browserPattern.id).toUriIfPossible.get)
     b.content(browserPattern)
   }
 
-  def browserTypeAsResourceObject(browserType: BrowserType): ResObjBuilder[BrowserType, Nothing] = {
+  def browserTypeAsResourceObject(browserType: BrowserType, request: Request): ResObjBuilder[BrowserType, Nothing] = {
     val b = new ResObjBuilder[BrowserType, Nothing]()
-    for (tpl <- browserTypeById.asUriTemplate)
+    for (tpl <- browserTypeById.asUriTemplate(request))
       b.link("self", tpl.expandPath("id", browserType.id).toUriIfPossible.get)
     b.content(browserType)
   }
 
-  def browserTypesAsResource(self: Uri, browserTypes: Seq[BrowserType]): ResObjBuilder[Nothing, BrowserType] = {
+  def browserTypesAsResource(request: Request, browserTypes: Seq[BrowserType]): ResObjBuilder[Nothing, BrowserType] = {
+    val self = request.uri
     val hal = new ResObjBuilder[Nothing, BrowserType]()
     hal.link("self", self)
     val res = ListBuffer[ResourceObject[BrowserType, Nothing]]()
     browserTypes.foreach { browserType =>
-      res.append(browserTypeAsResourceObject(browserType).build)
+      res.append(browserTypeAsResourceObject(browserType, request).build)
     }
     hal.resources("browserTypes", res.toList)
   }
 
-  def operatingSystemsAsResource(self: Uri, first: Int, max: Int, operatingSystems: Seq[OperatingSystem], total: Int): ResObjBuilder[(String, Long), OperatingSystem] = {
+  def operatingSystemsAsResource(request: Request, first: Int, max: Int, operatingSystems: Seq[OperatingSystem], total: Int): ResObjBuilder[(String, Long), OperatingSystem] = {
+    val self = request.uri
     val hal = new ResObjBuilder[(String, Long), OperatingSystem]()
     hal.link("self", selfWithFirstAndMax(self, first, max))
     hal.content("total", total)
@@ -248,14 +244,14 @@ class RestService(val businessLayer: BusinessLayer) extends RhoService with Swag
     }
     val res = ListBuffer[ResourceObject[OperatingSystem, Nothing]]()
     operatingSystems.foreach { operatingSystem =>
-      res.append(operatingSystemAsResourceObject(operatingSystem).build)
+      res.append(operatingSystemAsResourceObject(operatingSystem, request).build)
     }
     hal.resources("operatingSystems", res.toList)
   }
 
-  def operatingSystemAsResourceObject(operatingSystem: OperatingSystem): ResObjBuilder[OperatingSystem, Nothing] = {
+  def operatingSystemAsResourceObject(operatingSystem: OperatingSystem, request: Request): ResObjBuilder[OperatingSystem, Nothing] = {
     val b = new ResObjBuilder[OperatingSystem, Nothing]()
-    for (tpl <- operatingSystemById.asUriTemplate)
+    for (tpl <- operatingSystemById.asUriTemplate(request))
       b.link("self", tpl.expandPath("id", operatingSystem.id).toUriIfPossible.get)
     b.content(operatingSystem)
   }


### PR DESCRIPTION
This change should help the users when working with `Uri`s or `UriTemplates`s created from route definition bits.
