### PR TITLE
[swagger] For a header parameter, set the `required` flag to false if there is a default value

### DIFF
--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
@@ -193,7 +193,7 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
       stack match {
         case Nil                                   => Nil
         case AndRule(a,b)::xs                      => go(a::b::xs)
-        case MetaRule(a,HeaderMetaData(key,_))::xs => mkHeaderParam(key)::go(a::xs)
+        case MetaRule(a,HeaderMetaData(key,d))::xs => mkHeaderParam(key, d)::go(a::xs)
         case MetaRule(a,_)::xs                     => go(a::xs)
         case (EmptyRule | CaptureRule(_))::xs      => go(xs)
         case IgnoreRule(r)::xs                     => go(r::xs)
@@ -334,11 +334,11 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
     }
   }
 
-  def mkHeaderParam(key: HeaderKey.Extractable): HeaderParameter =
+  def mkHeaderParam(key: HeaderKey.Extractable, hasDefault: Boolean): HeaderParameter =
     HeaderParameter(
       `type`   = "string",
       name     = key.name.toString.some,
-      required = true)
+      required = !hasDefault)
 
   def linearizeStack(stack: List[PathRule]): List[List[PathOperation]] = {
 

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
@@ -145,6 +145,14 @@ class SwaggerModelsBuilderSpec extends Specification {
         HeaderParameter(`type` = "string", name = "Content-Length".some, description = orStr("Content-MD5"), required = true),
         HeaderParameter(`type` = "string", name = "Content-MD5".some,    description = orStr("Content-Length"), required = true))
     }
+
+    "set required = false if there is a default value for the header" in {
+      val ra = fooPath >>> captureMapR(`Content-Length`, Option(Ok("5")))(\/-(_)) |>> { (_: `Content-Length`) => "" }
+
+      sb.collectHeaderParams(ra) must_==
+        List(HeaderParameter(`type` = "string", name = "Content-Length".some, required = false))
+    }
+
   }
 
   "SwaggerModelsBuilder.mkOperation" should {


### PR DESCRIPTION
@bryce-anderson I need something like that to:

 - accept a `X-Flow-Id` header if the client passes on
 - generate a `X-Flow-Id` header otherwise

And have `required=false` in the swagger file for that header parameter.

Does it make sense to you too?