### PR TITLE
Upgrade to http4s-0.13-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ The primary goal of ρ is to provide an easy to use AST with which to build HTTP
 
 Get ρ
 -----
-Rho artifacts are available at Maven Central and snapshots are available from the Sonatype repositories
+Rho artifacts are available at Maven Central and snapshots are available from the Sonatype repositories.
+
+__Currently there is an incompatibility with scalac 2.11.8 resulting in failure to resolve the requisite implicits for
+defining a route with statically known status codes. Hopefully this will be addressed soon. In the meantime, compiling
+with scalac 2.11.7 should work as advertised.__
 
 Read the [Rho Scaladocs](http://rho.http4s.org)
 

--- a/core/src/main/scala/org/http4s/rho/bits/PathTree.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/PathTree.scala
@@ -90,7 +90,7 @@ private[rho] object PathTree {
         Leaf { (req, pathstack) =>
           RuleExecutor.runRequestRules(req, c.router.rules, pathstack).map{ i =>
             parser.decode(req, false).run.flatMap(_.fold(e =>
-              Response(Status.BadRequest, req.httpVersion).withBody(e.msg),
+              e.toHttpResponse(req.httpVersion),
               { body =>
                 // `asInstanceOf` to turn the untyped HList to type T
                 route.action.act(req, (body :: i).asInstanceOf[T])

--- a/core/src/test/scala/ApiExamples.scala
+++ b/core/src/test/scala/ApiExamples.scala
@@ -106,12 +106,12 @@ class ApiExamples extends Specification {
         val path2 = "two" / pathVar[Int]
 
         val getLength = captureMap(`Content-Length`)(_.length)
-        val getTag = captureMap(ETag)(_ => -1)
+        val getTag = captureMap(ETag)(_ => -1l)
 
         GET / (path1 || path2) +?
             param[String]("foo") >>>
             (getLength || getTag) |>> {
-          (i: Int, foo: String, v: Int) =>
+          (i: Int, foo: String, v: Long) =>
             Ok(s"Received $i, $foo, $v")
         }
       }

--- a/core/src/test/scala/org/http4s/rho/ApiTest.scala
+++ b/core/src/test/scala/org/http4s/rho/ApiTest.scala
@@ -130,12 +130,12 @@ class ApiTest extends Specification {
 
 
       val route1 = (path >>> lplus1 >>> capture(ETag)).decoding(EntityDecoder.text) runWith {
-        (world: String, lplus1: Int, tag: ETag, body: String) =>
+        (world: String, lplus1: Long, tag: ETag, body: String) =>
           Ok("")
       }
 
       val route2 = (path >>> (lplus1 && capture(ETag))).decoding(EntityDecoder.text) runWith {
-        (world: String, lplus1: Int, tag: ETag, body: String) =>
+        (world: String, _: Long, tag: ETag, body: String) =>
           Ok("")
       }
 

--- a/project/build.scala
+++ b/project/build.scala
@@ -199,9 +199,9 @@ object Dependencies {
   lazy val http4sJetty         = "org.http4s"                 %% "http4s-servlet"        % http4sVersion
   lazy val http4sJson4sJackson = "org.http4s"                 %% "http4s-json4s-jackson" % http4sVersion
   lazy val http4sXmlInstances  = "org.http4s"                 %% "http4s-scala-xml"      % http4sVersion
-  lazy val json4s              = "org.json4s"                 %% "json4s-ext"            % "3.2.11"
+  lazy val json4s              = "org.json4s"                 %% "json4s-ext"            % "3.3.0"
   lazy val json4sJackson       = "org.json4s"                 %% "json4s-jackson"        % json4s.revision
-  lazy val swaggerModels       = "io.swagger"                  % "swagger-models"        % "1.5.3"
+  lazy val swaggerModels       = "io.swagger"                  % "swagger-models"        % "1.5.8"
   lazy val swaggerCore         = "io.swagger"                  % "swagger-core"          % swaggerModels.revision
   lazy val logbackClassic      = "ch.qos.logback"              % "logback-classic"       % "1.1.3"
   lazy val specs2              = "org.specs2"                 %% "specs2-core"           % "3.6.5"

--- a/project/build.scala
+++ b/project/build.scala
@@ -189,7 +189,7 @@ object RhoBuild extends Build {
 }
 
 object Dependencies {
-  lazy val http4sVersion = "0.12.0"
+  lazy val http4sVersion = "0.13.0-SNAPSHOT"
   lazy val http4sServerVersion = if (!http4sVersion.endsWith("SNAPSHOT")) (http4sVersion.dropRight(1) + "0")
                                  else http4sVersion
 


### PR DESCRIPTION
The examples here won't build with 2.11.8. Its fixed by a patch in http4s proper but its not clear if that is a real fix or just a band-aid.