### PR TITLE
Added an object property to nest attributes on a definition

### DIFF
--- a/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
@@ -673,6 +673,32 @@ object models {
     }
   }
 
+  case class ObjectProperty
+  (
+    required    : Boolean        = false
+    , title       : Option[String] = None
+    , description : Option[String] = None
+    , format      : Option[String] = None
+    , properties  : Map[String, Property] = Map.empty
+  ) extends Property {
+
+    override val `type` = "object"
+
+    def withRequired(required: Boolean): ObjectProperty =
+      copy(required = required)
+
+    def toJModel: jm.properties.Property = {
+      val ap = new jm.properties.ObjectProperty
+      ap.setType(`type`)
+      ap.setRequired(required)
+      ap.setTitle(fromOption(title))
+      ap.setDescription(fromOption(description))
+      ap.setFormat(fromOption(format))
+      ap.setProperties(fromMap(properties.mapValues(_.toJModel)))
+      ap
+    }
+  }
+  
   case class ArrayProperty
     (
       items       : Property


### PR DESCRIPTION
The `ObjectProperty` is part of the Java Swagger model and is actually useful for me in order to avoid having to create and reference another definition when I can just nest attributes.