### PR TITLE
Added the possibility to add the description of an ApiKeyAuth security definition

### DIFF
--- a/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
@@ -122,16 +122,19 @@ object models {
   }
 
   case class ApiKeyAuthDefinition
-    (
-      name : String
+  (
+    name : String
     , in   : In
-    ) extends SecuritySchemeDefinition {
+    , description: Option[String] = None
+  ) extends SecuritySchemeDefinition {
 
     override val `type` = "apiKey"
 
     def toJModel: jm.auth.ApiKeyAuthDefinition = {
       val akad  = new jm.auth.ApiKeyAuthDefinition
-      akad.name(name).in(in.toJModel)
+      val definition = akad.name(name).in(in.toJModel)
+      description.foreach(definition.setDescription)
+      definition
     }
   }
 


### PR DESCRIPTION
@bryce-anderson this is not essential but helps us describing the content of the JWT token we are using.