### PR TITLE
Add the possibility to specify a swagger 'file' type for a given response

### DIFF
--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerFileResponse.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerFileResponse.scala
@@ -1,0 +1,11 @@
+package org.http4s.rho.swagger
+
+import org.http4s.EntityEncoder
+
+final case class SwaggerFileResponse[T](value: T)
+
+object SwaggerFileResponse {
+  implicit def entityEncoder[T](implicit encoder: EntityEncoder[T]): EntityEncoder[SwaggerFileResponse[T]] =
+    encoder.contramap(_.value)
+}
+

--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
@@ -257,6 +257,8 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
         typeToProp(tpe.dealias.typeArgs(1))
       else if (tpe.isTask)
         typeToProp(tpe.dealias.typeArgs(0))
+      else if (tpe.isSwaggerFile)
+        AbstractProperty(`type` = "file").some
       else
         RefProperty(ref = tpe.simpleName).some      
 

--- a/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
@@ -157,7 +157,6 @@ object TypeBuilder {
     val Boolean = DataType("boolean")
     val Date = DataType("string", Some("date"))
     val DateTime = DataType("string", Some("date-time"))
-    val File = DataType("file")
 
     object GenList {
       def apply(): DataType = ContainerDataType("List")
@@ -197,7 +196,6 @@ object TypeBuilder {
       else if (isDecimal(klass)) this.Double
       else if (isDateTime(klass)) this.DateTime
       else if (isBool(klass)) this.Boolean
-      else if (klass <:< typeOf[SwaggerFileResponse]) this.File
       else if (klass <:< typeOf[scala.collection.Set[_]] || klass <:< typeOf[java.util.Set[_]]) {
         if (t.typeArgs.nonEmpty) GenSet(fromType(t.typeArgs.head))
         else GenSet()

--- a/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
@@ -157,6 +157,7 @@ object TypeBuilder {
     val Boolean = DataType("boolean")
     val Date = DataType("string", Some("date"))
     val DateTime = DataType("string", Some("date-time"))
+    val File = DataType("file")
 
     object GenList {
       def apply(): DataType = ContainerDataType("List")
@@ -196,6 +197,7 @@ object TypeBuilder {
       else if (isDecimal(klass)) this.Double
       else if (isDateTime(klass)) this.DateTime
       else if (isBool(klass)) this.Boolean
+      else if (klass <:< typeOf[SwaggerFileResponse]) this.File
       else if (klass <:< typeOf[scala.collection.Set[_]] || klass <:< typeOf[java.util.Set[_]]) {
         if (t.typeArgs.nonEmpty) GenSet(fromType(t.typeArgs.head))
         else GenSet()

--- a/swagger/src/main/scala/org/http4s/rho/swagger/package.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/package.scala
@@ -34,7 +34,7 @@ package object swagger {
         typeOf[java.lang.Double], typeOf[java.lang.Float], typeOf[BigDecimal],
         typeOf[java.lang.Byte], typeOf[java.lang.Boolean], typeOf[Number],
         typeOf[java.lang.Short], typeOf[Date], typeOf[Timestamp], typeOf[scala.Symbol],
-        typeOf[java.math.BigDecimal], typeOf[java.math.BigInteger], typeOf[SwaggerFileResponse])
+        typeOf[java.math.BigDecimal], typeOf[java.math.BigInteger])
     }
 
     private[swagger] val excludes = {
@@ -87,7 +87,7 @@ package object swagger {
       t <:< typeOf[Option[_]]
 
     def isPrimitive: Boolean =
-      Reflector.primitives.find(t <:< _).isDefined ||
+      Reflector.primitives.find(_ =:= t).isDefined ||
         Reflector.isPrimitive(t, Set(typeOf[Char], typeOf[Unit]))
 
     def isProcess: Boolean =
@@ -95,8 +95,8 @@ package object swagger {
 
     def isTask: Boolean =
       t <:< typeOf[Task[_]]
-  }
 
-  /** marker trait for responses returning files */
-  trait SwaggerFileResponse
+    def isSwaggerFile: Boolean =
+      t <:< typeOf[SwaggerFileResponse[_]]
+  }
 }

--- a/swagger/src/main/scala/org/http4s/rho/swagger/package.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/package.scala
@@ -34,7 +34,7 @@ package object swagger {
         typeOf[java.lang.Double], typeOf[java.lang.Float], typeOf[BigDecimal],
         typeOf[java.lang.Byte], typeOf[java.lang.Boolean], typeOf[Number],
         typeOf[java.lang.Short], typeOf[Date], typeOf[Timestamp], typeOf[scala.Symbol],
-        typeOf[java.math.BigDecimal], typeOf[java.math.BigInteger])
+        typeOf[java.math.BigDecimal], typeOf[java.math.BigInteger], typeOf[SwaggerFileResponse])
     }
 
     private[swagger] val excludes = {
@@ -87,7 +87,7 @@ package object swagger {
       t <:< typeOf[Option[_]]
 
     def isPrimitive: Boolean =
-      Reflector.primitives.find(_ =:= t).isDefined ||
+      Reflector.primitives.find(t <:< _).isDefined ||
         Reflector.isPrimitive(t, Set(typeOf[Char], typeOf[Unit]))
 
     def isProcess: Boolean =
@@ -97,4 +97,6 @@ package object swagger {
       t <:< typeOf[Task[_]]
   }
 
+  /** marker trait for responses returning files */
+  trait SwaggerFileResponse
 }

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
@@ -17,6 +17,7 @@ import scalaz._, Scalaz._
 import scalaz.stream._
 import scalaz.concurrent.Task
 
+
 object SwaggerModelsBuilderSpec {
   
   case class Foo(a: String, b: Int)
@@ -317,7 +318,7 @@ class SwaggerModelsBuilderSpec extends Specification {
     }
 
     "collect response with file type" in {
-      val ra = GET / "test" |>> { () => Ok(CsvFile()) }
+      val ra = GET / "test" |>> { () => Ok(SwaggerFileResponse(CsvFile())) }
 
       sb.collectResponses(ra) must havePair(
         "200" -> Response(description = "OK", schema = AbstractProperty(`type` = "file").some))
@@ -442,7 +443,7 @@ class SwaggerModelsBuilderSpec extends Specification {
   implicit def listEntityEncoder[A]: EntityEncoder[List[A]] =
     EntityEncoder.simple[List[A]]()(_ => ByteVector.view("A".getBytes))
 
-  case class CsvFile() extends SwaggerFileResponse
+  case class CsvFile()
 
   object CsvFile {
     implicit def EntityEncoderCsvFile: EntityEncoder[CsvFile] =

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
@@ -316,6 +316,13 @@ class SwaggerModelsBuilderSpec extends Specification {
         "200" -> Response(description = "OK", schema = AbstractProperty(`type` = "string").some))
     }
 
+    "collect response with file type" in {
+      val ra = GET / "test" |>> { () => Ok(CsvFile()) }
+
+      sb.collectResponses(ra) must havePair(
+        "200" -> Response(description = "OK", schema = AbstractProperty(`type` = "file").some))
+    }
+
     "collect response of user-defined types" in {
       val ra = GET / "test" |>> { () => Ok(ModelA("", 0)) }
 
@@ -434,4 +441,15 @@ class SwaggerModelsBuilderSpec extends Specification {
 
   implicit def listEntityEncoder[A]: EntityEncoder[List[A]] =
     EntityEncoder.simple[List[A]]()(_ => ByteVector.view("A".getBytes))
+
+  case class CsvFile() extends SwaggerFileResponse
+
+  object CsvFile {
+    implicit def EntityEncoderCsvFile: EntityEncoder[CsvFile] =
+      EntityEncoder.encodeBy[CsvFile](`Content-Type`(MediaType.`text/csv`, Some(Charset.`UTF-8`))) { file: CsvFile =>
+        ByteVector.encodeUtf8("file content").fold(Task.fail, bv =>
+          Task.now(EntityEncoder.Entity(scalaz.stream.Process.emit(bv), Some(bv.length))))
+      }
+  }
+
 }


### PR DESCRIPTION
@bryce-anderson feel free to change the naming of the marker trait.

Also note that I changed slightly the primitive type check from using `=:=` to `<:<`. I think this is working ok but maybe you prefer to consider `file` as an entirely separate case and not treat it as "primitive" (it is a Swagger primitive type but not a Scala one).