### PR TITLE
Change error catch in the ModelBuilder to only catch NonFatal exceptions

### DIFF
--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
@@ -11,6 +11,7 @@ import org.http4s.rho.bits._
 import org.log4s.getLogger
 
 import scala.reflect.runtime.universe._
+import scala.util.control.NonFatal
 
 import scalaz._, Scalaz._
 
@@ -265,8 +266,8 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
 
     val schema = {
       try otpe.flatMap(typeToProp)
-      catch { case _: Throwable =>
-        logger.warn(s"Failed to build model for type ${otpe.get}")
+      catch { case NonFatal(t) =>
+        logger.warn(t)(s"Failed to build model for type ${otpe.get}")
         None
       }
     }


### PR DESCRIPTION
If the whole ship is sinking, we should probably just let it go. I
expect this to not happen considering the logic wrapped in the try.

cc/@LeifW