### PR TITLE
Ok[Task[String]]

### DIFF
--- a/core/src/test/scala/org/http4s/rho/RhoServiceSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/RhoServiceSpec.scala
@@ -74,6 +74,11 @@ class RhoServiceSpec extends Specification with RequestRunner {
       Task(s"${i.getAndIncrement}")
     }
 
+    GET / "taskResult" |>> {
+      val i = new AtomicInteger(0)
+      Ok(Task(s"${i.getAndIncrement}"))
+    }
+
     GET / "terminal" / "" |>> "terminal/"
 
     GET / "terminal" |>> "terminal"


### PR DESCRIPTION
`Ok[Task[String]]` currently fails because if divergent implicits. I couldn't exactly pin the source, WA is `task.map(Ok)`.