### PR TITLE
Remove `Empty` from the ResultInfo ADT.

### DIFF
--- a/core/src/main/scala/org/http4s/rho/bits/ResultInfo.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/ResultInfo.scala
@@ -8,4 +8,3 @@ sealed trait ResultInfo
 case class TypeOnly(tpe: Type) extends ResultInfo
 case class StatusAndType(status: Status, tpe: Type) extends ResultInfo
 case class StatusOnly(status: Status) extends ResultInfo
-case object Empty extends ResultInfo

--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
@@ -104,7 +104,6 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
       case TypeOnly(tpe)         => mkResponse("200", "OK", tpe.some).some
       case StatusAndType(s, tpe) => mkResponse(s.code.toString, s.reason, tpe.some).some
       case StatusOnly(s)         => mkResponse(s.code.toString, s.reason, none).some
-      case Empty                 => none
     }.flatten.toMap
 
   def collectSummary(ra: RhoAction[_, _]): Option[String] = {


### PR DESCRIPTION
It turns out that the only existing use cases of `ResultInfo` are in collections where `Empty` is discarded anyhow.

It seems more fun to remove code these days. :smile: 