### PR TITLE
Generate Swagger docs from multiple `RhoService`s. Fixes #166

### DIFF
--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
@@ -24,13 +24,13 @@ object SwaggerSupport {
 
     lazy val swaggerSpec: Swagger =
       createSwagger(swaggerFormats, apiPath, apiInfo)(
-        routes ++ (if(swaggerRoutesInSwagger) swaggerRoutes else Seq.empty )
+        routes ++ (if(swaggerRoutesInSwagger) swaggerRoute else Seq.empty )
       )
 
-    lazy val swaggerRoutes: Seq[RhoRoute[_ <: HList]] =
-      createSwaggerRoutes(swaggerSpec, apiPath).getRoutes
+    lazy val swaggerRoute: Seq[RhoRoute[_ <: HList]] =
+      createSwaggerRoute(swaggerSpec, apiPath).getRoutes
 
-    routes ++ swaggerRoutes
+    routes ++ swaggerRoute
   }
 
   /**
@@ -48,7 +48,7 @@ object SwaggerSupport {
    * Create a RhoService with the route to the Swagger json
    * for the given Swagger Specification
    */
-  def createSwaggerRoutes(
+  def createSwaggerRoute(
     swagger: => Swagger,
     apiPath: TypedPath[HNil] = "swagger.json"
   ): RhoService = new RhoService {

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
@@ -56,7 +56,7 @@ class SwaggerSupportSpec extends Specification {
 
     "Provide a way to agregate routes from multiple RhoServices" in {
       val aggregateSwagger = SwaggerSupport.createSwagger()(baseService.getRoutes ++ moarRoutes.getRoutes)
-      val swaggerRoutes = SwaggerSupport.createSwaggerRoutes(aggregateSwagger)
+      val swaggerRoutes = SwaggerSupport.createSwaggerRoute(aggregateSwagger)
       val httpServices = NonEmptyList(baseService, moarRoutes, swaggerRoutes).map(_.toService())
       val allthogetherService = httpServices.foldLeft1(Service.withFallback(_)(_))
 

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
@@ -3,6 +3,8 @@ package rho
 package swagger
 
 import org.specs2.mutable.Specification
+import scalaz.NonEmptyList
+import scalaz.syntax.foldable1._
 
 import org.http4s.rho.bits.MethodAliases.GET
 
@@ -16,6 +18,11 @@ class SwaggerSupportSpec extends Specification {
   val baseService = new RhoService {
     GET / "hello" |>> { () => Ok("hello world") }
     GET / "hello"/ pathVar[String] |>> { world: String => Ok("hello " + world) }
+  }
+
+  val moarRoutes = new RhoService {
+    GET / "goodbye" |>> { () => Ok("goodbye world") }
+    GET / "goodbye"/ pathVar[String] |>> { world: String => Ok("goodbye " + world) }
   }
 
 
@@ -46,5 +53,20 @@ class SwaggerSupportSpec extends Specification {
 
       swaggerSpec.paths must haveSize(2)
     }
+
+    "Provide a way to agregate routes from multiple RhoServices" in {
+      val aggregateSwagger = SwaggerSupport.createSwagger()(baseService.getRoutes ++ moarRoutes.getRoutes)
+      val swaggerRoutes = SwaggerSupport.createSwaggerRoutes(aggregateSwagger)
+      val httpServices = NonEmptyList(baseService, moarRoutes, swaggerRoutes).map(_.toService())
+      val allthogetherService = httpServices.foldLeft1(Service.withFallback(_)(_))
+
+      val r = Request(GET, Uri(path = "/swagger.json"))
+
+      val JObject(List((a, JObject(_)), (b, JObject(_)), (c, JObject(_)), (d, JObject(_)))) =
+        parseJson(RRunner(allthogetherService).checkOk(r)) \\ "paths"
+
+      Set(a, b, c, d) should_== Set("/hello", "/hello/{string}", "/goodbye", "/goodbye/{string}")
+    }
+
   }
 }


### PR DESCRIPTION
Factor out Swagger routes (/swagger.json) creation so it can be reused
when the Swagger Specification is an aggregate from multiple `RhoService`s