### PR TITLE
The DataType of an AnyVal should be the DataType of its underlying type.

### DIFF
--- a/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
@@ -208,6 +208,8 @@ object TypeBuilder {
       } else if (t.isProcess) {
         if (t.typeArgs.nonEmpty) GenArray(fromType(t.typeArgs(1)))
         else GenArray()
+      } else if (klass <:< typeOf[AnyVal]) {
+        fromType(t.members.filter(_.isConstructor).flatMap(_.asMethod.paramLists.flatten).head.typeSignature)
       } else {
         val stt = if (t.isOption) t.typeArgs.head else t
         ComplexDataType(stt.simpleName, qualifiedName = Option(stt.fullName))

--- a/swagger/src/test/scala/org/http4s/rho/swagger/TypeBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/TypeBuilderSpec.scala
@@ -3,14 +3,14 @@ package org.http4s.rho.swagger
 import java.sql.Timestamp
 import java.util.Date
 
+import org.specs2.execute.Result
 import org.specs2.mutable.Specification
 
 import scalaz.concurrent.Task
 import scalaz.stream.Process
-
-import scala.reflect.runtime.universe.{ TypeTag, typeTag, typeOf }
-
-import scalaz._, Scalaz._
+import scala.reflect.runtime.universe.{TypeTag, typeOf, typeTag}
+import scalaz._
+import Scalaz._
 
 package object model {
   case class Foo(a: Int, b: String)
@@ -218,5 +218,23 @@ class TypeBuilderSpec extends Specification {
     "Get the type for a container" in {
       DataType(typeTag[Seq[Int]]).name must_== "List"
     }
+
+    "Get the DataType of the underlying type for an AnyVal" in {
+      val datatypes = List[(TypeTag[_], TypeTag[_])](
+        (typeTag[StringAnyVal], typeTag[String]), (typeTag[IntAnyVal], typeTag[Int]),
+        (typeTag[DoubleAnyVal], typeTag[Double]), (typeTag[EntityAnyVal], typeTag[Entity])
+      )
+
+      Result.foreach(datatypes) { case (anyValType, underlyingType) =>
+        DataType(anyValType) === DataType(underlyingType)
+      }
+    }
   }
 }
+
+case class StringAnyVal(value: String) extends AnyVal
+case class IntAnyVal(value: Int) extends AnyVal
+case class DoubleAnyVal(value: Double) extends AnyVal
+case class EntityAnyVal(value: Entity) extends AnyVal
+
+case class Entity(name: String)


### PR DESCRIPTION
We are using `AnyVals` to model query parameters which are `String` or `Int` and give them a bit more type safety.

I propose that those `AnyVals` are not being considered as independent models but just as wrappers around the underlying value. Not doing this creates an invalid Swagger file for us and I didn't find any convenient work-around.