### PR TITLE
Route construction can add a non-capturing prefix

### DIFF
--- a/core/src/main/scala/org/http4s/rho/PathBuilder.scala
+++ b/core/src/main/scala/org/http4s/rho/PathBuilder.scala
@@ -22,6 +22,7 @@ final class PathBuilder[T <: HList](val method: Method, val path: PathRule)
   with Decodable[T, Nothing]
   with UriConvertible
   with HeaderAppendable[T]
+  with RoutePrependable[PathBuilder[T]]
 {
   type HeaderAppendResult[T <: HList] = Router[T]
 
@@ -52,6 +53,9 @@ final class PathBuilder[T <: HList](val method: Method, val path: PathRule)
 
   def /[T2 <: HList](t: RequestLineBuilder[T2])(implicit prep: Prepend[T2, T]): QueryBuilder[prep.Out] =
     QueryBuilder(method, PathAnd(path, t.path), t.query)
+
+  override def /:(prefix: TypedPath[HNil]): PathBuilder[T] =
+    new PathBuilder(method, PathAnd(prefix.rule, path))
 
   def toAction: Router[T] = >>>(TypedHeader[HNil](EmptyHeaderRule))
 

--- a/core/src/main/scala/org/http4s/rho/QueryBuilder.scala
+++ b/core/src/main/scala/org/http4s/rho/QueryBuilder.scala
@@ -7,7 +7,7 @@ import bits.QueryAST._
 import bits.HeaderAST._
 
 import shapeless.ops.hlist.Prepend
-import shapeless.{ ::, HList }
+import shapeless.{HNil, ::, HList}
 
 case class QueryBuilder[T <: HList](method: Method,
                                       path: PathRule,
@@ -15,7 +15,11 @@ case class QueryBuilder[T <: HList](method: Method,
   extends RouteExecutable[T]
   with HeaderAppendable[T]
   with UriConvertible
+  with RoutePrependable[QueryBuilder[T]]
 {
+  override def /:(prefix: TypedPath[HNil]): QueryBuilder[T] =
+    new QueryBuilder[T](method, PathAnd(prefix.rule, path), query)
+  
   override type HeaderAppendResult[T <: HList] = Router[T]
 
   override def makeRoute(action: Action[T]): RhoRoute[T] = RhoRoute(Router(method, path, query, headers), action)

--- a/core/src/main/scala/org/http4s/rho/RequestLineBuilder.scala
+++ b/core/src/main/scala/org/http4s/rho/RequestLineBuilder.scala
@@ -4,15 +4,19 @@ package rho
 import org.http4s.rho.bits.QueryAST.{ QueryAnd, TypedQuery, QueryRule }
 
 import bits.HeaderAST.{ EmptyHeaderRule, HeaderRule }
-import bits.PathAST.PathRule
-import shapeless.HList
+import org.http4s.rho.bits.PathAST.{PathAnd, TypedPath, PathRule}
+import shapeless.{HNil, HList}
 import shapeless.ops.hlist.Prepend
 
 case class RequestLineBuilder[T <: HList](path: PathRule, query: QueryRule)
   extends TypedBuilder[T]
+  with RoutePrependable[RequestLineBuilder[T]]
   with UriConvertible {
 
   override def headers: HeaderRule = EmptyHeaderRule
+
+  override def /:(prefix: TypedPath[HNil]): RequestLineBuilder[T] =
+    copy(path = PathAnd(prefix.rule, path))
 
   def &[T1 <: HList](q: TypedQuery[T1])(implicit prep: Prepend[T1, T]): RequestLineBuilder[prep.Out] =
     RequestLineBuilder(path, QueryAnd(query, q.rule))

--- a/core/src/main/scala/org/http4s/rho/RhoRoute.scala
+++ b/core/src/main/scala/org/http4s/rho/RhoRoute.scala
@@ -2,18 +2,24 @@ package org.http4s
 package rho
 
 import bits.HeaderAST.HeaderRule
-import bits.PathAST.PathRule
+import org.http4s.rho.bits.PathAST.{TypedPath, PathRule}
 import org.http4s.rho.bits.QueryAST.QueryRule
 import org.http4s.rho.bits.ResultInfo
 
-import shapeless.HList
+import shapeless.{HNil, HList}
 
 import scalaz.concurrent.Task
 
 /** A shortcut type to bundle everything needed to define a route */
-final case class RhoRoute[T <: HList](router: RoutingEntity[T], action: Action[T]) {
+final case class RhoRoute[T <: HList](router: RoutingEntity[T], action: Action[T])
+      extends RoutePrependable[RhoRoute[T]]
+{
 
   def apply(req: Request, hlist: T): Task[Response] = action.act(req, hlist)
+
+  def /:(prefix: TypedPath[HNil]): RhoRoute[T] = {
+    copy(router = prefix /: router)
+  }
 
   def method: Method = router.method
   def path: PathRule = router.path

--- a/core/src/main/scala/org/http4s/rho/RhoService.scala
+++ b/core/src/main/scala/org/http4s/rho/RhoService.scala
@@ -2,14 +2,16 @@ package org.http4s
 package rho
 
 import org.http4s.rho.CompileService.ServiceBuilder
+import org.http4s.rho.bits.PathAST.TypedPath
 import org.http4s.server.HttpService
 
 import org.log4s.getLogger
-import shapeless.HList
+import shapeless.{HNil, HList}
 
 class RhoService(routes: Seq[RhoRoute[_ <: HList]] = Vector.empty)
     extends bits.MethodAliases
     with bits.ResponseGeneratorInstances
+    with RoutePrependable[RhoService]
 {
   final protected val logger = getLogger
 
@@ -27,5 +29,9 @@ class RhoService(routes: Seq[RhoRoute[_ <: HList]] = Vector.empty)
   final def toService(filter: RhoMiddleware = identity): HttpService = compileService.toService(filter)
 
   final override def toString(): String = s"RhoService(${compileService.routes().toString()})"
+
+  final override def /:(prefix: TypedPath[HNil]): RhoService = {
+    new RhoService(compileService.routes().map { prefix /: _ })
+  }
 }
 

--- a/core/src/main/scala/org/http4s/rho/RouteExecutable.scala
+++ b/core/src/main/scala/org/http4s/rho/RouteExecutable.scala
@@ -18,7 +18,7 @@ trait RouteExecutable[T <: HList] extends TypedBuilder[T] { exec =>
   /** [[Method]] of the incoming HTTP [[Request]] */
   def method: Method
 
-//  /** Create a [[RhoAction]] from this [[RouteExecutable]] with the provided converters */
+//  /** Create a [[RhoRoute]] from this [[RouteExecutable]] with the provided converters */
   def makeRoute(action: Action[T]): RhoRoute[T]
 
   /** Compiles a HTTP request definition into an action */

--- a/core/src/main/scala/org/http4s/rho/RoutePrependable.scala
+++ b/core/src/main/scala/org/http4s/rho/RoutePrependable.scala
@@ -1,0 +1,9 @@
+package org.http4s.rho
+
+import org.http4s.rho.bits.PathAST.TypedPath
+import shapeless.HNil
+
+/** Types that extends this trait can be prepended with noncapturing paths */
+trait RoutePrependable[T <: RoutePrependable[T]] {
+  def /:(prefix: TypedPath[HNil]): T
+}

--- a/core/src/test/scala/org/http4s/rho/RequestRunner.scala
+++ b/core/src/test/scala/org/http4s/rho/RequestRunner.scala
@@ -24,4 +24,4 @@ trait RequestRunner {
   }
 }
 
-class RRunner(val service: HttpService) extends RequestRunner
+case class RRunner(val service: HttpService) extends RequestRunner

--- a/core/src/test/scala/org/http4s/rho/RhoServiceSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/RhoServiceSpec.scala
@@ -349,4 +349,17 @@ class RhoServiceSpec extends Specification with RequestRunner {
     }
   }
 
+  "RhoService prefixation" should {
+    "Prefix a RhoService" in {
+      val srvc1 = new RhoService {
+        GET / "bar" |>> "bar"
+      }
+
+      val srvc2 = "foo" /: srvc1 toService()
+
+      val req1 = Request(uri = Uri(path ="/foo/bar"))
+      getBody(srvc2(req1).run.body) === "bar"
+    }
+  }
+
 }

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
@@ -6,25 +6,39 @@ import org.specs2.mutable.Specification
 
 import org.http4s.rho.bits.MethodAliases.GET
 
-class SwaggerSupportSpec extends Specification with RequestRunner {
+class SwaggerSupportSpec extends Specification {
 
   import org.json4s.JsonAST._
   import org.json4s.jackson._
 
-  val service = new RhoService {
+
+
+  val baseService = new RhoService {
     GET / "hello" |>> { () => Ok("hello world") }
     GET / "hello"/ pathVar[String] |>> { world: String => Ok("hello " + world) }
-  }.toService(SwaggerSupport())
+  }
+
 
   "SwaggerSupport" should {
-
     "Expose an API listing" in {
+      val service = baseService.toService(SwaggerSupport())
+
       val r = Request(GET, Uri(path = "/swagger.json"))
 
       val JObject(List((a, JObject(_)), (b, JObject(_)), (c, JObject(_)))) =
-        parseJson(checkOk(r)) \\ "paths"
+        parseJson(RRunner(service).checkOk(r)) \\ "paths"
 
       Set(a, b, c) should_== Set("/swagger.json", "/hello", "/hello/{string}")
+    }
+
+    "Support prefixed routes" in {
+      val service = ("foo" /: baseService).toService(SwaggerSupport())
+      val r = Request(GET, Uri(path = "/swagger.json"))
+
+      val JObject(List((a, JObject(_)), (b, JObject(_)), (c, JObject(_)))) =
+        parseJson(RRunner(service).checkOk(r)) \\ "paths"
+
+      Set(a, b, c) should_== Set("/swagger.json", "/foo/hello", "/foo/hello/{string}")
     }
   }
 }


### PR DESCRIPTION
The idea is that most route construction types can now do the following:
val service = GET / "bar"
val prefixedService = "foo" /: service

We could add capturing prefixes if we wanted to drop support for this from routers but
that would rule out prefixing an already constructed service which is probably the
dominant use case.