### PR TITLE
Remove ADT member from HeaderAST

### DIFF
--- a/core/src/main/scala/org/http4s/rho/bits/HeaderAST.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/HeaderAST.scala
@@ -5,6 +5,7 @@ import org.http4s.rho.Result.BaseResult
 import shapeless.ops.hlist.Prepend
 import shapeless.{::, HList}
 
+import scalaz.\/
 import scalaz.concurrent.Task
 
 /** AST representing the Header operations of the DSL */
@@ -26,11 +27,9 @@ object HeaderAST {
 
   sealed trait HeaderRule
 
-  case class HeaderRequire[T <: HeaderKey.Extractable](key: T, f: T#HeaderT => Option[Task[BaseResult]]) extends HeaderRule
+  case class HeaderExists[T <: HeaderKey.Extractable](key: T, f: T#HeaderT => Option[Task[BaseResult]]) extends HeaderRule
 
-  case class HeaderMapper[T <: HeaderKey.Extractable, R](key: T, f: T#HeaderT => R) extends HeaderRule
-
-  case class HeaderCapture(key: HeaderKey.Extractable) extends HeaderRule
+  case class HeaderCapture[T <: HeaderKey.Extractable, R](key: T, f: T#HeaderT => Task[BaseResult]\/R, default: Option[Task[BaseResult]]) extends HeaderRule
 
   case class HeaderAnd(a: HeaderRule, b: HeaderRule) extends HeaderRule
 

--- a/core/src/test/scala/org/http4s/rho/RhoServiceSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/RhoServiceSpec.scala
@@ -293,7 +293,7 @@ class RhoServiceSpec extends Specification with RequestRunner {
     }
 
     "work with all syntax elements" in {
-      val reqHeader = requireThat(headers.`Content-Length`){ h => h.length <= 3 }
+      val reqHeader = existsAnd(headers.`Content-Length`){ h => h.length <= 3 }
 
       val srvc = new RhoService {
         POST / "foo" / pathVar[Int] +? param[String]("param") >>> reqHeader ^ EntityDecoder.text |>> {

--- a/core/src/test/scala/org/http4s/rhotest/ApiExamples.scala
+++ b/core/src/test/scala/org/http4s/rhotest/ApiExamples.scala
@@ -43,14 +43,14 @@ class ApiExamples extends Specification {
         }
 
         // header validation is also composable
-        val v1 = requireThat(headers.`Content-Length`)(_.length > 0)
+        val v1 = existsAnd(headers.`Content-Length`)(_.length > 0)
         val v2 = v1 && capture(headers.ETag)
 
         // Now these two can be combined to make the 'Router'
         val r = path2 >>> v2
 
         // you can continue to add validation actions to a 'Router' but can no longer modify the path
-        val r2 = r >>> require(headers.`Cache-Control`)
+        val r2 = r >>> exists(headers.`Cache-Control`)
         // r2 / "stuff" // Doesn't work
 
         // Now this can be combined with a method to make the 'Action'
@@ -68,8 +68,8 @@ class ApiExamples extends Specification {
         val path6 = "one" / pathVar[Int]
         val path7 = "two" / pathVar[Int]
 
-        val v6 = requireMap(headers.`Content-Length`)(_.length)
-        val v7 = requireMap(headers.ETag)(_ => -1)
+        val v6 = captureMap(headers.`Content-Length`)(_.length)
+        val v7 = captureMap(headers.ETag)(_ => -1)
 
         GET / (path6 || path7) +? param[String]("foo") >>> (v6 || v7) |>> {
           (i: Int, foo: String, v: Int) =>

--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/MyService.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/MyService.scala
@@ -25,7 +25,7 @@ object MyService extends RhoService with SwaggerSupport {
 
   case class JsonResult(name: String, number: Int) extends AutoSerializable
 
-  val requireCookie = requireThatR(headers.Cookie){ cookie =>
+  val requireCookie = existsAndR(headers.Cookie){ cookie =>
     cookie.values.toList.find(c => c.name == "Foo" && c.content == "bar") match {
       case Some(_) => None   // Cookie found, good to go.
       case None => // Didn't find cookie

--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
@@ -169,12 +169,11 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
 
     def go(stack: List[HeaderRule]): List[HeaderParameter] =
       stack match {
-        case HeaderAnd(a, b)::xs        => go(a::b::xs)
-        case MetaCons(a, _)::xs         => go(a::xs)
+        case HeaderAnd(a,b)::xs         => go(a::b::xs)
+        case MetaCons(a,_)::xs          => go(a::xs)
         case EmptyHeaderRule::xs        => go(xs)
-        case HeaderCapture(key)::xs     => mkHeaderParam(key)::go(xs)
-        case HeaderMapper(key, _)::xs   => mkHeaderParam(key)::go(xs)
-        case HeaderRequire(key, _)::xs  => mkHeaderParam(key)::go(xs)
+        case HeaderCapture(key,_,_)::xs  => mkHeaderParam(key)::go(xs)
+        case HeaderExists(key,_)::xs   => mkHeaderParam(key)::go(xs)
 
         case HeaderOr(a, b)::xs         =>
           val as = go(a::xs)

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
@@ -70,14 +70,14 @@ class SwaggerModelsBuilderSpec extends Specification {
   "SwaggerModelsBuilder.collectHeaderParams" should {
 
     "handle an action with single header rule" in {
-      val ra = fooPath >>> require(`Content-Length`) |>> { () => "" }
+      val ra = fooPath >>> exists(`Content-Length`) |>> { () => "" }
 
       sb.collectHeaderParams(ra) must_==
       List(HeaderParameter(`type` = "string", name = "Content-Length".some, required = true))
     }
 
     "handle an action with two header rules" in {
-      val ra = fooPath >>> (require(`Content-Length`) && require(`Content-MD5`)) |>> { () => "" }
+      val ra = fooPath >>> (exists(`Content-Length`) && exists(`Content-MD5`)) |>> { () => "" }
 
       sb.collectHeaderParams(ra) must_==
       List(
@@ -89,7 +89,7 @@ class SwaggerModelsBuilderSpec extends Specification {
 
       def orStr(str: String) = s"Optional if the following headers are satisfied: [$str]".some
 
-      val ra = fooPath >>> (require(`Content-Length`) || require(`Content-MD5`)) |>> { () => "" }
+      val ra = fooPath >>> (exists(`Content-Length`) || exists(`Content-MD5`)) |>> { () => "" }
 
       sb.collectHeaderParams(ra) must_==
       List(


### PR DESCRIPTION
It turns out that there was a redundency in the HeaderAST: HeaderCapture and HeaderMapper are basically the same thing where HeaderMapper(key, identity) == HeaderCapture.

HeaderCapture now can take a default should the header not exist, and can return an alternate response should the header not be suitable in some way.

Some functions were also renamed to better reflect what they do.