### PR TITLE
Make the examples work again

### DIFF
--- a/examples/src/main/scala/com/http4s/rho/Helpers.scala
+++ b/examples/src/main/scala/com/http4s/rho/Helpers.scala
@@ -1,0 +1,22 @@
+package com.http4s.rho
+
+import org.http4s.server.HttpService
+import org.http4s.{Request, Status}
+
+import scalaz.Kleisli
+import scalaz.concurrent.Task
+
+ object Helpers {
+
+   // TODO: this should be in http4s proper
+  /** Helper so that a HttpServices can be chained */
+  implicit class OrElseSyntax(val service: HttpService) extends AnyVal {
+    def orElse(service2: HttpService): HttpService = Kleisli { req: Request =>
+      service(req).flatMap {
+        case resp if resp.status == Status.NotFound => service2(req)
+        case resp => Task.now(resp)
+      }
+    }
+  }
+
+}

--- a/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/ServerApp.scala
+++ b/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/ServerApp.scala
@@ -3,6 +3,8 @@ package com.http4s.rho.hal.plus.swagger.demo
 import org.http4s.server.blaze.BlazeBuilder
 import net.sf.uadetector.service.UADetectorServiceFactory.ResourceModuleXmlDataStore
 
+import com.http4s.rho.Helpers._
+
 import org.log4s.getLogger
 
 class ServerApp(port: Int) {
@@ -12,8 +14,7 @@ class ServerApp(port: Int) {
   val routes = new Routes(businessLayer)
 
   val server = BlazeBuilder
-    .mountService(routes.staticContent, "")
-    .mountService(routes.dynamicContent, "")
+    .mountService(routes.staticContent orElse routes.dynamicContent, "")
     .bindLocal(port)
 
   def run(): Unit = server.start.run.awaitShutdown()

--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/Main.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/Main.scala
@@ -1,11 +1,11 @@
 package com.http4s.rho.swagger.demo
 
 import org.http4s.server.blaze.BlazeBuilder
+import com.http4s.rho.Helpers._
 
 object Main extends App {
   BlazeBuilder
-    .mountService(StaticContentService.routes)
-    .mountService(MyService.toService)
+    .mountService(StaticContentService.routes orElse MyService.toService)
     .bindLocal(8080)
     .start
     .run

--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/StaticContentService.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/StaticContentService.scala
@@ -34,7 +34,6 @@ object StaticContentService {
       fetchResource(swaggerUiDir + "/index.html", req)
     case req @ GET -> Root / "swagger-ui.js" =>
       fetchResource(swaggerUiDir + "/swagger-ui.min.js", req)
-
   }
 
 }


### PR DESCRIPTION
See Issue #97.

This includes a bit of a 'shim' that should be a part of http4s. The orElse functionality is reintroduced with a syntax class that checks for 404 NotFound responses.