### PR TITLE
Use pretty-printing for swagger schema.

### DIFF
--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
@@ -25,7 +25,7 @@ object SwaggerSupport {
       createSwagger(swaggerFormats, apiPath, apiInfo)(routes ++ swaggerRoutes)
 
     lazy val swaggerRoutes: Seq[RhoRoute[_ <: HList]] = new RhoService {
-      lazy val response = Ok(Json.mapper().
+      lazy val response = Ok(Json.mapper().writerWithDefaultPrettyPrinter().
         writeValueAsString(swaggerSpec.toJModel)).
         putHeaders(`Content-Type`(MediaType.`application/json`))
 


### PR DESCRIPTION
Makes schema much more readable and makes the line numbers from Swagger Editor error messages much more helpful.

As the Swagger-schema is normally only used for dev/documentation purposes, I think the increase in size shouldn't be a problem.