### PR TITLE
Fix file response schema

### DIFF
--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/MyService.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/MyService.scala
@@ -94,7 +94,10 @@ object MyService extends RhoService {
       val p: Process[Task, String] = Process.emitAll(s)
       Ok(p)
     }
-    
+
+  "Get a file" **
+    GET / "file" |>> Ok(SwaggerFileResponse("HELLO"))
+
   import scala.reflect._
   import scala.reflect.runtime.universe._
     

--- a/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
@@ -52,6 +52,9 @@ object TypeBuilder {
           if (!known.exists(_ =:= ntpe)) go(ntpe, alreadyKnown, known + ntpe)
           else Set.empty
 
+        case tpe if tpe.isSwaggerFile =>
+          Set.empty
+
         case tpe if (alreadyKnown.map(_.id).contains(tpe.fullName) || (tpe.isPrimitive)) =>
           Set.empty
 

--- a/swagger/src/test/scala/org/http4s/rho/swagger/TypeBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/TypeBuilderSpec.scala
@@ -228,6 +228,10 @@ class TypeBuilderSpec extends Specification {
       modelOf[Task[Foo]] must_== modelOf[Foo]
     }
 
+    "Get types from a SwaggerFileResponse" in {
+      modelOf[SwaggerFileResponse[Foo]] must_== Set.empty
+    }
+
     "Build model that contains a List" in {
       val ms = modelOf[FooWithList]
       ms.size must_== 1


### PR DESCRIPTION
Current master mistakenly generates schema definitions for swagger file responses. Example:
<pre>
"definitions":{"SwaggerFileResponseÂ«StringÂ»":{"required":["value"],"properties":{"value":{"type":"string"}},"description":"SwaggerFileResponseÂ«StringÂ»"}
</pre>

This PR fixes that by omitting SwaggerFileResponse objects when building the model.