### PR TITLE
Extracted a method from SwaggerSupport to create the Swagger spec

### DIFF
--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
@@ -40,5 +40,11 @@ class SwaggerSupportSpec extends Specification {
 
       Set(a, b, c) should_== Set("/swagger.json", "/foo/hello", "/foo/hello/{string}")
     }
+
+    "Provide a method to build the Swagger model for a list of routes" in {
+      val swaggerSpec = SwaggerSupport.createSwagger(apiPath = "/api")(baseService.getRoutes)
+
+      swaggerSpec.paths must haveSize(2)
+    }
   }
 }


### PR DESCRIPTION
This is useful for us in order to generate a Swagger YAML file which we can commit for review before committing to a given API.

The recursive lazy values in the `apply` method seem to work ok and allow the removal of the `var` :-).