### PR TITLE
Added option to disable swagger routes in swagger

### DIFF
--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
@@ -19,10 +19,13 @@ object SwaggerSupport {
   def apply(
     swaggerFormats: SwaggerFormats = DefaultSwaggerFormats,
     apiPath: TypedPath[HNil] = "swagger.json",
-    apiInfo: Info = Info(title = "My API", version = "1.0.0")): RhoMiddleware = { routes =>
+    apiInfo: Info = Info(title = "My API", version = "1.0.0"),
+    swaggerRoutesInSwagger: Boolean = true): RhoMiddleware = { routes =>
 
     lazy val swaggerSpec: Swagger =
-      createSwagger(swaggerFormats, apiPath, apiInfo)(routes ++ swaggerRoutes)
+      createSwagger(swaggerFormats, apiPath, apiInfo)(
+        routes ++ (if(swaggerRoutesInSwagger) swaggerRoutes else Seq.empty )
+      )
 
     lazy val swaggerRoutes: Seq[RhoRoute[_ <: HList]] = new RhoService {
       lazy val response = Ok(Json.mapper().writerWithDefaultPrettyPrinter().


### PR DESCRIPTION
Personally, I thought it was a little weird that the swagger routes were showing up in swagger.  So I've added an option to disable this while leaving the default behavior the same.