### PR TITLE
Cache the swagger json.

### DIFF
--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
@@ -2,7 +2,6 @@ package org.http4s
 package rho
 package swagger
 
-import com.wordnik.swagger.{ models => m }
 import com.wordnik.swagger.util.Json
 
 import headers.`Content-Type`
@@ -12,7 +11,8 @@ import shapeless.HList
 trait SwaggerSupport extends RhoService {
   import models._
 
-  var swagger: Swagger = Swagger()
+  private var swaggerSpec: Swagger = Swagger()
+  private lazy val swaggerResponse = Json.mapper().writeValueAsString(swaggerSpec.toJModel)
 
   /** Override the `swaggerFormats` to add your own custom serializers */
   def swaggerFormats: SwaggerFormats = DefaultSwaggerFormats
@@ -21,14 +21,12 @@ trait SwaggerSupport extends RhoService {
 
   def apiInfo: Info = Info(title = "My API", version = "1.0.0")
 
-  GET / apiPath |>> { () =>
-    val swaggerJson = Json.mapper().writeValueAsString(swagger.toJModel)
-    Ok(swaggerJson).withHeaders(`Content-Type`(MediaType.`application/json`))
-  }
+  "Swagger documentation" **
+    GET / apiPath |>> { () => Ok(swaggerResponse).withHeaders(`Content-Type`(MediaType.`application/json`)) }
 
   override protected def append[T <: HList, F](ra: RhoAction[T, F]): Unit = {
     super.append(ra)
     val sb = new SwaggerModelsBuilder(swaggerFormats)    
-    swagger = sb.mkSwagger(apiInfo, ra)(swagger)
+    swaggerSpec = sb.mkSwagger(apiInfo, ra)(swaggerSpec)
   }
 }


### PR DESCRIPTION
Because the model is done during class initialization we can count on
the swagger model being constant once its passed to the user. Therefor,
we should cache the result so we don't waste resources transforming
things back and forth into text.