### PR TITLE
Add the concept of a RequestFilter

### DIFF
--- a/core/src/main/scala/org/http4s/rho/RequestFilter.scala
+++ b/core/src/main/scala/org/http4s/rho/RequestFilter.scala
@@ -1,0 +1,41 @@
+package org.http4s
+package rho
+
+import bits.{ResultMatcher, HListToFunc}
+import shapeless.HList
+
+import scalaz.concurrent.Task
+
+/**
+ * Created on 7/9/15.
+ */
+
+final class RequestFilter[R: ResultMatcher] private(filter: Request => Task[Option[R]]) {
+  def ^?>[H <: HList, F](f: F)(implicit ev: HListToFunc[H, F]): RequestFiltered[H, F, R] = RequestFiltered(f, filter)
+  def filtering[H <: HList, F](f: F)(implicit ev: HListToFunc[H, F]): RequestFiltered[H, F, R] = ^?>(f)
+}
+
+object RequestFilter {
+  def filter[R: ResultMatcher](filter: Request => Task[Option[R]]): RequestFilter[R] = new RequestFilter(filter)
+  def pureFilter[R: ResultMatcher](f: Request => Option[R]): RequestFilter[R] = filter(f.andThen(Task.now))
+}
+
+final case class RequestFiltered[H <: HList, +F, R](f: F, filter: Request => Task[Option[R]])(implicit ev: HListToFunc[H, F], ev2: ResultMatcher[R])
+
+object RequestFiltered {
+  implicit def beforeFiltered[H <: HList, F, R](implicit ev: HListToFunc[H, F], rev: ResultMatcher[R]): HListToFunc[H, RequestFiltered[H, F, R]] = new HListToFunc[H, RequestFiltered[H, F, R]] {
+    override def matcher = ev.matcher.addInfo(rev.encodings, rev.resultInfo)
+
+    override def conv(beforeFilter: RequestFiltered[H, F, R]): (Request, H) => Task[Response] = {
+      // cache the inner converter in case it does a lot of 'stuff'
+      val conv = ev.conv(beforeFilter.f)
+      (req, h) => for {
+                    filtered <- beforeFilter.filter(req)
+                    r <- filtered match {
+                           case Some(r) => rev.conv(req, r)
+                           case None    => conv(req, h)
+                         }
+                  } yield r
+    }
+  }
+}

--- a/core/src/test/scala/org/http4s/rho/ApiTest.scala
+++ b/core/src/test/scala/org/http4s/rho/ApiTest.scala
@@ -297,7 +297,6 @@ class ApiTest extends Specification {
       val path = GET / "hello"
 
       val req = Request(uri = uri("/hello?foo=bar"))
-        .withHeaders(Headers(headers.`Content-Length`("foo".length)))
 
       val route1 = (path +? param[Int]("foo")).runWith { i: Int =>
         Ok("shouldn't get here.")

--- a/core/src/test/scala/org/http4s/rho/RequestFilterSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/RequestFilterSpec.scala
@@ -1,0 +1,45 @@
+package org.http4s
+package rho
+
+import bits.MethodAliases._
+import bits.ResponseGeneratorInstances._
+
+import org.specs2.mutable.Specification
+
+import scalaz.concurrent.Task
+
+/**
+ * Created on 7/9/15.
+ */
+class RequestFilterSpec extends Specification {
+
+  "BeforeFilters" should {
+
+    val path = GET / "foo"
+    val req = Request(uri = uri("/foo"))
+
+    "Let a response pass through" in {
+      val passFilter = RequestFilter.pureFilter(_ => None: Option[String])
+      val route = path.runWith(passFilter ^?> { () => Ok("Good.")})
+      route(req).run.map(_.status) must beSome(Status.Ok)
+    }
+
+    "Let a response pass through asynchronously" in {
+      val passFilter = RequestFilter.filter(_ => Task(None: Option[String]))
+      val route = path.runWith(passFilter ^?> { () => Ok("Good.")})
+      route(req).run.map(_.status) must beSome(Status.Ok)
+    }
+
+    "Chose the filtered response" in {
+      val passFilter = RequestFilter.pureFilter(_ => Some(Unauthorized("Boo..")))
+      val route = path.runWith(passFilter ^?> { () => sys.error("Shouldn't get here!!!"); Ok("Good.") })
+      route(req).run.map(_.status) must beSome(Status.Unauthorized)
+    }
+
+    "Chose the filtered response asynchronously" in {
+      val passFilter = RequestFilter.filter(_ => Task(Some(Unauthorized("Boo.."))))
+      val route = path.runWith(passFilter ^?> { () => sys.error("Shouldn't get here!!!"); Ok("Good.") })
+      route(req).run.map(_.status) must beSome(Status.Unauthorized)
+    }
+  }
+}

--- a/core/src/test/scala/org/http4s/rhotest/ApiExamples.scala
+++ b/core/src/test/scala/org/http4s/rhotest/ApiExamples.scala
@@ -108,10 +108,13 @@ class ApiExamples extends Specification {
           val exchange: scalaz.stream.Exchange[WebSocketFrame,WebSocketFrame] = null
           WS(exchange)
         }
+
+        // We can add filters to an action with the '^?>' operator
+        val myFilter = RequestFilter.pureFilter(req => if (req.params.get("foo").nonEmpty) None else Some(Conflict("I'm so conflicted...")))
+        GET / "filtered" |>> myFilter ^?> Ok("You had a foo param")
       }
 
-      true should_== true
+      ok
     }
   }
-
 }


### PR DESCRIPTION
A RequestFilter can be used to examine an incoming request before running the action. It returns a Task, so it can be asynchronous in its evaluation.