### PR TITLE
Move HTTP method resolution to the end of the route match

### DIFF
--- a/core/src/main/scala/org/http4s/rho/bits/ParserResult.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/ParserResult.scala
@@ -29,6 +29,7 @@ sealed trait ParserResult[+T] extends RouteResult[T] {
 }
 
 case class ParserSuccess[+T](result: T) extends ParserResult[T]
+
 case class ParserFailure(reason: String) extends ParserResult[Nothing]
 // TODO: I think the reason for failure could be made easier to use with specific failure types
 case class ValidationFailure(response: Task[BaseResult]) extends ParserResult[Nothing]

--- a/core/src/test/scala/org/http4s/rho/RhoServiceSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/RhoServiceSpec.scala
@@ -82,8 +82,15 @@ class RhoServiceSpec extends Specification with RequestRunner {
     }
 
     "Handle definition without a path but with a parameter" in {
-      val request = Request(Method.GET, Uri.fromString("/?foo=biz").getOrElse(sys.error("Fail.")))
+      val request = Request(Method.GET, uri("/?foo=biz"))
       checkOk(request) should_== "just root with parameter 'foo=biz'"
+    }
+
+    "Return a 405 when a path is defined but the method doesn't match" in {
+      val request = Request(Method.POST, uri("/hello"))
+      val resp = service.toService(request).run.get
+      resp.status must_== Status.MethodNotAllowed
+      resp.headers.get("Allow".ci) must beSome(Header.Raw("Allow".ci, "GET"))
     }
 
     "Consider PathMatch(\"\") a NOOP" in {


### PR DESCRIPTION
__Note:__ This PR may not be quite finished: it could use some polish with regard to the ```PathTree``` abstraction; in particular requiring a ```Method``` makes it less abstract.

This PR moves resolution of the HTTP method to the end of the path matching process. This has two major effects:
* It will lower performance as more paths must now be considered.
* It allows for easy return of 405 responses due to the knowledge of what methods are available to a path.

I think the 405 response is more valuable than the small performance advantage. This is a feature that is missing from the http4s core-dsl as noted in issue https://github.com/http4s/http4s/issues/234.
