### PR TITLE
Swagger descriptions for sum types

### DIFF
--- a/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
@@ -80,7 +80,7 @@ object TypeBuilder {
 
           models ++ generics ++ children
 
-        case tpe@TypeRef(_, sym: Symbol, tpeArgs: List[Type]) if isSealed(sym) =>
+        case tpe@TypeRef(_, sym: Symbol, tpeArgs: List[Type]) if isSumType(sym) =>
           // TODO promote methods on sealed trait from children to model
           modelToSwagger(tpe, sfs).map({ m =>
             // TODO parameterize
@@ -122,8 +122,10 @@ object TypeBuilder {
   private[this] def isCaseClass(sym: Symbol): Boolean =
     sym.isClass && sym.asClass.isCaseClass && sym.asClass.primaryConstructor.isMethod
 
-  private[this] def isSealed(sym: Symbol): Boolean =
-    sym.asClass.isSealed
+  private[this] def isSumType(sym: Symbol): Boolean =
+    sym.asClass.isSealed && ! sym.asClass.knownDirectSubclasses.forall({ symbol =>
+      symbol.isModuleClass && symbol.asClass.isCaseClass
+    })
 
   private[this] def isExcluded(t: Type, excludes: Seq[Type] = Nil) =
     (defaultExcluded ++ excludes).exists(_ =:= t)

--- a/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
@@ -249,7 +249,7 @@ object models {
       o.setDeprecated(deprecated)
       vendorExtensions.foreach { case (key, value) => o.setVendorExtension(key, value) }
       o
-    }      
+    }
   }
 
   case class Response
@@ -398,7 +398,7 @@ object models {
 
   object Parameter {
     implicit class Ops(val parameter: Parameter) extends AnyVal {
-      def withDesc(desc: Option[String]): Parameter = 
+      def withDesc(desc: Option[String]): Parameter =
         parameter match {
           case p : BodyParameter => p.copy(description = desc)
           case p : CookieParameter => p.copy(description = desc)
@@ -410,7 +410,7 @@ object models {
         }
     }
   }
-  
+
   case class BodyParameter
     (
       schema           : Option[Model]    = None
@@ -460,7 +460,7 @@ object models {
       cp.setName(fromOption(name))
       cp.setDescription(fromOption(description))
       cp.setRequired(required)
-      cp.setAccess(fromOption(access))      
+      cp.setAccess(fromOption(access))
       vendorExtensions.foreach { case (key, value) => cp.setVendorExtension(key, value) }
       cp
     }
@@ -495,7 +495,7 @@ object models {
       fp.setAccess(fromOption(access))
       vendorExtensions.foreach { case (key, value) => fp.setVendorExtension(key, value) }
       fp
-    }    
+    }
   }
 
   case class HeaderParameter
@@ -560,7 +560,7 @@ object models {
       vendorExtensions.foreach { case (key, value) => pp.setVendorExtension(key, value) }
       pp
     }
-      
+
   }
 
   case class QueryParameter
@@ -580,9 +580,9 @@ object models {
     ) extends Parameter {
 
     override val in = Some("query")
-    
+
     import com.fasterxml.jackson.annotation.JsonPropertyOrder
-    
+
     @JsonPropertyOrder(Array("name", "in", "description", "required", "type", "$ref", "items", "collectionFormat", "default"))
     private class QueryRefParameter extends jm.parameters.QueryParameter {
       protected var $ref: String = _
@@ -595,8 +595,8 @@ object models {
       def get$ref() = $ref
       def set$ref($ref: String) { this.$ref = $ref }
     }
-    
-    def toJModel: jm.parameters.Parameter = {      
+
+    def toJModel: jm.parameters.Parameter = {
       val qp = new QueryRefParameter()
       qp.setIn("query")
       qp.setType(if (isArray) "array" else fromOption(`type`))
@@ -611,7 +611,7 @@ object models {
       qp.setAccess(fromOption(access))
       vendorExtensions.foreach { case (key, value) => qp.setVendorExtension(key, value) }
       qp
-    }      
+    }
   }
 
   case class RefParameter
@@ -636,7 +636,7 @@ object models {
       rp
     }
   }
-  
+
   sealed trait Property {
     def `type`: String
     def required: Boolean
@@ -657,22 +657,22 @@ object models {
     , description : Option[String] = None
     , format      : Option[String] = None
     ) extends Property {
-    
+
     class RefProperty extends jm.properties.AbstractProperty {
       protected var $ref: String = _
-        
-      def $ref($ref: String) = { 
+
+      def $ref($ref: String) = {
         this.set$ref($ref)
         this
       }
-      
+
       def get$ref() = $ref
-      def set$ref($ref: String) { this.$ref = $ref }              
+      def set$ref($ref: String) { this.$ref = $ref }
     }
-    
+
     def withRequired(required: Boolean): AbstractProperty =
       copy(required = required)
-      
+
     def toJModel: jm.properties.Property = {
       val ap = new RefProperty
       ap.setType(`type`)
@@ -736,7 +736,7 @@ object models {
       ap
     }
   }
-  
+
   case class ArrayProperty
     (
       items       : Property
@@ -799,7 +799,7 @@ object models {
       ed.setDescription(description)
       ed.setUrl(url)
       ed
-    }      
+    }
   }
 
   private object JValue {

--- a/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
@@ -3,6 +3,7 @@ package org.http4s.rho.swagger
 import io.swagger.{models => jm}
 
 import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 object models {
   import JValue._
@@ -354,10 +355,10 @@ object models {
       val cm = new jm.ComposedModel
       cm.setDescription(fromOption(description))
       cm.setAllOf(fromList(allOf.map(_.toJModel)))
-      cm.setParent(fromOption(parent.map(_.toJModel)))
-      cm.setChild(fromOption(child.map(_.toJModel)))
-      cm.setInterfaces(fromList(interfaces.map(_.toJModel.asInstanceOf[jm.RefModel])))
-      cm.setProperties(fromMap(properties.mapValues(_.toJModel)))
+      parent.map(_.toJModel).foreach(p => cm.setParent(p))
+      child.map(_.toJModel).foreach(c => cm.setChild(c))
+      cm.setInterfaces(interfaces.map(_.toJModel.asInstanceOf[jm.RefModel]).asJava)
+      cm.setProperties(properties.mapValues(_.toJModel).asJava)
       cm.setExample(fromOption(example))
       cm.setExternalDocs(fromOption(externalDocs.map(_.toJModel)))
       cm

--- a/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
@@ -2,7 +2,6 @@ package org.http4s.rho.swagger
 
 import io.swagger.{models => jm}
 
-import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
 
 object models {
@@ -244,7 +243,7 @@ object models {
       o.setParameters(fromList(parameters.map(_.toJModel)))
       o.setResponses(fromMap(responses.mapValues(_.toJModel)))
       o.setSecurity(fromList(security.map { m =>
-        m.mapValues(xs => xs : java.util.List[String]) : java.util.Map[String, java.util.List[String]]
+        m.mapValues(_.asJava).asJava
       }))
       o.setExternalDocs(fromOption(externalDocs.map(_.toJModel)))
       o.setDeprecated(deprecated)
@@ -303,7 +302,7 @@ object models {
       m.setType(fromOption(`type`))
       m.setName(fromOption(name))
       m.setDescription(fromOption(description))
-      m.setRequired(required)
+      m.setRequired(required.asJava)
       m.setExample(fromOption(example))
       m.setProperties(fromMap(properties.mapValues(_.toJModel)))
       if (additionalProperties.nonEmpty) m.setAdditionalProperties(fromOption(additionalProperties.map(_.toJModel)))
@@ -809,9 +808,9 @@ object models {
       oa.getOrElse(null.asInstanceOf[A])
 
     def fromList[A](xs: List[A]): java.util.List[A] =
-      if (xs.isEmpty) null else xs
+      if (xs.isEmpty) null else xs.asJava
 
     def fromMap[A, B](m: Map[A, B]): java.util.Map[A, B] =
-      if (m.isEmpty) null else m
+      if (m.isEmpty) null else m.asJava
   }
 }

--- a/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
@@ -3,6 +3,7 @@ package org.http4s.rho.swagger
 import io.swagger.{models => jm}
 
 import scala.collection.JavaConverters._
+import java.util.ArrayList
 
 object models {
   import JValue._
@@ -353,7 +354,7 @@ object models {
     def toJModel: jm.Model = {
       val cm = new jm.ComposedModel
       cm.setDescription(fromOption(description))
-      cm.setAllOf(fromList(allOf.map(_.toJModel)))
+      cm.setAllOf(new ArrayList(allOf.map(_.toJModel).asJava))
       parent.map(_.toJModel).foreach(p => cm.setParent(p))
       child.map(_.toJModel).foreach(c => cm.setChild(c))
       cm.setInterfaces(interfaces.map(_.toJModel.asInstanceOf[jm.RefModel]).asJava)

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
@@ -45,7 +45,7 @@ class SwaggerModelsBuilderSpec extends Specification {
   import SwaggerModelsBuilderSpec._
 
   implicit def defaultCompiler: CompileService[RhoRoute.Tpe] = CompileService.identityCompiler
-  
+
   sealed abstract class Renderable
   case class ModelA(name: String, color: Int) extends Renderable
   case class ModelB(name: String, id: Long) extends Renderable
@@ -57,12 +57,12 @@ class SwaggerModelsBuilderSpec extends Specification {
   val barPath = GET / "bar"
 
   "SwaggerModelsBuilder.collectQueryParams" should {
-    
+
     "handle head request" in {
       val ra = HEAD / "foobar" |>> { "" }
       sb.collectPaths(ra)(Swagger()).get("/foobar").flatMap(_.head) must beSome[Operation]
     }
-    
+
     "handle an action with one query parameter" in {
       val ra = fooPath +? param[Int]("id") |>> { (i: Int) => "" }
 
@@ -103,10 +103,10 @@ class SwaggerModelsBuilderSpec extends Specification {
         QueryParameter(`type` = "integer".some, name = "id".some,  description = orStr("id2"), required = true),
         QueryParameter(`type` = "integer".some, name = "id2".some, description = orStr("id"),  required = true))
     }
-    
+
     "handle an action with one query parameter of complex data type" in {
        val ra = fooPath +? param[Foo]("foo") |>> { (_: Foo) => "" }
-       
+
        sb.collectQueryParams(ra) must_==
        List(QueryParameter(`type` = None, $ref = "Foo".some, name = "foo".some, required = true))
     }
@@ -127,7 +127,7 @@ class SwaggerModelsBuilderSpec extends Specification {
 
     "handle and action with two query parameters of complex data type" in {
       val ra = fooPath +? param[Foo]("foo") & param[Seq[Bar]]("bar", Nil) |>> { (_: Foo, _: Seq[Bar]) => "" }
-      
+
       sb.collectQueryParams(ra) must_==
       List(
         QueryParameter(`type` = None, $ref = "Foo".some, name = "foo".some, required = true),
@@ -200,42 +200,42 @@ class SwaggerModelsBuilderSpec extends Specification {
     "find a simple path - GET" in {
       val ra = GET / "foo" |>> { () => "" }
       val paths = sb.collectPaths(ra)(Swagger())
-      
+
       paths must havePair("/foo" -> Path(get = sb.mkOperation("/foo", ra).some))
     }
 
     "find a simple path - PUT" in {
       val ra = PUT / "foo" |>> { () => "" }
       val paths = sb.collectPaths(ra)(Swagger())
-      
+
       paths must havePair("/foo" -> Path(put = sb.mkOperation("/foo", ra).some))
     }
 
     "find a simple path - POST" in {
       val ra = POST / "foo" |>> { () => "" }
       val paths = sb.collectPaths(ra)(Swagger())
-      
+
       paths must havePair("/foo" -> Path(post = sb.mkOperation("/foo", ra).some))
     }
 
     "find a simple path - PATCH" in {
       val ra = PATCH / "foo" |>> { () => "" }
       val paths = sb.collectPaths(ra)(Swagger())
-      
+
       paths must havePair("/foo" -> Path(patch = sb.mkOperation("/foo", ra).some))
     }
 
     "find a simple path - OPTIONS" in {
       val ra = OPTIONS / "foo" |>> { () => "" }
       val paths = sb.collectPaths(ra)(Swagger())
-      
+
       paths must havePair("/foo" -> Path(options = sb.mkOperation("/foo", ra).some))
     }
 
     "find a simple and-path" in {
       val ra = GET / "foo" / "bar" |>> { () => "" }
       val paths = sb.collectPaths(ra)(Swagger())
-      
+
       paths must havePair("/foo/bar" -> Path(get = sb.mkOperation("/foo/bar", ra).some))
     }
 

--- a/swagger/src/test/scala/org/http4s/rho/swagger/TypeBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/TypeBuilderSpec.scala
@@ -27,6 +27,11 @@ package object model {
   case class FooWithMap(l: Map[String, Int])
   case class FooVal(str: String) extends AnyVal
   case class BarWithFooVal(fooVal: FooVal)
+  sealed trait Sealed {
+    def foo: String
+  }
+  case class FooSealed(a: Int, foo: String) extends Sealed
+  case class BarSealed(str: String, foo: String) extends Sealed
 }
 
 class TypeBuilderSpec extends Specification {
@@ -290,6 +295,17 @@ class TypeBuilderSpec extends Specification {
           name must_== "fooVal"
           prop.`type` must_== "string"
       }
+    }
+
+    "Build a model for sealed traits" in {
+      val ms = modelOf[Sealed]
+      ms.foreach(_.toJModel) // Testing that there are no exceptions
+      ms.size must_== 3
+      val Some(seal: models.ModelImpl) = ms.find(_.id2 == "Sealed")
+      seal.discriminator must_== Some("type")
+      val Some(foo: models.ComposedModel) = ms.find(_.id2 == "FooSealed")
+      val Some(fooRef) = foo.allOf.collectFirst({case ref: models.RefModel => ref})
+      fooRef.ref must_== "Sealed"
     }
   }
 

--- a/swagger/src/test/scala/org/http4s/rho/swagger/TypeBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/TypeBuilderSpec.scala
@@ -27,6 +27,7 @@ package object model {
   case class FooWithMap(l: Map[String, Int])
   case class FooVal(str: String) extends AnyVal
   case class BarWithFooVal(fooVal: FooVal)
+  @DiscriminatorField("foobar")
   sealed trait Sealed {
     def foo: String
   }
@@ -302,9 +303,9 @@ class TypeBuilderSpec extends Specification {
       ms.foreach(_.toJModel) // Testing that there are no exceptions
       ms.size must_== 3
       val Some(seal: models.ModelImpl) = ms.find(_.id2 == "Sealed")
-      seal.discriminator must_== Some("type")
+      seal.discriminator must_== Some("foobar")
       val Some(foo: models.ComposedModel) = ms.find(_.id2 == "FooSealed")
-      val Some(fooRef) = foo.allOf.collectFirst({case ref: models.RefModel => ref})
+      val Some(fooRef) = foo.allOf.collectFirst {case ref: models.RefModel => ref}
       fooRef.ref must_== "Sealed"
     }
   }


### PR DESCRIPTION
According to [the `discriminator` spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#models-with-polymorphism-support). There's still two description fields - one in the `ComposedModel` and one in the `RefModel`. Not sure how to fix that.

Also, how should the discriminator field be passed in? Via an annotation?