### PR TITLE
Add support for the http4s.Response as a Result

### DIFF
--- a/core/src/main/scala/org/http4s/rho/bits/ResultMatcher.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/ResultMatcher.scala
@@ -438,4 +438,10 @@ object ResultMatcher {
     override def resultInfo: Set[ResultInfo] = r.resultInfo
     override def conv(req: Request, t: Task[R]): Task[Response] = t.flatMap(r.conv(req, _))
   }
+
+  implicit object ResponseMatcher extends ResultMatcher[Response] {
+    override def encodings: Set[MediaType] = Set.empty
+    override def conv(req: Request, r: Response): Task[Response] = Task.now(r)
+    override def resultInfo: Set[ResultInfo] = Set.empty
+  }
 }

--- a/core/src/test/scala/org/http4s/rhotest/ApiExamples.scala
+++ b/core/src/test/scala/org/http4s/rhotest/ApiExamples.scala
@@ -1,9 +1,12 @@
 package org.http4s
 package rhotest
 
+import org.http4s.websocket.WebsocketBits.WebSocketFrame
 import org.specs2.mutable.Specification
 import org.http4s.rho._
 import scalaz.concurrent.Task
+
+import server.websocket.WS
 
 
 
@@ -97,6 +100,13 @@ class ApiExamples extends Specification {
         // Using decoders you can parse the body as well
         POST / "postSomething" ^ UrlForm.entityDecoder |>> { m: UrlForm =>
           Ok(s"You posted these things: $m")
+        }
+
+        // We can use a standard http4s.Response, but we don't get any metadata along with it. Useful for things
+        // like Websocket support.
+        GET / "websockets" |>> {
+          val exchange: scalaz.stream.Exchange[WebSocketFrame,WebSocketFrame] = null
+          WS(exchange)
         }
       }
 


### PR DESCRIPTION
closes #79

We don't get any metadata, but some http4s idioms like websockets will return a Response.