### PR TITLE
Allow more complex Property types in models

### DIFF
--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerFormatsSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerFormatsSpec.scala
@@ -1,6 +1,5 @@
 package org.http4s.rho.swagger
 
-import scala.collection.mutable.LinkedHashMap
 import scala.reflect.runtime.universe._
 
 import org.specs2.mutable.Specification
@@ -40,7 +39,7 @@ class SwaggerFormatsSpec extends Specification {
       val sfs = DefaultSwaggerFormats.withFieldSerializers(typeOf[Seq[Fruit]], arrProp)
 
       def modelOf[T](t: TypeTag[T]): Set[Model] =
-        TypeBuilder.collectModels(t.tpe, Set.empty, DefaultSwaggerFormats)
+        TypeBuilder.collectModels(t.tpe, Set.empty, sfs)
 
       modelOf(typeTag[FruitBox]).nonEmpty must_== true
       modelOf(typeTag[FruitBox]).head.properties.head._1 must_== "fruits"


### PR DESCRIPTION
This fixes #138

The `Property` type is actually recursive, in that `ArrayProperty` can contain inner properties. This wasn't being used correctly as could be seen if trying to use a Seq[Int] as the type: Int would be incorrectly represented as a `RefProperty`.