### PR TITLE
Upgrade to http4s 0.12.0

### DIFF
--- a/core/src/main/scala/org/http4s/rho/CompileService.scala
+++ b/core/src/main/scala/org/http4s/rho/CompileService.scala
@@ -4,7 +4,7 @@ package rho
 import org.log4s.getLogger
 
 import org.http4s.rho.bits.PathTree
-import org.http4s.server.{Service, HttpService}
+import org.http4s.{Service, HttpService}
 import shapeless.HList
 
 /** This trait serves to transform a [[RhoRoute]] into an `RouteType`

--- a/core/src/main/scala/org/http4s/rho/RhoService.scala
+++ b/core/src/main/scala/org/http4s/rho/RhoService.scala
@@ -3,7 +3,7 @@ package rho
 
 import org.http4s.rho.CompileService.ServiceBuilder
 import org.http4s.rho.bits.PathAST.TypedPath
-import org.http4s.server.HttpService
+import org.http4s.HttpService
 
 import org.log4s.getLogger
 import shapeless.{HNil, HList}

--- a/core/src/main/scala/org/http4s/rho/RouteExecutable.scala
+++ b/core/src/main/scala/org/http4s/rho/RouteExecutable.scala
@@ -2,7 +2,7 @@ package org.http4s
 package rho
 
 import bits.HListToFunc
-import org.http4s.server.HttpService
+import org.http4s.HttpService
 import shapeless.HList
 
 import scalaz.concurrent.Task

--- a/core/src/main/scala/org/http4s/rho/bits/ResultResponse.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/ResultResponse.scala
@@ -4,7 +4,7 @@ import org.http4s.rho.bits.FailureResponse._
 import org.http4s.rho.bits.ResponseGeneratorInstances.{InternalServerError, BadRequest}
 import org.http4s.Response
 import org.http4s.rho.Result.BaseResult
-import org.http4s.server.HttpService
+import org.http4s.HttpService
 
 import scalaz.concurrent.Task
 

--- a/core/src/test/scala/org/http4s/rho/ParamDefaultValueSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/ParamDefaultValueSpec.scala
@@ -1,7 +1,7 @@
 package org.http4s
 package rho
 
-import org.http4s.server.HttpService
+import org.http4s.HttpService
 import org.specs2.mutable.Specification
 import scodec.bits.ByteVector
 

--- a/core/src/test/scala/org/http4s/rho/RequestRunner.scala
+++ b/core/src/test/scala/org/http4s/rho/RequestRunner.scala
@@ -1,7 +1,7 @@
 package org.http4s.rho
 
 import org.http4s._
-import org.http4s.server.HttpService
+import org.http4s.HttpService
 import scodec.bits.ByteVector
 
 /** Helper for collecting a the body from a `RhoService` */

--- a/core/src/test/scala/org/http4s/rho/ResultSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/ResultSpec.scala
@@ -1,6 +1,8 @@
 package org.http4s.rho
 
-import org.http4s.{AttributeKey, DateTime}
+import java.time.Instant
+
+import org.http4s.AttributeKey
 import org.http4s.headers._
 import org.specs2.mutable.Specification
 
