### PR TITLE
Fix TypedHeader map method return type.

### DIFF
--- a/core/src/main/scala/org/http4s/rho/bits/TypedASTs.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/TypedASTs.scala
@@ -54,10 +54,10 @@ final case class TypedHeader[T <: HList](rule: RequestRule) {
     *
     * The new rule will have all the original metadata.
     */
-  def map[TR <: HList, F, R](f: F)(implicit rev: Reverse.Aux[T, TR], fp: FnToProduct.Aux[F, TR => R]): TypedQuery[shapeless.::[R, HNil]] = {
+  def map[TR <: HList, F, R](f: F)(implicit rev: Reverse.Aux[T, TR], fp: FnToProduct.Aux[F, TR => R]): TypedHeader[shapeless.::[R, HNil]] = {
     import shapeless.::
     val fn: T => R :: HNil = t => fp(f)(t.reverse) :: HNil
-    TypedQuery(MapRule[T, R :: HNil](this.rule, fn))
+    TypedHeader(MapRule[T, R :: HNil](this.rule, fn))
   }
 }
 

--- a/core/src/test/scala/org/http4s/rho/ApiTest.scala
+++ b/core/src/test/scala/org/http4s/rho/ApiTest.scala
@@ -90,7 +90,7 @@ class ApiTest extends Specification {
       val paramFoo = captureMap(headers.`Content-Length`)(_.length) && captureMap(headers.Date)(_.date) map Foo.apply _
 
       val now = java.time.Instant.now()
-      val path = GET / "hello" +? paramFoo
+      val path = GET / "hello" >>> paramFoo
       val req = Request(
         uri = Uri.fromString("/hello?i=32&f=3.2&s=Asdf").right.getOrElse(sys.error("Failed.")),
         headers = Headers(headers.`Content-Length`.unsafeFromLong(10), headers.Date(HttpDate.now))


### PR DESCRIPTION
Corrected a Copy-Paste Error on the TypedHeader.map implementation from PR #169