### PR TITLE
Fix Prepend type param ordering

### DIFF
--- a/core/src/main/scala/org/http4s/rho/Router.scala
+++ b/core/src/main/scala/org/http4s/rho/Router.scala
@@ -37,7 +37,7 @@ case class Router[T <: HList](method: Method,
 {
   override type HeaderAppendResult[T <: HList] = Router[T]
 
-  override def >>>[T2 <: HList](v: TypedHeader[T2])(implicit prep1: Prepend[T2, T]): Router[prep1.Out] =
+  override def >>>[T1 <: HList](v: TypedHeader[T1])(implicit prep1: Prepend[T1, T]): Router[prep1.Out] =
     Router(method, path, query, HeaderAnd(headers, v.rule))
 
   override def makeRoute(action: Action[T]): RhoRoute[T] = RhoRoute(this, action)
@@ -54,7 +54,7 @@ case class CodecRouter[T <: HList, R](router: Router[T], decoder: EntityDecoder[
 {
   override type HeaderAppendResult[T <: HList] = CodecRouter[T, R]
 
-  override def >>>[T2 <: HList](v: TypedHeader[T2])(implicit prep1: Prepend[T2, T]): CodecRouter[prep1.Out,R] =
+  override def >>>[T1 <: HList](v: TypedHeader[T1])(implicit prep1: Prepend[T1, T]): CodecRouter[prep1.Out,R] =
     CodecRouter(router >>> v, decoder)
 
   /** Append the header to the builder, generating a new typed representation of the route */

--- a/core/src/main/scala/org/http4s/rho/bits/HeaderAST.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/HeaderAST.scala
@@ -17,10 +17,10 @@ object HeaderAST {
 
     def ||(v: TypedHeader[T]): TypedHeader[T] = or(v)
 
-    def and[T1 <: HList](v: TypedHeader[T1])(implicit prepend: Prepend[T, T1]): TypedHeader[prepend.Out] =
+    def and[T1 <: HList](v: TypedHeader[T1])(implicit prepend: Prepend[T1, T]): TypedHeader[prepend.Out] =
       TypedHeader(HeaderAnd(this.rule, v.rule))
 
-    def &&[T1 <: HList](v: TypedHeader[T1])(implicit prepend: Prepend[T, T1]): TypedHeader[prepend.Out] = and(v)
+    def &&[T1 <: HList](v: TypedHeader[T1])(implicit prepend: Prepend[T1, T]): TypedHeader[prepend.Out] = and(v)
   }
 
   ///////////////// Header and body AST ///////////////////////

--- a/core/src/main/scala/org/http4s/rho/bits/QueryAST.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/QueryAST.scala
@@ -14,12 +14,12 @@ object QueryAST {
 
     final def ||(v: TypedQuery[T]): TypedQuery[T] = or(v)
 
-    final def and[T1 <: HList](v: TypedQuery[T1])(implicit prepend: Prepend[T, T1]): TypedQuery[prepend.Out] =
+    final def and[T1 <: HList](v: TypedQuery[T1])(implicit prepend: Prepend[T1, T]): TypedQuery[prepend.Out] =
       TypedQuery(QueryAnd(this.rule, v.rule))
 
-    final def &&[T1 <: HList](v: TypedQuery[T1])(implicit prepend: Prepend[T, T1]): TypedQuery[prepend.Out] = and(v)
+    final def &&[T1 <: HList](v: TypedQuery[T1])(implicit prepend: Prepend[T1, T]): TypedQuery[prepend.Out] = and(v)
 
-    final def &[T1 <: HList](v: TypedQuery[T1])(implicit prepend: Prepend[T, T1]): TypedQuery[prepend.Out] = and(v)
+    final def &[T1 <: HList](v: TypedQuery[T1])(implicit prepend: Prepend[T1, T]): TypedQuery[prepend.Out] = and(v)
 
     /**
      * Resolves names of query parameters to capture

--- a/core/src/test/scala/org/http4s/rho/RhoServiceSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/RhoServiceSpec.scala
@@ -37,7 +37,7 @@ class RhoServiceSpec extends Specification with RequestRunner {
     GET / "hello" / "compete" |>> Ok("route7")
 
     // Testing query params
-    GET / "query" / "twoparams" +? param[Int]("foo") & param[String]("bar") |>> { (foo: Int, bar: String) =>
+    GET / "query" / "twoparams" +? (param[Int]("foo") and param[String]("bar")) |>> { (foo: Int, bar: String) =>
       Ok("twoparams" + foo + bar)
     }
 

--- a/core/src/test/scala/org/http4s/rhotest/ApiExamples.scala
+++ b/core/src/test/scala/org/http4s/rhotest/ApiExamples.scala
@@ -107,7 +107,7 @@ class ApiExamples extends Specification {
         }
       }
 
-      true should_== true
+      ok
     }
   }
 


### PR DESCRIPTION
closes #86

The order of the type arguments to a Shapeless Prepend were reversed leading to incorrect type.