### PR TITLE
Clean up a few sections of the API

### DIFF
--- a/core/src/main/scala/org/http4s/rho/CompileService.scala
+++ b/core/src/main/scala/org/http4s/rho/CompileService.scala
@@ -1,13 +1,11 @@
 package org.http4s
 package rho
 
-import org.log4s.getLogger
-
 import org.http4s.rho.bits.PathTree
-import org.http4s.{Service, HttpService}
 import shapeless.HList
 
-/** This trait serves to transform a [[RhoRoute]] into an `RouteType`
+/** Transforms a [[RhoRoute]] into an `RouteType`.
+  *
   * This can be a stateful operation, storing the action for later execution
   * or any other type of compilation phase.
   */
@@ -43,46 +41,6 @@ object CompileService {
     */
   def foldServices(routes: Seq[RhoRoute.Tpe], filter: RhoMiddleware = identity): HttpService = {
     val tree = filter(routes).foldLeft(PathTree()){ (t, r) => t.appendRoute(r) }
-      Service.lift { req => tree.getResult(req).toResponse }
-  }
-
-  /** Tool for accumulating compiled routes */
-  final case class ServiceBuilder() extends CompileService[RhoRoute.Tpe] {
-    private val logger = getLogger
-    private val internalRoutes = Vector.newBuilder[RhoRoute.Tpe]
-
-    /** Turn the accumulated routes into an `HttpService`
-      *
-      * @param filter [[RhoMiddleware]] to apply to the collection of routes.
-      * @return An `HttpService` which can be mounted by http4s servers.
-      */
-    final def toService(filter: RhoMiddleware = identity): HttpService =
-      foldServices(internalRoutes.result(), filter)
-
-    /** Get the currently acquired routes */
-    def routes(): Seq[RhoRoute.Tpe] = internalRoutes.synchronized(internalRoutes.result())
-
-    /** Accumulate the routes into this [[ServiceBuilder]]
-      *
-      * @param routes Routes to accumulate.
-      * @return `this` instance with its internal state mutated.
-      */
-    def append(routes: TraversableOnce[RhoRoute.Tpe]): this.type = {
-      internalRoutes ++= routes
-      this
-    }
-
-    /** Accumulate the [[RhoRoute]] into this [[ServiceBuilder]]
-      *
-      * This is the same as appending a the single route and returning the same route.
-      *
-      * @param route [[RhoRoute]] to compile.
-      * @tparam T `HList` representation of the result of the route
-      * @return The [[RhoRoute]] passed to the method.
-      */
-    override def compile[T <: HList](route: RhoRoute[T]): RhoRoute[T] = internalRoutes.synchronized {
-      internalRoutes += route
-      route
-    }
+    Service.lift { req => tree.getResult(req).toResponse }
   }
 }

--- a/core/src/main/scala/org/http4s/rho/RouteExecutable.scala
+++ b/core/src/main/scala/org/http4s/rho/RouteExecutable.scala
@@ -24,12 +24,4 @@ trait RouteExecutable[T <: HList] extends TypedBuilder[T] { exec =>
   /** Compiles a HTTP request definition into an action */
   final def |>>[F, R](f: F)(implicit hltf: HListToFunc[T, F], srvc: CompileService[R]): R =
     srvc.compile(makeRoute(hltf.toAction(f)))
-
-  /** Provide an action from which to generate a complete route
-    * @return a function `Request => Option[Task[Response]]` which can be used as a complete route
-    */
-  final def runWith[F](f: F)(implicit hltf: HListToFunc[T, F]): Request => Task[Response] = {
-    val srvc = new RhoService { exec |>> f }.toService()
-    srvc.apply(_: Request)
-  }
 }

--- a/core/src/main/scala/org/http4s/rho/ServiceBuilder.scala
+++ b/core/src/main/scala/org/http4s/rho/ServiceBuilder.scala
@@ -1,0 +1,58 @@
+package org.http4s.rho
+
+import org.http4s._
+import org.log4s._
+import shapeless.HList
+
+import scala.collection.immutable.VectorBuilder
+
+/** CompileService which accumulates routes and can build a `HttpService` */
+final class ServiceBuilder private(internalRoutes: VectorBuilder[RhoRoute.Tpe]) extends CompileService[RhoRoute.Tpe] {
+  private val logger = getLogger
+
+  /** Turn the accumulated routes into an `HttpService`
+    *
+    * @param filter [[RhoMiddleware]] to apply to the collection of routes.
+    * @return An `HttpService` which can be mounted by http4s servers.
+    */
+  def toService(filter: RhoMiddleware = identity): HttpService =
+    CompileService.foldServices(internalRoutes.result(), filter)
+
+  /** Get a snapshot of the currently acquired routes */
+  def routes(): Seq[RhoRoute.Tpe] = internalRoutes.result()
+
+  /** Append the routes into this [[ServiceBuilder]]
+    *
+    * @param routes Routes to accumulate.
+    * @return `this` instance with its internal state mutated.
+    */
+  def append(routes: TraversableOnce[RhoRoute.Tpe]): this.type = {
+    internalRoutes ++= routes
+    this
+  }
+
+  /** Accumulate the [[RhoRoute]] into this [[ServiceBuilder]]
+    *
+    * This is the same as appending a the single route and returning the same route.
+    *
+    * @param route [[RhoRoute]] to compile.
+    * @tparam T `HList` representation of the result of the route
+    * @return The [[RhoRoute]] passed to the method.
+    */
+  override def compile[T <: HList](route: RhoRoute[T]): RhoRoute[T] = {
+    internalRoutes += route
+    route
+  }
+}
+
+object ServiceBuilder {
+  /** Constructor method for new `ServiceBuilder` instances */
+  def apply(): ServiceBuilder = apply(Seq.empty)
+
+  /** Constructor method for new `ServiceBuilder` instances with existing routes */
+  def apply(routes: Seq[RhoRoute.Tpe]): ServiceBuilder = {
+    val builder = new VectorBuilder[RhoRoute.Tpe]
+    builder ++= routes
+    new ServiceBuilder(builder)
+  }
+}

