### PR TITLE
Construct paths without manually breaking up the uri sections

### DIFF
--- a/core/src/main/scala/org/http4s/rho/PathBuilder.scala
+++ b/core/src/main/scala/org/http4s/rho/PathBuilder.scala
@@ -34,7 +34,10 @@ final class PathBuilder[T <: HList](val method: Method, val path: PathRule)
 
   def /(t: CaptureTail.type): Router[List[String] :: T] = new Router(method, PathAnd(path, t), EmptyQuery, EmptyHeaderRule)
 
-  def /(s: String): PathBuilder[T] = new PathBuilder(method, PathAnd(path, PathMatch(s)))
+  def /(s: String): PathBuilder[T] = {
+    val newPath = s.split("/").foldLeft(path)((p,s) => PathAnd(p, PathMatch(s)))
+    new PathBuilder[T](method, newPath)
+  }
 
   def /(s: Symbol): PathBuilder[String :: T] = {
     val capture = PathCapture(s.name, StringParser.strParser, implicitly[TypeTag[String]])

--- a/core/src/test/scala/org/http4s/rho/RhoServiceSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/RhoServiceSpec.scala
@@ -25,6 +25,8 @@ class RhoServiceSpec extends Specification with RequestRunner {
 
     GET / "hello" / "world" |>> (Ok("route3"))
 
+    GET / "hello/world2" |>> (Ok("/hello/world2"))
+
     GET / "hello" / "headers" +? param[Int]("foo") |>> { foo: Int => Ok("route" + foo) }
 
     GET / "hello" / "default" / "parameter" +? param[Int]("some", 23) |>> { s: Int => Ok("some:" + s) }
@@ -118,6 +120,11 @@ class RhoServiceSpec extends Specification with RequestRunner {
     "Execute a route with a single param" in {
       val req = Get("/world")
       checkOk(req) should_== "route2"
+    }
+
+    "Execute a route with concatonated path" in {
+      val req = Get("/hello/world2")
+      checkOk(req) === "/hello/world2"
     }
 
     "Execute a route with a single param" in {


### PR DESCRIPTION
Currently the behavior would be to accept the string in construction but it would never be matched because uri segments will be broken up by the '/' chars. This PR does the breaking up for the user.