### PR TITLE
Correctly use custom serializers with Option wrapped types

### DIFF
--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/MyService.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/MyService.scala
@@ -5,7 +5,6 @@ import java.time.Instant
 
 import org.http4s.Uri
 import org.http4s.rho.RhoService
-import org.http4s.rho.swagger.SwaggerSupport
 
 import JsonEncoder.AutoSerializable
 import scalaz.Scalaz._

--- a/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
@@ -125,7 +125,6 @@ object TypeBuilder {
   // Turn a `Type` into the appropriate `Property` representation
   private def typeToProperty(tpe: Type, sfs: SwaggerFormats): Property = {
     sfs.customFieldSerializers.applyOrElse(tpe, { _: Type =>
-
       val TypeRef(_, ptSym: Symbol, _) = tpe
 
       if (tpe.isCollection && !tpe.isNothingOrNull) {
@@ -133,6 +132,8 @@ object TypeBuilder {
         val itemProperty = typeToProperty(pType, sfs).withRequired(false)
         ArrayProperty(items = itemProperty)
       }
+      else if (tpe.isOption && !tpe.isNothingOrNull)
+        typeToProperty(tpe.typeArgs.head, sfs).withRequired(false)
       else if (isCaseClass(ptSym))
         RefProperty(tpe.simpleName)
       else


### PR DESCRIPTION
Fixes issue #140

Problem

The Option type was being passed to DataType.fromType
which doesn't know about custom serializers.

Solution

Unwrap the Option wrapper and `TypeBuilder.typeToProperty` and
recurse.