--- a/core/src/main/scala/org/http4s/rho/bits/PathTree.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/PathTree.scala
@@ -2,7 +2,6 @@ package org.http4s
 package rho
 package bits
 
-import scala.language.existentials
 import org.http4s.rho.bits.PathAST._
 import org.http4s.rho.bits.ResponseGeneratorInstances._
 import org.http4s.util.UrlCodingUtils
@@ -11,6 +10,7 @@ import shapeless.{HList, HNil}
 
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
+import scala.language.existentials
 import scala.util.control.NonFatal
 import scalaz.concurrent.Task
 
@@ -20,7 +20,7 @@ import scalaz.concurrent.Task
   * A [[PathTree]] contains a map of the known route paths. The values of the
   * tree are [[RhoRoute]]'s that can generate a reply to a `Request`.
   */
-final class PathTree private(private val paths: PathTree.MatchNode) {
+private[rho] final class PathTree private(private val paths: PathTree.MatchNode) {
   import PathTree._
 
   override def toString = paths.toString()

--- a/core/src/main/scala/org/http4s/rho/bits/ResultResponse.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/ResultResponse.scala
@@ -1,10 +1,9 @@
 package org.http4s.rho.bits
 
-import org.http4s.rho.bits.FailureResponse._
-import org.http4s.rho.bits.ResponseGeneratorInstances.{InternalServerError, BadRequest}
-import org.http4s.Response
+import org.http4s.{HttpService, Response}
 import org.http4s.rho.Result.BaseResult
-import org.http4s.HttpService
+import org.http4s.rho.bits.FailureResponse._
+import org.http4s.rho.bits.ResponseGeneratorInstances.{BadRequest, InternalServerError}
 
 import scalaz.concurrent.Task
 
@@ -20,7 +19,7 @@ sealed trait RouteResult[+T] {
     case _       => false
   }
 
-  final def toResponse(implicit ev: T<:<Task[Response]): Task[Response] = this match {
+  final def toResponse(implicit ev: T <:< Task[Response]): Task[Response] = this match {
       case SuccessResponse(t) => ev(t)
       case NoMatch            => HttpService.notFound
       case FailureResponse(r) => r.toResponse

--- a/core/src/test/scala/org/http4s/rho/CompileServiceSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/CompileServiceSpec.scala
@@ -1,10 +1,9 @@
 package org.http4s.rho
 
-import scala.language.existentials
-
 import org.http4s.{Method, Request, Uri}
-import org.http4s.rho.CompileService.ServiceBuilder
 import org.specs2.mutable.Specification
+
+import scala.language.existentials
 
 class CompileServiceSpec extends Specification {
 
@@ -36,8 +35,8 @@ class CompileServiceSpec extends Specification {
     }
 
     "Make routes from a collection of RhoRoutes" in {
-      import dsl._
       import CompileService.Implicit.compiler
+      import dsl._
 
       val routes =
         (GET / "hello" |>> "GetFoo") ::

--- a/core/src/test/scala/org/http4s/rho/RhoServiceSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/RhoServiceSpec.scala
@@ -1,9 +1,10 @@
 package org.http4s
 package rho
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import org.http4s.headers.{`Content-Length`, `Content-Type`}
 import org.specs2.mutable.Specification
-import java.util.concurrent.atomic.AtomicInteger
 import scodec.bits.ByteVector
 
 import scalaz.concurrent.Task
@@ -336,7 +337,7 @@ class RhoServiceSpec extends Specification with RequestRunner {
     }
   }
 
-  "RhoService concatonation" should {
+  "RhoService and method" should {
     "concatonate service" in {
       val srvc1 = new RhoService {
         GET / "foo1" |>> "Foo1"
@@ -347,7 +348,7 @@ class RhoServiceSpec extends Specification with RequestRunner {
       val both = (srvc1 and srvc2)
       val bothService = both.toService()
 
-      both.getRoutes() === srvc1.getRoutes() ++ srvc2.getRoutes()
+      both.getRoutes === srvc1.getRoutes ++ srvc2.getRoutes
 
       val req1 = Request(uri = uri("foo1"))
       getBody(bothService(req1).run.body) === "Foo1"
@@ -357,8 +358,8 @@ class RhoServiceSpec extends Specification with RequestRunner {
     }
   }
 
-  "RhoService prefixation" should {
-    "Prefix a RhoService" in {
+  "RhoService prefix operator" should {
+    "prefix a RhoService" in {
       val srvc1 = new RhoService {
         GET / "bar" |>> "bar"
       }

--- a/core/src/test/scala/org/http4s/rho/RhoServiceSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/RhoServiceSpec.scala
@@ -338,7 +338,7 @@ class RhoServiceSpec extends Specification with RequestRunner {
   }
 
   "RhoService and method" should {
-    "concatonate service" in {
+    "concatenate service" in {
       val srvc1 = new RhoService {
         GET / "foo1" |>> "Foo1"
       }


### PR DESCRIPTION
We have a lot of API surface right now that should probably not be exposed. This commit starts to trim away the things that aren't necessary for public consumption.

Targets include:

* RouteExecutable: `runWith` is unnecessary and very inefficient.
* CompileService: pull ServiceBuilder into its own file and clean it up.
* Minor other changes.

This is a binary incompatible change, but shouldn't be controversial.