### PR TITLE
Allow swagger routes with trailing slashes in Rho Swagger

### DIFF
--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
@@ -97,6 +97,7 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
     def go(stack: List[PathOperation], pathStr: String): String =
       stack match {
         case Nil                          => if(pathStr.isEmpty) "/" else pathStr
+        case PathMatch("")::Nil           => pathStr + "/"
         case PathMatch("")::xs            => go(xs, pathStr)
         case PathMatch(s)::xs             => go(xs, pathStr + "/" + s)
         case MetaCons(_, _)::xs           => go(xs, pathStr)

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
@@ -23,6 +23,10 @@ class SwaggerSupportSpec extends Specification {
     GET / "goodbye"/ pathVar[String] |>> { world: String => Ok("goodbye " + world) }
   }
 
+  val trailingSlashService = new RhoService {
+    GET / "foo" / "" |>> { () => Ok("hello world") }
+  }
+
 
   "SwaggerSupport" should {
     "Expose an API listing" in {
@@ -64,6 +68,14 @@ class SwaggerSupportSpec extends Specification {
         parseJson(RRunner(allthogetherService).checkOk(r)) \\ "paths"
 
       Set(a, b, c, d) should_== Set("/hello", "/hello/{string}", "/goodbye", "/goodbye/{string}")
+    }
+
+    "Support endpoints which end in a slash" in {
+      val service = trailingSlashService.toService(SwaggerSupport())
+      val r = Request(GET, Uri(path = "/swagger.json"))
+      val JObject(List((a, JObject(_)))) = parseJson(RRunner(service).checkOk(r)) \\ "paths"
+
+      a should_== "/foo/"
     }
 
   }


### PR DESCRIPTION
This allows people to define a route with a final section of `/ ""` to insist that there's a slash on the end.