### PR TITLE
to address #89

### DIFF
--- a/examples/src/main/resources/swagger-ui/index.html
+++ b/examples/src/main/resources/swagger-ui/index.html
@@ -28,7 +28,7 @@
       if (url && url.length > 1) {
         url = decodeURIComponent(url[1]);
       } else {
-        url = "http://localhost:8080/swagger.json";
+        url = window.location.origin + "/swagger.json";
       }
       window.swaggerUi = new SwaggerUi({
         url: url,

--- a/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
@@ -128,6 +128,8 @@ object TypeBuilder {
         DataType.fromType(pType) match {
           case DataType.ValueDataType(name, format, qName) =>
             AbstractProperty(`type` = name, description = qName, format = format)
+          case DataType.ComplexDataType(name, qName) =>
+            AbstractProperty(`type` = name, description = qName)
           case DataType.ContainerDataType(name, tpe, uniqueItems) =>
             AbstractProperty(`type` = name)
         }
@@ -143,6 +145,7 @@ object TypeBuilder {
 
     case class ValueDataType(name: String, format: Option[String] = None, qualifiedName: Option[String] = None) extends DataType
     case class ContainerDataType(name: String, typeArg: Option[DataType] = None, uniqueItems: Boolean = false) extends DataType
+    case class ComplexDataType(name: String, qualifiedName: Option[String] = None) extends DataType
 
     val Void = DataType("void")
     val String = DataType("string")
@@ -207,7 +210,7 @@ object TypeBuilder {
         else GenArray()
       } else {
         val stt = if (t.isOption) t.typeArgs.head else t
-        new ValueDataType(stt.simpleName, qualifiedName = Option(stt.fullName))
+        ComplexDataType(stt.simpleName, qualifiedName = Option(stt.fullName))
       }
     }
 


### PR DESCRIPTION
1. Introduce `ComplexDataType` as a new sub class for `DataType` to
distinguish from the primitive data types supported by `swagger` out of
the box.
2. Modify interface of `QueryParameter` and `AbstractProperty` in model to
introduce the `$ref` field for referencing the complex data type. Note
that `RefParameter` and `RefProperty` coming from the Java library do
not work in this case, since they seem to be redeemed for other
purposes. Unfortunately both swagger wiki and java library are very
vague (if not specified at all) how complex type other than the
primitives should be referenced in the query parameter, what I come up
with sort of falls into the realm of “rule-of-thumb” .
(forgot to mention, I also change how the `array` type should be represented, and I believe this is the right way to do it.)
3. In `SwaggerModelsBuilder`, `makeQueryParams` now is changed so that
it absorbs the new format proposed by 2.
4. In `SwaggerModelsBuilder`, create a method to extract complex types
from queries and include them into `collectDefinitions`
5. Add test cases for the change
6. Add example route