### PR TITLE
Topic/mergeASTs

### DIFF
--- a/core/src/main/scala/org/http4s/rho/ExecutableCompiler.scala
+++ b/core/src/main/scala/org/http4s/rho/ExecutableCompiler.scala
@@ -1,9 +1,7 @@
 package org.http4s
 package rho
 
-import bits.HeaderAST._
-import bits.QueryAST._
-import org.http4s.rho.bits.ResponseGeneratorInstances.BadRequest
+import org.http4s.rho.bits.RequestAST._
 
 import org.http4s.rho.bits._
 
@@ -17,57 +15,16 @@ trait ExecutableCompiler {
   //////////////////////// Stuff for executing the route //////////////////////////////////////
 
   /** Walks the validation tree */
-  def ensureValidHeaders(v: HeaderRule, req: Request): ResultResponse[HList] =
-    runValidation(req, v, HNil)
+  def runRequestRules(v: RequestRule, req: Request): ResultResponse[HList] =
+    runRequestRules(req, v, HNil)
 
-  /** The untyped guts of ensureValidHeaders and friends */
-  def runValidation(req: Request, v: HeaderRule, stack: HList): ResultResponse[HList] = {
-    import bits.HeaderAST.MetaCons
-    v match {
-      case HeaderAnd(a, b) => runValidation(req, a, stack).flatMap(runValidation(req, b, _))
 
-      case HeaderOr(a, b) => runValidation(req, a, stack).orElse(runValidation(req, b, stack))
-
-      case HeaderExists(key, f) => req.headers.get(key) match {
-        case Some(h) => 
-          scalaz.\/.fromTryCatchNonFatal( f(h) ) match {
-            case scalaz.-\/(t) => FailureResponse.badRequest(t.getMessage())
-            case scalaz.\/-(option) => option.fold[ResultResponse[HList]](SuccessResponse(stack))(f => FailureResponse.result(f))
-          }
-        case None => FailureResponse.badRequest(s"Missing header: ${key.name}")
-      }
-
-      case HeaderCapture(key, f, default) => req.headers.get(key) match {
-        case Some(h) =>
-          scalaz.\/.fromTryCatchNonFatal( f(h) ) match {
-            case scalaz.-\/(t) => FailureResponse.badRequest(t.getMessage())
-            case scalaz.\/-(option) => option.fold(f => FailureResponse.result(f), r => SuccessResponse(r::stack))
-          }
-
-        case None => default match {
-          case Some(r) => FailureResponse.result(r)
-          case None    => FailureResponse.badRequest(s"Missing header: ${key.name}")
-        }
-      }
-
-      case MetaCons(r, _) => runValidation(req, r, stack)
-
-      case EmptyHeaderRule => SuccessResponse(stack)
-    }
-  }
-
-  def runQuery(req: Request, v: QueryRule, stack: HList): ResultResponse[HList] = {
-    import QueryAST.MetaCons
-    v match {
-      case QueryAnd(a, b) => runQuery(req, a, stack).flatMap(runQuery(req, b, _))
-
-      case QueryOr(a, b) => runQuery(req, a, stack).orElse(runQuery(req, b, stack))
-
-      case QueryCapture(name, parser, default, _) => parser.collect(name, req.multiParams, default).map(_ :: stack)
-
-      case MetaCons(r, _) => runQuery(req, r, stack)
-
-      case EmptyQuery => SuccessResponse(stack)
-    }
+  def runRequestRules(req: Request, v: RequestRule, stack: HList): ResultResponse[HList] = v match {
+    case AndRule(a, b) => runRequestRules(req, a, stack).flatMap(runRequestRules(req, b, _))
+    case OrRule(a, b) => runRequestRules(req, a, stack).orElse(runRequestRules(req, b, stack))
+    case CaptureRule(reader) => reader(req).map(_::stack)
+    case MetaRule(r, _) => runRequestRules(req, r, stack)
+    case EmptyRule => SuccessResponse(stack)
+    case IgnoreRule(r) => runRequestRules(req, r, stack).map(_ => stack)
   }
 }

--- a/core/src/main/scala/org/http4s/rho/RequestLineBuilder.scala
+++ b/core/src/main/scala/org/http4s/rho/RequestLineBuilder.scala
@@ -1,23 +1,20 @@
 package org.http4s
 package rho
 
-import org.http4s.rho.bits.QueryAST.{ QueryAnd, TypedQuery, QueryRule }
-
-import bits.HeaderAST.{ EmptyHeaderRule, HeaderRule }
+import org.http4s.rho.bits.QueryAST.TypedQuery
 import org.http4s.rho.bits.PathAST.{PathAnd, TypedPath, PathRule}
+import org.http4s.rho.bits.RequestAST.{AndRule, RequestRule}
 import shapeless.{HNil, HList}
 import shapeless.ops.hlist.Prepend
 
-case class RequestLineBuilder[T <: HList](path: PathRule, query: QueryRule)
+case class RequestLineBuilder[T <: HList](path: PathRule, rules: RequestRule)
   extends TypedBuilder[T]
   with RoutePrependable[RequestLineBuilder[T]]
   with UriConvertible {
-
-  override def headers: HeaderRule = EmptyHeaderRule
 
   override def /:(prefix: TypedPath[HNil]): RequestLineBuilder[T] =
     copy(path = PathAnd(prefix.rule, path))
 
   def &[T1 <: HList](q: TypedQuery[T1])(implicit prep: Prepend[T1, T]): RequestLineBuilder[prep.Out] =
-    RequestLineBuilder(path, QueryAnd(query, q.rule))
+    RequestLineBuilder(path, AndRule(rules, q.rule))
 }

--- a/core/src/main/scala/org/http4s/rho/RhoRoute.scala
+++ b/core/src/main/scala/org/http4s/rho/RhoRoute.scala
@@ -1,9 +1,8 @@
 package org.http4s
 package rho
 
-import bits.HeaderAST.HeaderRule
 import org.http4s.rho.bits.PathAST.{TypedPath, PathRule}
-import org.http4s.rho.bits.QueryAST.QueryRule
+import org.http4s.rho.bits.RequestAST.RequestRule
 import org.http4s.rho.bits.ResultInfo
 
 import shapeless.{HNil, HList}
@@ -23,8 +22,7 @@ final case class RhoRoute[T <: HList](router: RoutingEntity[T], action: Action[T
 
   def method: Method = router.method
   def path: PathRule = router.path
-  def query: QueryRule = router.query
-  def headers: HeaderRule = router.headers
+  def rules: RequestRule = router.rules
   def responseEncodings: Set[MediaType] = action.responseEncodings
   def resultInfo: Set[ResultInfo] = action.resultInfo
   def validMedia: Set[MediaRange] = router match {

--- a/core/src/main/scala/org/http4s/rho/TypedBuilder.scala
+++ b/core/src/main/scala/org/http4s/rho/TypedBuilder.scala
@@ -1,9 +1,8 @@
 package org.http4s
 package rho
 
-import org.http4s.rho.bits.HeaderAST.HeaderRule
 import org.http4s.rho.bits.PathAST.PathRule
-import org.http4s.rho.bits.QueryAST.QueryRule
+import org.http4s.rho.bits.RequestAST.RequestRule
 import org.http4s.rho.bits.UriConverter
 
 import shapeless.HList
@@ -14,20 +13,17 @@ import shapeless.HList
  */
 trait TypedBuilder[T <: HList] extends UriConvertible {
   /** Untyped AST representation of the path to operate on */
-  def path: PathRule
+  val path: PathRule
 
-  /** Untyped AST representation of the query to operate on */
-  def query: QueryRule
+  /** Untyped AST describing the extraction of headers and the query from the [[Request]] */
+  val rules: RequestRule
 
-  /** Untyped AST representation of the [[Header]]s to operate on */
-  def headers: HeaderRule
-
-  private val uriTemplate =
+  private def uriTemplate =
     for {
       p <- UriConverter.createPath(path)
-      q <- UriConverter.createQuery(query)
+      q <- UriConverter.createQuery(rules)
     } yield UriTemplate(path = p, query = q)
 
-  override def asUriTemplate(request: Request) =
+  final override def asUriTemplate(request: Request) =
     UriConvertible.respectPathInfo(uriTemplate, request)
 }

--- a/core/src/main/scala/org/http4s/rho/bits/HeaderAST.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/HeaderAST.scala
@@ -1,42 +1,22 @@
 package org.http4s
 package rho.bits
 
-import org.http4s.rho.Result.BaseResult
+import org.http4s.rho.bits.RequestAST.{AndRule, OrRule, RequestRule}
 import shapeless.ops.hlist.Prepend
 import shapeless.{::, HList}
-
-import scalaz.\/
-import scalaz.concurrent.Task
 
 /** AST representing the Header operations of the DSL */
 object HeaderAST {
 
-  final case class TypedHeader[T <: HList](rule: HeaderRule) {
+  final case class TypedHeader[T <: HList](rule: RequestRule) {
 
-    def or(v: TypedHeader[T]): TypedHeader[T] = TypedHeader(HeaderOr(this.rule, v.rule))
+    def or(v: TypedHeader[T]): TypedHeader[T] = TypedHeader(OrRule(this.rule, v.rule))
 
     def ||(v: TypedHeader[T]): TypedHeader[T] = or(v)
 
     def and[T1 <: HList](v: TypedHeader[T1])(implicit prepend: Prepend[T1, T]): TypedHeader[prepend.Out] =
-      TypedHeader(HeaderAnd(this.rule, v.rule))
+      TypedHeader(AndRule(this.rule, v.rule))
 
     def &&[T1 <: HList](v: TypedHeader[T1])(implicit prepend: Prepend[T1, T]): TypedHeader[prepend.Out] = and(v)
   }
-
-  ///////////////// Header and body AST ///////////////////////
-
-  sealed trait HeaderRule
-
-  case class HeaderExists[T <: HeaderKey.Extractable](key: T, f: T#HeaderT => Option[Task[BaseResult]]) extends HeaderRule
-
-  case class HeaderCapture[T <: HeaderKey.Extractable, R](key: T, f: T#HeaderT => Task[BaseResult]\/R, default: Option[Task[BaseResult]]) extends HeaderRule
-
-  case class HeaderAnd(a: HeaderRule, b: HeaderRule) extends HeaderRule
-
-  case class HeaderOr(a: HeaderRule, b: HeaderRule) extends HeaderRule
-
-  case class MetaCons(a: HeaderRule, meta: Metadata) extends HeaderRule
-
-  case object EmptyHeaderRule extends HeaderRule
-
 }

--- a/core/src/main/scala/org/http4s/rho/bits/Metadata.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/Metadata.scala
@@ -1,9 +1,16 @@
 package org.http4s
 package rho.bits
 
+import scala.language.existentials
+
+import scala.reflect.runtime.universe.TypeTag
+
 trait Metadata
 
 trait TextMetaData extends Metadata {
   def msg: String
 }
 
+case class QueryMetaData[T](name: String, p: QueryParser[T], default: Option[T], m: TypeTag[T]) extends Metadata
+
+case class HeaderMetaData[T <: HeaderKey.Extractable, R](key: T, default: Boolean) extends Metadata

--- a/core/src/main/scala/org/http4s/rho/bits/PathAST.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/PathAST.scala
@@ -38,7 +38,7 @@ object PathAST {
       TypedPath(PathAnd(this.rule, t.rule))
 
     def /[T2 <: HList](t: RequestLineBuilder[T2])(implicit prep: Prepend[T, T2]): RequestLineBuilder[prep.Out] =
-      RequestLineBuilder(PathAnd(this.rule, t.path), t.query)
+      RequestLineBuilder(PathAnd(this.rule, t.path), t.rules)
 
     def +?[T1 <: HList](q: TypedQuery[T1])(implicit prep: Prepend[T1, T]): RequestLineBuilder[prep.Out] =
       RequestLineBuilder(rule, q.rule)

--- a/core/src/main/scala/org/http4s/rho/bits/PathTree.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/PathTree.scala
@@ -69,25 +69,23 @@ private[rho] object PathTree {
 
   private def makeLeaf[T <: HList](route: RhoRoute[T]): Leaf = {
     route.router match {
-      case Router(method, _, query, vals) =>
+      case Router(method, _, rules) =>
         Leaf { (req, pathstack) =>
-          for {
-            i <- ValidationTools.runQuery(req, query, pathstack)
-            j <- ValidationTools.runValidation(req, vals, i) // `asInstanceOf` to turn the untyped HList to type T
-          } yield route.action.act(req, j.asInstanceOf[T])
+          ValidationTools.runRequestRules(req, rules, pathstack).map{ i =>
+            route.action.act(req, i.asInstanceOf[T])
+          }
         }
 
       case c @ CodecRouter(_, parser) =>
         Leaf { (req, pathstack) =>
-          for {
-            i <- ValidationTools.runQuery(req, c.router.query, pathstack)
-            j <- ValidationTools.runValidation(req, c.headers, i)
-          } yield parser.decode(req).run.flatMap(_.fold(e =>
-            Response(Status.BadRequest, req.httpVersion).withBody(e.sanitized),
-          { body =>
-            // `asInstanceOf` to turn the untyped HList to type T
-            route.action.act(req, (body :: j).asInstanceOf[T])
-          }))
+          ValidationTools.runRequestRules(req, c.router.rules, pathstack).map{ i =>
+            parser.decode(req).run.flatMap(_.fold(e =>
+              Response(Status.BadRequest, req.httpVersion).withBody(e.sanitized),
+              { body =>
+                // `asInstanceOf` to turn the untyped HList to type T
+                route.action.act(req, (body :: i).asInstanceOf[T])
+              }))
+          }
         }
     }
   }

--- a/core/src/main/scala/org/http4s/rho/bits/QueryAST.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/QueryAST.scala
@@ -2,20 +2,20 @@ package org.http4s
 package rho.bits
 
 import org.http4s.rho.UriConvertible
+import org.http4s.rho.bits.RequestAST._
 
-import scala.reflect.runtime.universe.TypeTag
 import shapeless.HList
 import shapeless.ops.hlist.Prepend
 
 object QueryAST {
 
-  case class TypedQuery[T <: HList](rule: QueryRule) extends UriConvertible {
-    final def or(v: TypedQuery[T]): TypedQuery[T] = TypedQuery(QueryOr(this.rule, v.rule))
+  case class TypedQuery[T <: HList](rule: RequestRule) extends UriConvertible {
+    final def or(v: TypedQuery[T]): TypedQuery[T] = TypedQuery(OrRule(this.rule, v.rule))
 
     final def ||(v: TypedQuery[T]): TypedQuery[T] = or(v)
 
     final def and[T1 <: HList](v: TypedQuery[T1])(implicit prepend: Prepend[T1, T]): TypedQuery[prepend.Out] =
-      TypedQuery(QueryAnd(this.rule, v.rule))
+      TypedQuery(AndRule(this.rule, v.rule))
 
     final def &&[T1 <: HList](v: TypedQuery[T1])(implicit prepend: Prepend[T1, T]): TypedQuery[prepend.Out] = and(v)
 
@@ -36,43 +36,34 @@ object QueryAST {
 
   object TypedQuery {
     import shapeless.{HNil, ::}
+
     implicit def queryParamKeyLike[T]: QueryParamKeyLike[TypedQuery[T::HNil]] = new QueryParamKeyLike[TypedQuery[T::HNil]] {
       override def getKey(t: TypedQuery[T::HNil]): QueryParameterKey =
         getKey(t.rule).getOrElse(sys.error("Empty Query doesn't have a key name"))
 
-      private def getKey(rule: QueryRule): Option[QueryParameterKey] = rule match {
-        case QueryCapture(n,_,_,_) => Some(QueryParameterKey(n))
-        case QueryOr(a, b)         => getKey(a) orElse getKey(b)
-        case MetaCons(r,_)         => getKey(r)
-        case QueryAnd(a, b)        => getKey(a) orElse getKey(b) // shouldn't get here
-        case EmptyQuery            => None                       // shouldn't get here
+      private def getKey(rule: RequestRule): Option[QueryParameterKey] = rule match {
+        case MetaRule(_,QueryMetaData(n,_,_,_)) => Some(QueryParameterKey(n))
+        case MetaRule(r,_)                      => getKey(r)
+        case OrRule(a, b)                       => getKey(a) orElse getKey(b)
+        case IgnoreRule(r)                      => getKey(r)
+        case AndRule(a, b)                      => getKey(a) orElse getKey(b) // shouldn't get here
+        case CaptureRule(_)                     => None                       // shouldn't get here
+        case EmptyRule                          => None                       // shouldn't get here
       }
     }
   }
 
-  sealed trait QueryRule
-
-  case class QueryCapture[T](name: String, p: QueryParser[T], default: Option[T], m: TypeTag[T]) extends QueryRule
-
-  case class QueryAnd(a: QueryRule, b: QueryRule) extends QueryRule
-
-  case class QueryOr(a: QueryRule, b: QueryRule) extends QueryRule
-
-  case class MetaCons(query: QueryRule, meta: Metadata) extends QueryRule
-
-  case object EmptyQuery extends QueryRule
-
-  private def collectNames(rule: QueryRule): List[String] = {
+  private def collectNames(rule: RequestRule): List[String] = {
     @scala.annotation.tailrec
-    def go(r: List[QueryRule], acc: List[String]): List[String] = r match {
+    def go(r: List[RequestRule], acc: List[String]): List[String] = r match {
       case Nil => acc
-      case MetaCons(query, _) :: rs => go(rs, acc)
-      case QueryAnd(a, b) :: rs => go(a :: b :: rs, acc)
-      case QueryCapture(name, _, _, _) :: rs => go(rs, name :: acc)
-      case QueryOr(a, _) :: rs => go(a :: rs, acc)
-      case EmptyQuery :: rs => go(rs, acc)
+      case MetaRule(q, QueryMetaData(n,_,_,_)) :: rs  => go(q :: rs, n :: acc)
+      case MetaRule(q, _) :: rs                       => go(q :: rs, acc)
+      case AndRule(a, b) :: rs                        => go(a :: b :: rs, acc)
+      case OrRule(a, _) :: rs                         => go(a :: rs, acc)
+      case IgnoreRule(r) :: rs                        => go(r :: rs, acc)
+      case (EmptyRule | CaptureRule(_)) :: rs         => go(rs, acc)
     }
     go(List(rule), Nil).reverse
   }
-
 }

--- a/core/src/main/scala/org/http4s/rho/bits/QueryParser.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/QueryParser.scala
@@ -15,17 +15,6 @@ trait QueryParser[A] {
   def collect(name: String, params: Params, default: Option[A]): ResultResponse[A]
 }
 
-final class ValidatingParser[A](parent: QueryParser[A], validate: A => Option[Task[BaseResult]]) extends QueryParser[A] {
-  override def collect(name: String, params: Params, default: Option[A]): ResultResponse[A] = {
-    val result = parent.collect(name, params, default)
-    result.flatMap{ r => validate(r) match {
-        case None       => result
-        case Some(resp) => FailureResponse.pure(resp.map(_.resp))
-      }
-    }
-  }
-}
-
 object QueryParser {
   type Params = Map[String, Seq[String]]
 

--- a/core/src/main/scala/org/http4s/rho/bits/RequestAST.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/RequestAST.scala
@@ -1,0 +1,19 @@
+package org.http4s
+package rho.bits
+
+object RequestAST {
+
+  sealed trait RequestRule
+
+  case class CaptureRule[T](reader: Request => ResultResponse[T]) extends RequestRule
+
+  case class IgnoreRule(rule: RequestRule) extends RequestRule
+
+  case class AndRule(a: RequestRule, b: RequestRule) extends RequestRule
+
+  case class OrRule(a: RequestRule, b: RequestRule) extends RequestRule
+
+  case class MetaRule(query: RequestRule, meta: Metadata) extends RequestRule
+
+  case object EmptyRule extends RequestRule
+}

--- a/core/src/main/scala/org/http4s/rho/bits/ResultResponse.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/ResultResponse.scala
@@ -1,7 +1,7 @@
 package org.http4s.rho.bits
 
 import org.http4s.rho.bits.FailureResponse._
-import org.http4s.rho.bits.ResponseGeneratorInstances.BadRequest
+import org.http4s.rho.bits.ResponseGeneratorInstances.{InternalServerError, BadRequest}
 import org.http4s.Response
 import org.http4s.rho.Result.BaseResult
 import org.http4s.server.HttpService
@@ -53,6 +53,8 @@ case class FailureResponse(reason: FailureReason) extends ResultResponse[Nothing
 
 object FailureResponse {
   def badRequest(reason: String): FailureResponse = FailureResponse(new ResponseReason(BadRequest.pure(reason)))
+
+  def error(message: String): FailureResponse = FailureResponse(new ResponseReason(InternalServerError.pure(message)))
 
   def pure(response: =>Task[Response]): FailureResponse = FailureResponse(new ResponseReason(response))
 

--- a/core/src/test/scala/org/http4s/rho/ApiTest.scala
+++ b/core/src/test/scala/org/http4s/rho/ApiTest.scala
@@ -4,8 +4,9 @@ package rho
 import bits.MethodAliases._
 import bits.ResponseGeneratorInstances._
 
-import bits.HeaderAST.{TypedHeader, HeaderAnd}
+import bits.HeaderAST.TypedHeader
 import bits.{PathTree, SuccessResponse, FailureResponse}
+import org.http4s.rho.bits.RequestAST.AndRule
 
 import org.specs2.mutable._
 import shapeless.HNil
@@ -33,12 +34,12 @@ class ApiTest extends Specification {
 
   "RhoDsl bits" should {
     "Combine validators" in {
-      RequireETag && RequireNonZeroLen should_== TypedHeader(HeaderAnd(RequireETag.rule, RequireNonZeroLen.rule))
+      RequireETag && RequireNonZeroLen should_== TypedHeader(AndRule(RequireETag.rule, RequireNonZeroLen.rule))
     }
 
     "Fail on a bad request" in {
       val badreq = Request().withHeaders(Headers(lenheader))
-      val res = PathTree.ValidationTools.ensureValidHeaders((RequireETag && RequireNonZeroLen).rule,badreq)
+      val res = PathTree.ValidationTools.runRequestRules((RequireETag && RequireNonZeroLen).rule,badreq)
 
       res must beAnInstanceOf[FailureResponse]
       res.asInstanceOf[FailureResponse].toResponse.run.status must_== Status.BadRequest
@@ -46,56 +47,55 @@ class ApiTest extends Specification {
                                                                                         
     "Fail on a bad request 2" in {
       val req = Request().withHeaders(Headers(lenheader))
-      val res = PathTree.ValidationTools.ensureValidHeaders(RequireThrowException.rule, req)                                                            
+      val res = PathTree.ValidationTools.runRequestRules(RequireThrowException.rule, req)
       res must beAnInstanceOf[FailureResponse]                                                                                                          
-      res.asInstanceOf[FailureResponse].toResponse.run.status must_== Status.BadRequest
-      res.asInstanceOf[FailureResponse].toResponse.run.as[String].run must_== "this could happen"
+      res.asInstanceOf[FailureResponse].toResponse.run.status must_== Status.InternalServerError
     }
 
     "Match captureless route" in {
       val c = RequireETag && RequireNonZeroLen
 
       val req = Request().withHeaders(Headers(etag, lenheader))
-      PathTree.ValidationTools.ensureValidHeaders(c.rule, req) should_== SuccessResponse(HNil)
+      PathTree.ValidationTools.runRequestRules(c.rule, req) should_== SuccessResponse(HNil)
     }
 
     "Capture params" in {
       val req = Request().withHeaders(Headers(etag, lenheader))
       Seq({
         val c2 = capture(headers.`Content-Length`) && RequireETag
-        PathTree.ValidationTools.ensureValidHeaders(c2.rule, req) should_== SuccessResponse(lenheader::HNil)
+        PathTree.ValidationTools.runRequestRules(c2.rule, req) should_== SuccessResponse(lenheader::HNil)
       }, {
         val c3 = capture(headers.`Content-Length`) && capture(headers.ETag)
-        PathTree.ValidationTools.ensureValidHeaders(c3.rule, req) should_== SuccessResponse(etag::lenheader::HNil)
+        PathTree.ValidationTools.runRequestRules(c3.rule, req) should_== SuccessResponse(etag::lenheader::HNil)
       }).reduce( _ and _)
     }
 
     "Map header params" in {
       val req = Request().withHeaders(Headers(etag, lenheader))
       val c = captureMap(headers.`Content-Length`)(_.length)
-      PathTree.ValidationTools.ensureValidHeaders(c.rule, req) should_== SuccessResponse(4::HNil)
+      PathTree.ValidationTools.runRequestRules(c.rule, req) should_== SuccessResponse(4::HNil)
     }
 
     "Map header params with exception" in {
       val req = Request().withHeaders(Headers(etag, lenheader))
       val c = captureMap(headers.`Content-Length`)(_.length / 0)
-      PathTree.ValidationTools.ensureValidHeaders(c.rule, req) must beAnInstanceOf[FailureResponse]
+      PathTree.ValidationTools.runRequestRules(c.rule, req) must beAnInstanceOf[FailureResponse]
     }
 
     "Map with possible default" in {
       val req = Request().withHeaders(Headers(etag, lenheader))
 
       val c1 = captureMapR(headers.`Content-Length`)(r => \/-(r.length))
-      PathTree.ValidationTools.ensureValidHeaders(c1.rule, req) should_== SuccessResponse(4::HNil)
+      PathTree.ValidationTools.runRequestRules(c1.rule, req) should_== SuccessResponse(4::HNil)
 
       val r2 = Gone("Foo")
       val c2 = captureMapR(headers.`Content-Length`)(_ => -\/(r2))
-      val v1 = PathTree.ValidationTools.ensureValidHeaders(c2.rule, req)
+      val v1 = PathTree.ValidationTools.runRequestRules(c2.rule, req)
       v1 must beAnInstanceOf[FailureResponse]
       v1.asInstanceOf[FailureResponse].toResponse.run.status must_== r2.run.resp.status
 
       val c3 = captureMapR(headers.`Access-Control-Allow-Credentials`, Some(r2))(_ => ???)
-      val v2 = PathTree.ValidationTools.ensureValidHeaders(c3.rule, req)
+      val v2 = PathTree.ValidationTools.runRequestRules(c3.rule, req)
       v2 must beAnInstanceOf[FailureResponse]
       v2.asInstanceOf[FailureResponse].toResponse.run.status must_== r2.run.resp.status
     }

--- a/core/src/test/scala/org/http4s/rho/CompileServiceSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/CompileServiceSpec.scala
@@ -1,5 +1,7 @@
 package org.http4s.rho
 
+import scala.language.existentials
+
 import org.http4s.{Method, Request, Uri}
 import org.http4s.rho.CompileService.ServiceBuilder
 import org.specs2.mutable.Specification

--- a/core/src/test/scala/org/http4s/rho/ParamDefaultValueSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/ParamDefaultValueSpec.scala
@@ -1,6 +1,7 @@
 package org.http4s
 package rho
 
+import org.http4s.server.HttpService
 import org.specs2.mutable.Specification
 import scodec.bits.ByteVector
 
@@ -42,11 +43,9 @@ class ParamDefaultValueSpec extends Specification {
     GET / "test12" +? param[Option[String]]("param1", Some("default1"), (p: Option[String]) => p != Some("fail") && p != Some("")) |>> { os: Option[String] => Ok("test12:" + os.getOrElse("")) }
 
     GET / "test13" +? param[Seq[String]]("param1", Seq("a", "b"), (p: Seq[String]) => !p.contains("") && !p.contains("z")) |>> { os: Seq[String] => Ok("test13:" + os.mkString(",")) }
-
-    GET / "test14" +? param[Seq[Int]]("param1", Seq(3, 5, 8), (p: Seq[Int]) => p != Seq(8, 5, 3)) |>> { os: Seq[Int] => Ok("test14:" + os.mkString(",")) }
   }.toService()
 
-  def body(r: Request): String = getBody(service(r).run.body)
+  def body(service: HttpService, r: Request): String = getBody(service(r).run.body)
 
   def requestGet(s: String, h: Header*): Request =
     Request(bits.MethodAliases.GET, Uri.fromString(s).getOrElse(sys.error("Failed.")), headers = Headers(h: _*))
@@ -54,277 +53,334 @@ class ParamDefaultValueSpec extends Specification {
   def status(r: Request): Status = service(r).run.status
 
   "GET /test1" should {
+    val service = new RhoService {
+      GET / "test1" +? param[String]("param1") |>> { param1: String => Ok("test1:" + param1) }
+    }.toService()
+
     val default = "test1:default1"
     "map parameter with default value" in {
-      body(requestGet("/test1")) must be equalTo "Missing query param: param1"
+      body(service, requestGet("/test1")) must be equalTo "Missing query param: param1"
     }
     "map parameter with empty value" in {
-      body(requestGet("/test1?param1=")) must be equalTo "test1:"
+      body(service, requestGet("/test1?param1=")) must be equalTo "test1:"
     }
     "map parameter with value" in {
-      body(requestGet("/test1?param1=value1")) must be equalTo "test1:value1"
+      body(service, requestGet("/test1?param1=value1")) must be equalTo "test1:value1"
     }
     "map parameter without value" in {
-      body(requestGet("/test1?param1")) must be equalTo "Value of query parameter 'param1' missing"
+      body(service, requestGet("/test1?param1")) must be equalTo "Value of query parameter 'param1' missing"
     }
   }
 
   "GET /test2" should {
+    val service = new RhoService {
+      GET / "test2" +? param("param1", "default1") |>> { param1: String => Ok("test2:" + param1) }
+    }.toService()
+
     val default = "test2:default1"
     "map parameter with default value" in {
-      body(requestGet("/test2")) must be equalTo default
+      body(service, requestGet("/test2")) must be equalTo default
     }
     "map parameter with empty value" in {
-      body(requestGet("/test2?param1=")) must be equalTo "test2:"
+      body(service, requestGet("/test2?param1=")) must be equalTo "test2:"
     }
     "map parameter with value" in {
-      body(requestGet("/test2?param1=value1")) must be equalTo "test2:value1"
+      body(service, requestGet("/test2?param1=value1")) must be equalTo "test2:value1"
     }
     "map parameter without value" in {
-      body(requestGet("/test2?param1")) must be equalTo default
+      body(service, requestGet("/test2?param1")) must be equalTo default
     }
   }
 
   "GET /test3" should {
+    val service = new RhoService {
+      GET / "test3" +? param[Int]("param1", 1) |>> { param1: Int => Ok("test3:" + param1) }
+    }.toService()
+
     val default = "test3:1"
     "map parameter with default value" in {
-      body(requestGet("/test3")) must be equalTo default
+      body(service, requestGet("/test3")) must be equalTo default
     }
     "fail to map parameter with empty value" in {
-      body(requestGet("/test3?param1=")) must be equalTo "Invalid number format: ''"
+      body(service, requestGet("/test3?param1=")) must be equalTo "Invalid number format: ''"
     }
     "map parameter with numeric value" in {
-      body(requestGet("/test3?param1=12345")) must be equalTo "test3:12345"
+      body(service, requestGet("/test3?param1=12345")) must be equalTo "test3:12345"
     }
     "fail to map parameter with non-numeric value" in {
-      body(requestGet("/test3?param1=value1")) must be equalTo "Invalid number format: 'value1'"
+      body(service, requestGet("/test3?param1=value1")) must be equalTo "Invalid number format: 'value1'"
     }
     "map parameter without value" in {
-      body(requestGet("/test3?param1")) must be equalTo default
+      body(service, requestGet("/test3?param1")) must be equalTo default
     }
   }
 
   "GET /test4" should {
+    val service = new RhoService {
+      GET / "test4" +? param[Option[String]]("param1") |>> { os: Option[String] => Ok("test4:" + os.getOrElse("")) }
+    }.toService()
+
     val default = "test4:"
     "map parameter with default value" in {
-      body(requestGet("/test4")) must be equalTo default
+      body(service, requestGet("/test4")) must be equalTo default
     }
     "map parameter with empty value" in {
-      body(requestGet("/test4?param1=")) must be equalTo "test4:"
+      body(service, requestGet("/test4?param1=")) must be equalTo "test4:"
     }
     "map parameter with value" in {
-      body(requestGet("/test4?param1=value1")) must be equalTo "test4:value1"
+      body(service, requestGet("/test4?param1=value1")) must be equalTo "test4:value1"
     }
     "map parameter without value" in {
-      body(requestGet("/test4?param1")) must be equalTo "test4:"
+      body(service, requestGet("/test4?param1")) must be equalTo "test4:"
     }
   }
 
   "GET /test5" should {
+    val service = new RhoService {
+      GET / "test5" +? param[Option[Int]]("param1", Some(100)) |>> { os: Option[Int] => Ok("test5:" + os.getOrElse("")) }
+    }.toService()
+
     val default = "test5:100"
     "map parameter with default value" in {
-      body(requestGet("/test5")) must be equalTo default
+      body(service, requestGet("/test5")) must be equalTo default
     }
     "fail on parameter with empty value" in {
-      body(requestGet("/test5?param1=")) must be equalTo "Invalid number format: ''"
+      body(service, requestGet("/test5?param1=")) must be equalTo "Invalid number format: ''"
     }
     "map parameter with numeric value" in {
-      body(requestGet("/test5?param1=12345")) must be equalTo "test5:12345"
+      body(service, requestGet("/test5?param1=12345")) must be equalTo "test5:12345"
     }
     "fail on parameter with non-numeric value" in {
-      body(requestGet("/test5?param1=value1")) must be equalTo "Invalid number format: 'value1'"
+      body(service, requestGet("/test5?param1=value1")) must be equalTo "Invalid number format: 'value1'"
     }
     "map parameter without value" in {
-      body(requestGet("/test5?param1")) must be equalTo default
+      body(service, requestGet("/test5?param1")) must be equalTo default
     }
   }
 
   "GET /test6" should {
+    val service = new RhoService {
+      GET / "test6" +? param[Option[String]]("param1", Some("default1")) |>> { os: Option[String] => Ok("test6:" + os.getOrElse("")) }
+    }.toService()
+
     val default = "test6:default1"
     "map parameter with default value" in {
-      body(requestGet("/test6")) must be equalTo default
+      body(service, requestGet("/test6")) must be equalTo default
     }
     "map parameter with empty value" in {
-      body(requestGet("/test6?param1=")) must be equalTo "test6:"
+      body(service, requestGet("/test6?param1=")) must be equalTo "test6:"
     }
     "map parameter with value" in {
-      body(requestGet("/test6?param1=test12345")) must be equalTo "test6:test12345"
+      body(service, requestGet("/test6?param1=test12345")) must be equalTo "test6:test12345"
     }
     "map parameter without value" in {
-      body(requestGet("/test6?param1")) must be equalTo default
+      body(service, requestGet("/test6?param1")) must be equalTo default
     }
   }
 
   "GET /test7" should {
+    val service = new RhoService {
+      GET / "test7" +? param[Seq[String]]("param1", Seq("a", "b")) |>> { os: Seq[String] => Ok("test7:" + os.mkString(",")) }
+    }.toService()
+
     val default = "test7:a,b"
     "map parameter with default value" in {
-      body(requestGet("/test7")) must be equalTo default
+      body(service, requestGet("/test7")) must be equalTo default
     }
     "map parameter with empty value" in {
-      body(requestGet("/test7?param1=")) must be equalTo "test7:"
+      body(service, requestGet("/test7?param1=")) must be equalTo "test7:"
     }
     "map parameter with one value" in {
-      body(requestGet("/test7?param1=test12345")) must be equalTo "test7:test12345"
+      body(service, requestGet("/test7?param1=test12345")) must be equalTo "test7:test12345"
     }
     "map parameter with many values" in {
-      body(requestGet("/test7?param1=test123&param1=test456&param1=test889")) must be equalTo "test7:test123,test456,test889"
+      body(service, requestGet("/test7?param1=test123&param1=test456&param1=test889")) must be equalTo "test7:test123,test456,test889"
     }
     "map parameter without value" in {
-      body(requestGet("/test7?param1")) must be equalTo default
+      body(service, requestGet("/test7?param1")) must be equalTo default
     }
   }
 
   "GET /test8" should {
+    val service = new RhoService {
+      GET / "test8" +? param[Seq[Int]]("param1", Seq(3, 5, 8)) |>> { os: Seq[Int] => Ok("test8:" + os.mkString(",")) }
+    }.toService()
+
     val default = "test8:3,5,8"
     "map parameter with default value" in {
-      body(requestGet("/test8")) must be equalTo default
+      body(service, requestGet("/test8")) must be equalTo default
     }
     "fail to map parameter with empty value" in {
-      body(requestGet("/test8?param1=")) must be equalTo "Invalid number format: ''"
+      body(service, requestGet("/test8?param1=")) must be equalTo "Invalid number format: ''"
     }
     "map parameter with one numeric value" in {
-      body(requestGet("/test8?param1=12345")) must be equalTo "test8:12345"
+      body(service, requestGet("/test8?param1=12345")) must be equalTo "test8:12345"
     }
     "fail to map parameter with one non-numeric value" in {
-      body(requestGet("/test8?param1=test")) must be equalTo "Invalid number format: 'test'"
+      body(service, requestGet("/test8?param1=test")) must be equalTo "Invalid number format: 'test'"
     }
     "map parameter with many numeric values" in {
-      body(requestGet("/test8?param1=123&param1=456&param1=789")) must be equalTo "test8:123,456,789"
+      body(service, requestGet("/test8?param1=123&param1=456&param1=789")) must be equalTo "test8:123,456,789"
     }
     "fail to map parameter with many non-numeric values" in {
-      body(requestGet("/test8?param1=abc&param1=def")) must be equalTo "Invalid number format: 'abc'"
+      body(service, requestGet("/test8?param1=abc&param1=def")) must be equalTo "Invalid number format: 'abc'"
     }
     "map parameter without value" in {
-      body(requestGet("/test8?param1")) must be equalTo default
+      body(service, requestGet("/test8?param1")) must be equalTo default
     }
   }
 
   "GET /test9" should {
+    val service = new RhoService {
+      GET / "test9" +? param("param1", "default1", (p: String) => !p.isEmpty && p != "fail") |>> { param1: String => Ok("test9:" + param1) }
+    }.toService()
+
     val default = "test9:default1"
     "map parameter with default value" in {
-      body(requestGet("/test9")) must be equalTo default
+      body(service, requestGet("/test9")) must be equalTo default
     }
     "fail to map parameter with empty value" in {
-      body(requestGet("/test9?param1=")) must be equalTo "Invalid query parameter: \"\""
+      body(service, requestGet("/test9?param1=")) must be equalTo "Invalid query parameter: \"\""
     }
     "fail to map parameter with invalid value" in {
-      body(requestGet("/test9?param1=fail")) must be equalTo "Invalid query parameter: \"fail\""
+      body(service, requestGet("/test9?param1=fail")) must be equalTo "Invalid query parameter: \"fail\""
     }
     "map parameter with valid value" in {
-      body(requestGet("/test9?param1=pass")) must be equalTo "test9:pass"
+      body(service, requestGet("/test9?param1=pass")) must be equalTo "test9:pass"
     }
     "map parameter without value" in {
-      body(requestGet("/test9?param1")) must be equalTo default
+      body(service, requestGet("/test9?param1")) must be equalTo default
     }
   }
 
   "GET /test10" should {
+    val service = new RhoService {
+      GET / "test10" +? param[Int]("param1", 1, (p: Int) => p >= 0) |>> { param1: Int => Ok("test10:" + param1) }
+    }.toService()
+
     val default = "test10:1"
     "map parameter with default value" in {
-      body(requestGet("/test10")) must be equalTo default
+      body(service, requestGet("/test10")) must be equalTo default
     }
     "fail to map parameter with empty value" in {
-      body(requestGet("/test10?param1=")) must be equalTo "Invalid number format: ''"
+      body(service, requestGet("/test10?param1=")) must be equalTo "Invalid number format: ''"
     }
     "fail to map parameter with invalid numeric value" in {
-      body(requestGet("/test10?param1=-4")) must be equalTo "Invalid query parameter: \"-4\""
+      body(service, requestGet("/test10?param1=-4")) must be equalTo "Invalid query parameter: \"-4\""
     }
     "fail to map parameter with non-numeric value" in {
-      body(requestGet("/test10?param1=value1")) must be equalTo "Invalid number format: 'value1'"
+      body(service, requestGet("/test10?param1=value1")) must be equalTo "Invalid number format: 'value1'"
     }
     "map parameter with valid numeric value" in {
-      body(requestGet("/test10?param1=10")) must be equalTo "test10:10"
+      body(service, requestGet("/test10?param1=10")) must be equalTo "test10:10"
     }
     "map parameter without value" in {
-      body(requestGet("/test10?param1")) must be equalTo default
+      body(service, requestGet("/test10?param1")) must be equalTo default
     }
   }
 
   "GET /test11" should {
+    val service = new RhoService {
+      GET / "test11" +? param[Option[Int]]("param1", Some(100), (p: Option[Int]) => p != Some(0)) |>> { os: Option[Int] => Ok("test11:" + os.getOrElse("")) }
+    }.toService()
+
     val default = "test11:100"
     "map parameter with default value" in {
-      body(requestGet("/test11")) must be equalTo default
+      body(service, requestGet("/test11")) must be equalTo default
     }
     "fail to map parameter with empty value" in {
-      body(requestGet("/test11?param1=")) must be equalTo "Invalid number format: ''"
+      body(service, requestGet("/test11?param1=")) must be equalTo "Invalid number format: ''"
     }
     "fail to map parameter with invalid numeric value" in {
-      body(requestGet("/test11?param1=0")) must be equalTo "Invalid query parameter: \"Some(0)\""
+      body(service, requestGet("/test11?param1=0")) must be equalTo "Invalid query parameter: \"Some(0)\""
     }
     "fail to map parameter with non-numeric value" in {
-      body(requestGet("/test11?param1=value1")) must be equalTo "Invalid number format: 'value1'"
+      body(service, requestGet("/test11?param1=value1")) must be equalTo "Invalid number format: 'value1'"
     }
     "map parameter with valid numeric value" in {
-      body(requestGet("/test11?param1=1")) must be equalTo "test11:1"
+      body(service, requestGet("/test11?param1=1")) must be equalTo "test11:1"
     }
     "map parameter without value" in {
-      body(requestGet("/test11?param1")) must be equalTo default
+      body(service, requestGet("/test11?param1")) must be equalTo default
     }
   }
 
   "GET /test12" should {
+    val service = new RhoService {
+      GET / "test12" +? param[Option[String]]("param1", Some("default1"), (p: Option[String]) => p != Some("fail") && p != Some("")) |>> { os: Option[String] => Ok("test12:" + os.getOrElse("")) }
+    }.toService()
+
     val default = "test12:default1"
     "map parameter with default value" in {
-      body(requestGet("/test12")) must be equalTo default
+      body(service, requestGet("/test12")) must be equalTo default
     }
     "fail to map parameter with empty value" in {
-      body(requestGet("/test12?param1=")) must be equalTo "Invalid query parameter: \"Some()\""
+      body(service, requestGet("/test12?param1=")) must be equalTo "Invalid query parameter: \"Some()\""
     }
     "fail to map parameter with invalid value" in {
-      body(requestGet("/test12?param1=fail")) must be equalTo "Invalid query parameter: \"Some(fail)\""
+      body(service, requestGet("/test12?param1=fail")) must be equalTo "Invalid query parameter: \"Some(fail)\""
     }
     "map parameter with valid value" in {
-      body(requestGet("/test12?param1=pass")) must be equalTo "test12:pass"
+      body(service, requestGet("/test12?param1=pass")) must be equalTo "test12:pass"
     }
     "map parameter without value" in {
-      body(requestGet("/test12?param1")) must be equalTo default
+      body(service, requestGet("/test12?param1")) must be equalTo default
     }
   }
 
   "GET /test13" should {
+    val service = new RhoService {
+      GET / "test13" +? param[Seq[String]]("param1", Seq("a", "b"), (p: Seq[String]) => !p.contains("") && !p.contains("z")) |>> { os: Seq[String] => Ok("test13:" + os.mkString(",")) }
+    }.toService()
+
     val default = "test13:a,b"
     "map parameter with default value" in {
-      body(requestGet("/test13")) must be equalTo default
+      body(service, requestGet("/test13")) must be equalTo default
     }
     "fail to map parameter with empty value" in {
-      body(requestGet("/test13?param1=")) must be equalTo "Invalid query parameter: \"List()\""
+      body(service, requestGet("/test13?param1=")) must be equalTo "Invalid query parameter: \"List()\""
     }
     "fail to map parameter with one invalid value" in {
-      body(requestGet("/test13?param1=z")) must be equalTo "Invalid query parameter: \"List(z)\""
+      body(service, requestGet("/test13?param1=z")) must be equalTo "Invalid query parameter: \"List(z)\""
     }
     "map parameter with many values and one invalid" in {
-      body(requestGet("/test13?param1=z&param1=aa&param1=bb")) must be equalTo "Invalid query parameter: \"List(z, aa, bb)\""
+      body(service, requestGet("/test13?param1=z&param1=aa&param1=bb")) must be equalTo "Invalid query parameter: \"List(z, aa, bb)\""
     }
     "map parameter with many valid values" in {
-      body(requestGet("/test13?param1=c&param1=d")) must be equalTo "test13:c,d"
+      body(service, requestGet("/test13?param1=c&param1=d")) must be equalTo "test13:c,d"
     }
     "map parameter without value" in {
-      body(requestGet("/test13?param1")) must be equalTo default
+      body(service, requestGet("/test13?param1")) must be equalTo default
     }
   }
 
   "GET /test14" should {
+
+    val service = new RhoService {
+      GET / "test14" +? param[Seq[Int]]("param1", Seq(3, 5, 8), (p: Seq[Int]) => p != Seq(8, 5, 3)) |>> { os: Seq[Int] => Ok("test14:" + os.mkString(",")) }
+    }.toService()
+
     val default = "test14:3,5,8"
     "map parameter with default value" in {
-      body(requestGet("/test14")) must be equalTo default
+      body(service, requestGet("/test14")) must be equalTo default
     }
     "fail to map parameter with empty value" in {
-      body(requestGet("/test14?param1=")) must be equalTo "Invalid number format: ''"
+      body(service, requestGet("/test14?param1=")) must be equalTo "Invalid number format: ''"
     }
     "fail to map parameter with one invalid numeric value" in {
-      body(requestGet("/test14?param1=8&param1=5&param1=3")) must be equalTo "Invalid query parameter: \"List(8, 5, 3)\""
+      body(service, requestGet("/test14?param1=8&param1=5&param1=3")) must be equalTo "Invalid query parameter: \"List(8, 5, 3)\""
     }
     "fail to map parameter with one non-numeric value" in {
-      body(requestGet("/test14?param1=test")) must be equalTo "Invalid number format: 'test'"
+      body(service, requestGet("/test14?param1=test")) must be equalTo "Invalid number format: 'test'"
     }
     "fail to map parameter with many non-numeric values" in {
-      body(requestGet("/test14?param1=abc&param1=def")) must be equalTo "Invalid number format: 'abc'"
+      body(service, requestGet("/test14?param1=abc&param1=def")) must be equalTo "Invalid number format: 'abc'"
     }
     "map parameter with many valid numeric values" in {
-      body(requestGet("/test14?param1=1&param1=2&param1=3")) must be equalTo "test14:1,2,3"
+      body(service, requestGet("/test14?param1=1&param1=2&param1=3")) must be equalTo "test14:1,2,3"
     }
     "map parameter without value" in {
-      body(requestGet("/test14?param1")) must be equalTo default
+      body(service, requestGet("/test14?param1")) must be equalTo default
     }
   }
 

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
@@ -4,13 +4,11 @@ package swagger
 import org.http4s._
 import org.http4s.Method._
 import org.http4s.headers._
-import org.http4s.rho.bits.QueryAST.EmptyQuery
 import org.http4s.rho.bits.{ StringParser, ResultResponse, SuccessResponse, FailureResponse }
 
 import org.specs2.mutable.Specification
 
 import scodec.bits.ByteVector
-import shapeless.HList
 
 import scala.reflect._
 import scala.reflect.runtime.universe._


### PR DESCRIPTION
The HeaderAST and the QueryAST are very similar in form. (For that matter, so
is the PathAST but we leave that for another day) This commit merges the two
AST's into a RequestAST that contains variants specialized for query and header
capture respectively.

The information needed by swagger et al is really meta data so logically
it makes sense to attach it to the rule tree using a MetaRule. This
results in a dramatic reduction in the cases needed to examine when
moving through the tree, hiding unnecessary information from things like
the actual route evaluation logic.