### PR TITLE
Translate empty maps in a Swagger model to null in the Java model 

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -114,9 +114,8 @@ object RhoBuild extends Build {
 
         libraryDependencies <++= scalazVersion { sz => Seq(
           http4sServer(sz) % "provided",
-          logbackClassic   % "test",
-          specs2(sz)       % "test"
-        )},
+          logbackClassic   % "test"
+        ) ++ specs2(sz) },
         libraryDependencies += `scala-reflect` % scalaVersion.value
     )
 
@@ -217,8 +216,10 @@ object Dependencies {
   lazy val swaggerModels       = "io.swagger"                  % "swagger-models"        % "1.5.8"
   lazy val swaggerCore         = "io.swagger"                  % "swagger-core"          % swaggerModels.revision
   lazy val logbackClassic      = "ch.qos.logback"              % "logback-classic"       % "1.1.3"
-  def specs2(zv: String)       = "org.specs2"                 %% "specs2-core"           % specs2Version(zv)
   lazy val uadetector          = "net.sf.uadetector"           % "uadetector-resources"  % "2014.09"
+
+  def specs2(zv: String)       = Seq("org.specs2"              %% "specs2-core"          ,
+                                     "org.specs2"              %% "specs2-scalacheck"    ).map(_ % specs2Version(zv) % "test")
 
   lazy val `scala-reflect`     = "org.scala-lang"              % "scala-reflect"
 

--- a/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
@@ -187,6 +187,15 @@ object models {
     , vendorExtensions : Map[String, Any]  = Map.empty
     ) {
 
+    def operations: Seq[Operation] =
+      get.toList ++
+      put.toList ++
+      post.toList ++
+      delete.toList ++
+      patch.toList ++
+      options.toList ++
+      head.toList
+
     def toJModel: jm.Path = {
       val p = new jm.Path
       p.setGet(fromOption(get.map(_.toJModel)))
@@ -747,6 +756,6 @@ object models {
       if (xs.isEmpty) null else xs
 
     def fromMap[A, B](m: Map[A, B]): java.util.Map[A, B] =
-      if (m.isEmpty) Map.empty[A,B] else m
+      if (m.isEmpty) null else m
   }
 }

--- a/swagger/src/test/scala/org/http4s/rho/swagger/Arbitraries.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/Arbitraries.scala
@@ -1,0 +1,223 @@
+package org.http4s.rho.swagger
+
+import models._
+import org.scalacheck._, Gen._, Arbitrary._
+import scalaz._, Scalaz.{option=>_,_}
+import org.http4s.MediaType, MediaType._
+
+/**
+ * Arbitraries for the creation of Swagger models
+ *
+ * They can be improved by
+ *  - generating more data where Gen.const or Map.empty is used
+ *  - making sure the models are coherent in terms of parameters / properties / responses / definitions
+ */
+object Arbitraries {
+
+  implicit def ArbitrarySwagger: Arbitrary[Swagger] =
+    Arbitrary {
+      for {
+        swagger              <- identifier
+        info                 <- option(genInfo)
+        host                 <- option(genHost)
+        basePath             <- option(genBasePath)
+        schemes              <- listOf(genScheme)
+        consumes             <- listOf(genMediaType)
+        produces             <- listOf(genMediaType)
+        definitions          <- mapOf[Model]
+        paths                <- mapOf(genPath(definitions))
+        securityDefinitions  <- mapOf(genSecurityDefinition)
+        parameters           <- mapOf[Parameter]
+        externalDocs         <- option(genExternalDocs)
+      } yield Swagger(
+        swagger,
+        info,
+        host,
+        basePath,
+        schemes,
+        consumes,
+        produces,
+        paths,
+        securityDefinitions,
+        definitions,
+        parameters,
+        externalDocs
+      )
+    }
+
+  def genHost: Gen[String] =
+    const("rho.org")
+
+  def genBasePath: Gen[String] =
+    const("/")
+
+  def genInfo: Gen[Info] =
+    const(Info("title", "version"))
+
+  def genScheme: Gen[Scheme] =
+    oneOf(Scheme.HTTP, Scheme.HTTPS, Scheme.WS, Scheme.WSS)
+
+  def genMediaType: Gen[String] =
+    oneOf(
+      `application/json`,
+      `audio/midi`,
+      `image/gif`,
+      `text/html`
+    ).map(_.renderString)
+
+  def listOf[T : Arbitrary]: Gen[List[T]] =
+    listOf(arbitrary[T])
+
+  def listOf[T](gen: Gen[T]): Gen[List[T]] =
+    choose(0, 4).flatMap(n => listOfN(n, gen))
+
+  def mapOf[T : Arbitrary]: Gen[Map[String, T]] =
+    mapOf(arbitrary[T])
+
+  def mapOf[T](gen: Gen[T]): Gen[Map[String, T]] =
+    choose(1, 10).flatMap(n => listOfN(n, (identifier |@| gen)((_,_))).map(_.toMap))
+
+  def genPath(definitions: Map[String, Model]): Gen[Path] =
+    for {
+      get              <- option(genOperation(definitions))
+      put              <- option(genOperation(definitions))
+      post             <- option(genOperation(definitions))
+      delete           <- option(genOperation(definitions))
+      patch            <- option(genOperation(definitions))
+      options          <- option(genOperation(definitions))
+      head             <- option(genOperation(definitions))
+      parameters       <- listOf[Parameter]
+      vendorExtensions <- const(Map.empty[String, Any])
+    } yield Path(
+        get,
+        put,
+        post,
+        delete,
+        patch,
+        options,
+        head,
+        parameters,
+        vendorExtensions
+      )
+
+  def genOperation(definitions: Map[String, Model]): Gen[Operation] = for {
+    tags             <- listOf(identifier)
+    summary          <- option(identifier)
+    description      <- option(identifier)
+    operationId      <- option(identifier)
+    schemes          <- listOf(genScheme)
+    consumes         <- listOf(genMediaType)
+    produces         <- listOf(genMediaType)
+    parameters       <- listOf[Parameter]
+    responses        <- mapOf(genResponse(definitions))
+    security         <- const(Nil)
+    externalDocs     <- option(genExternalDocs)
+    deprecated       <- arbitrary[Boolean]
+    vendorExtensions <- const(Map.empty[String, Any])
+  } yield
+    Operation(
+      tags,
+      summary,
+      description,
+      operationId,
+      schemes,
+      consumes,
+      produces,
+      parameters,
+      responses,
+      security,
+      externalDocs,
+      deprecated,
+      vendorExtensions
+    )
+
+  def genResponse(definitions: Map[String, Model]): Gen[Response] = for {
+    description <- identifier
+    schema      <- option(oneOf(definitions.keys.toList).map(p => RefProperty(p)))
+    examples    <- mapOf(genExample)
+    headers     <- mapOf[Property]
+  } yield
+    Response(
+      description,
+      schema,
+      examples,
+      headers
+    )
+
+  def genExample: Gen[String] =
+    const("an example")
+
+
+  implicit def ArbitraryModel: Arbitrary[Model] =
+    Arbitrary {
+      for {
+        id                   <- identifier
+        id2                  <- identifier
+        description          <- option(identifier)
+        `type`               <- option(identifier)
+        name                 <- option(identifier)
+        properties           <- mapOf(arbitrary[Property])
+        required             <- choose(0, properties.size - 1).flatMap(n => const(properties.take(n).keys.toList))
+        isSimple             <- arbitrary[Boolean]
+        example              <- option(identifier)
+        additionalProperties <- Gen.const(None)
+        discriminator        <- Gen.const(None)
+        externalDocs         <- Gen.const(None)
+      } yield
+        ModelImpl(
+          id,
+          id2,
+          description,
+          `type`,
+          name,
+          required,
+          properties,
+          isSimple,
+          example,
+          additionalProperties,
+          discriminator,
+          externalDocs
+        )
+    }
+
+
+  def genSecurityDefinition: Gen[SecuritySchemeDefinition] =
+    Gen.oneOf(
+      OAuth2Definition("authorizationUrl", "tokenUrl", "flow", Map.empty),
+      ApiKeyAuthDefinition("name", In.HEADER),
+      BasicAuthDefinition)
+
+  implicit def ArbitraryParameter: Arbitrary[Parameter] =
+    Arbitrary {
+      Gen.oneOf(
+        BodyParameter(),
+        CookieParameter("string"),
+        FormParameter("string"),
+        HeaderParameter("string"),
+        PathParameter("string"),
+        QueryParameter(),
+        RefParameter("ref")
+      )
+    }
+
+  implicit def ArbitraryProperty: Arbitrary[Property] =
+    Arbitrary {
+      oneOf(
+        const(AbstractProperty(): Property),
+        oneOf(AbstractProperty(), RefProperty("ref")).map(p => ArrayProperty(p)),
+        const(RefProperty("ref"))
+      )
+    }
+
+  def genExternalDocs: Gen[ExternalDocs] =
+    Gen.const(ExternalDocs("description", "url"))
+
+  implicit def GenMonad: Monad[Gen] = new Monad[Gen] {
+    def point[A](a: =>A): Gen[A] =
+      Gen.const(a)
+
+    def bind[A, B](fa: Gen[A])(f: A => Gen[B]): Gen[B] =
+      fa.flatMap(f)
+  }
+
+}

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSpec.scala
@@ -1,0 +1,29 @@
+package org.http4s.rho.swagger
+
+import org.specs2.mutable._
+import org.specs2.ScalaCheck
+import Arbitraries._
+import io.swagger.models.{Response => jResponse}
+import org.http4s.rho.swagger.models.Swagger
+
+import scala.collection.JavaConverters._
+
+class SwaggerSpec extends Specification with ScalaCheck {
+  "The Swagger model can be translated to a 'Java' Swagger model".p
+
+  "If there are no examples in the path responses then the corresponding field in the Java model must be null" >> prop { swagger: Swagger =>
+    val paths = swagger.paths.values.toList
+    val operations = paths.flatMap(_.operations)
+    val responses = operations.flatMap(_.responses.values.toList)
+    val examples = responses.flatMap(_.examples)
+
+    val jpaths = swagger.toJModel.getPaths.asScala.values.toList
+    val joperations = jpaths.flatMap(_.getOperations.asScala)
+    val jresponses = joperations.flatMap(_.getResponses.asScala.values.toList)
+
+    jresponses must contain { response: jResponse =>
+      response.getExamples must beNull.iff(examples.isEmpty)
+    }.forall
+  }
+
+}


### PR DESCRIPTION
This prevents empty 'examples' and 'headers' fields to be generated for responses.

The biggest contribution of this PR is actually arbitraries for a `Swagger` model. They are far from complete but they allow to test this change.