### PR TITLE
Fix problem with yield 405 when no paths are defined

### DIFF
--- a/core/src/main/scala/org/http4s/rho/bits/PathTree.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/PathTree.scala
@@ -138,12 +138,14 @@ trait PathTree {
         if (path.tail.isEmpty) {
           end.get(method).map(_.attempt(req, h)) orElse
             variadic.get(method).map(_.attempt(req, Nil::h)) getOrElse {
-              val allowedMethods = end.keys.mkString(", ")
-              val msg = s"$method not allowed. Defined methods: $allowedMethods\n"
-              // TODO: replace Raw with a real Allow header once its in http4s propper.
-              ValidationFailure(MethodNotAllowed(msg).withHeaders(Header.Raw("Allow".ci, allowedMethods)))
+              if (end.keys.isEmpty) NoMatch
+              else {
+                val allowedMethods = end.keys.mkString(", ")
+                val msg = s"$method not allowed. Defined methods: $allowedMethods\n"
+                // TODO: replace Raw with a real Allow header once its in http4s propper.
+                ValidationFailure(MethodNotAllowed(msg).withHeaders(Header.Raw("Allow".ci, allowedMethods)))
+              }
             }
-
         }
         else {
           @tailrec             // warning: `error` may be null

--- a/core/src/test/scala/org/http4s/rho/bits/RhoPathTreeSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/bits/RhoPathTreeSpec.scala
@@ -26,6 +26,9 @@ class RhoPathTreeSpec extends Specification {
     "Interpret '//' as '/'" in {
       splitPath("/test//path") must_== List("test", "path")
     }
+    "Not swallow a trailing '/'" in {
+      splitPath("/test/") must_== List("test", "")
+    }
   }
 
   "Honor UriTranslations" in {


### PR DESCRIPTION
Before this, paths such as `/foo/bar` would cause request to `/foo` to return a 405 Method Not Allowed, which I believe is wrong.

I'll merge this soon barring objections.