@@ -10,18 +12,19 @@ class ResultSpec extends Specification with ResultSyntaxInstances {
 
   "ResultSyntax" should {
     "Add headers" in {
+      val date = Date(Instant.ofEpochMilli(0))
       val resp = Ok("Foo")
-                  .putHeaders(Date(DateTime.UnixEpoch))
+                  .putHeaders(date)
                   .run
                   .resp
 
-      resp.headers.get(Date) must_== Some(Date(DateTime.UnixEpoch))
+      resp.headers.get(Date) must_== Some(date)
 
       val respNow = Ok("Foo").run
-        .putHeaders(Date(DateTime.UnixEpoch))
+        .putHeaders(date)
         .resp
 
-      respNow.headers.get(Date) must_== Some(Date(DateTime.UnixEpoch))
+      respNow.headers.get(Date) must_== Some(date)
     }
 
     "Add atributes" in {

--- a/core/src/test/scala/org/http4s/rho/bits/PathTreeSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/bits/PathTreeSpec.scala
@@ -4,7 +4,7 @@ package bits
 
 import java.nio.charset.StandardCharsets
 
-import org.http4s.server.HttpService
+import org.http4s.HttpService
 import org.specs2.mutable.Specification
 
 import org.http4s.server.middleware.URITranslation

--- a/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/Routes.scala
+++ b/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/Routes.scala
@@ -1,7 +1,7 @@
 package com.http4s.rho.hal.plus.swagger.demo
 
 import org.http4s.rho.swagger.SwaggerSupport
-import org.http4s.server.HttpService
+import org.http4s.HttpService
 
 class Routes(businessLayer: BusinessLayer) {
 

--- a/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/ServerApp.scala
+++ b/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/ServerApp.scala
@@ -1,6 +1,6 @@
 package com.http4s.rho.hal.plus.swagger.demo
 
-import org.http4s.server.Service
+import org.http4s.Service
 import org.http4s.server.blaze.BlazeBuilder
 import net.sf.uadetector.service.UADetectorServiceFactory.ResourceModuleXmlDataStore
 

--- a/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/StaticContentService.scala
+++ b/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/StaticContentService.scala
@@ -5,7 +5,7 @@ import org.http4s.Request
 import org.http4s.Response
 import org.http4s.StaticFile
 import org.http4s.dsl._
-import org.http4s.server.HttpService
+import org.http4s.HttpService
 import scalaz.concurrent.Task
 
 object StaticContentService {

--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/Main.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/Main.scala
@@ -1,7 +1,7 @@
 package com.http4s.rho.swagger.demo
 
 import org.http4s.rho.swagger.SwaggerSupport
-import org.http4s.server.Service
+import org.http4s.Service
 import org.http4s.server.blaze.BlazeBuilder
 
 object Main extends App {

--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/MyService.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/MyService.scala
@@ -1,6 +1,7 @@
 package com.http4s.rho.swagger.demo
 
 import java.util.concurrent.atomic.AtomicInteger
+import java.time.Instant
 
 import org.http4s.Uri
 import org.http4s.rho.RhoService
@@ -17,7 +18,7 @@ object MyService extends RhoService {
   import org.http4s.EntityDecoder
 
   import org.http4s.headers
-  import org.http4s.{Request, Headers, DateTime}
+  import org.http4s.{Request, Headers}
 
   case class JsonResult(name: String, number: Int) extends AutoSerializable
 
@@ -77,7 +78,7 @@ object MyService extends RhoService {
       val hs = req.headers.get(headers.Cookie) match {
         case None => Headers.empty
         case Some(cookie) =>
-          Headers(cookie.values.toList.map { c => headers.`Set-Cookie`(c.copy(expires = Some(DateTime.UnixEpoch), maxAge = Some(0)))})
+          Headers(cookie.values.toList.map { c => headers.`Set-Cookie`(c.copy(expires = Some(Instant.ofEpochMilli(0)), maxAge = Some(0)))})
       }
 
       Ok("Deleted cookies!").replaceAllHeaders(hs)

--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/StaticContentService.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/StaticContentService.scala
@@ -5,7 +5,7 @@ import org.http4s.Request
 import org.http4s.Response
 import org.http4s.StaticFile
 import org.http4s.dsl._
-import org.http4s.server.HttpService
+import org.http4s.HttpService
 import scalaz.concurrent.Task
 
 object StaticContentService {

--- a/project/build.scala
+++ b/project/build.scala
@@ -189,7 +189,7 @@ object RhoBuild extends Build {
 }
 
 object Dependencies {
-  lazy val http4sVersion = "0.11.0"
+  lazy val http4sVersion = "0.12.0"
   lazy val http4sServerVersion = if (!http4sVersion.endsWith("SNAPSHOT")) (http4sVersion.dropRight(1) + "0")
                                  else http4sVersion
 

--- a/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
@@ -1,8 +1,8 @@
 package org.http4s.rho.swagger
 
 import java.util.Date
+import java.time.Instant
 
-import org.http4s.DateTime
 import org.http4s.rho.bits.ResponseGenerator.EmptyRe
 
 import org.log4s.getLogger
@@ -230,7 +230,7 @@ object TypeBuilder {
       DecimalTypes.exists(t =:= _)
 
     private[this] val DateTimeTypes =
-      Set[Type](typeOf[Date], typeOf[DateTime])
+      Set[Type](typeOf[Date], typeOf[Instant])
 
     private[this] def isDateTime(t: Type): Boolean =
       DateTimeTypes.exists(t <:< _)


### PR DESCRIPTION
Summary of changes:
* Service and HttpService moved from org.http4s.server to org.http4s so lots of changed imports.
* http4s dropped its home grown DateTime in favor of the java.time.Instant. The swagger TypeBuilder had to be changed accordingly. Also some tests needed changing.