### PR TITLE
security-scopes

### DIFF
--- a/core/src/main/scala/org/http4s/rho/bits/Metadata.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/Metadata.scala
@@ -18,6 +18,12 @@ trait TextMetaData extends Metadata {
   def msg: String
 }
 
+/** Security Scope meta data */
+trait SecurityScopesMetaData extends Metadata {
+  def definitions: Map[String, List[String]] // Like `auth0_jwk` -> List('admin', user)
+
+}
+
 /** Metadata about a query rule */
 case class QueryMetaData[T](name: String, description: Option[String], p: QueryParser[T], default: Option[T], m: TypeTag[T]) extends Metadata
 

--- a/core/src/main/scala/org/http4s/rho/bits/Metadata.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/Metadata.scala
@@ -21,7 +21,6 @@ trait TextMetaData extends Metadata {
 /** Security Scope meta data */
 trait SecurityScopesMetaData extends Metadata {
   def definitions: Map[String, List[String]] // Like `auth0_jwk` -> List('admin', user)
-
 }
 
 /** Metadata about a query rule */

--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
@@ -157,7 +157,6 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
     linearizeStack(rr.path::Nil).flatMap(go(_, None)).headOption
   }
 
-
   def collectSecurityScopes(rr: RhoRoute[_]): List[Map[String, List[String]]] = {
 
     def go(stack: List[PathOperation], summary: Option[Map[String, List[String]]]): Option[Map[String, List[String]]] =
@@ -178,7 +177,6 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
 
     linearizeStack(rr.path::Nil).flatMap(go(_, None))
   }
-
 
   def collectOperationParams(rr: RhoRoute[_]): List[Parameter] =
     collectPathParams(rr) ::: collectQueryParams(rr) ::: collectHeaderParams(rr) ::: collectBodyParams(rr).toList
@@ -203,7 +201,6 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
 
         case MetaRule(rs, m: TextMetaData)::xs =>
           go(rs::Nil).map(_.withDesc(m.msg.some)) ::: go(xs)
-
 
         case MetaRule(a, _)::xs => go(a::xs)
 

--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
@@ -159,23 +159,15 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
 
   def collectSecurityScopes(rr: RhoRoute[_]): List[Map[String, List[String]]] = {
 
-    def go(stack: List[PathOperation], summary: Option[Map[String, List[String]]]): Option[Map[String, List[String]]] =
+    def go(stack: List[PathOperation]): Option[Map[String, List[String]]] =
+
       stack match {
-        case PathMatch("")::Nil                => go(Nil, summary)
-        case PathMatch(s)::xs                  => go(xs, summary)
-        case PathCapture(id, _, parser, _)::xs => go(xs, summary)
-        case CaptureTail::xs                   => summary
-
-        case MetaCons(_, meta)::xs =>
-          meta match {
-            case RouteSecurityScope(secScope) => secScope.some
-            case _               => go(xs, summary)
-          }
-
-        case Nil => summary
+        case Nil => None
+        case MetaCons(_, RouteSecurityScope(secScope)) :: _ => secScope.some
+        case _ :: xs => go(xs)
       }
 
-    linearizeStack(rr.path::Nil).flatMap(go(_, None))
+     linearizeStack(rr.path::Nil).flatMap(go)
   }
 
   def collectOperationParams(rr: RhoRoute[_]): List[Parameter] =

--- a/swagger/src/main/scala/org/http4s/rho/swagger/package.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/package.scala
@@ -10,7 +10,7 @@ import org.http4s.rho.swagger.models.Model
 import shapeless.{HList, HNil}
 
 import scala.reflect.runtime.universe._
-import fs2.{Stream, Task}
+import fs2.{Task, Stream}
 
 package object swagger {
 
@@ -34,12 +34,10 @@ package object swagger {
 
     def ^^(route: RhoRoute.Tpe): PathBuilder[HNil] = new PathBuilder(route.method, PathAST.MetaCons(route.path, RouteSecurityScope(definitions)))
 
-
     def ^^[T<: HList](builder: PathBuilder[T]): PathBuilder[T] =
       new PathBuilder(builder.method, PathAST.MetaCons(builder.path, RouteSecurityScope(definitions)))
 
   }
-
 
   object Reflector {
     import scala.reflect.runtime.universe._

--- a/swagger/src/main/scala/org/http4s/rho/swagger/package.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/package.scala
@@ -28,7 +28,7 @@ package object swagger {
   /** Scopes carrier for specific routes */
   case class RouteSecurityScope(definitions: Map[String, List[String]]) extends SecurityScopesMetaData
 
-  /** Add support for adding documentation before a route using the ## operator */
+  /** Add support for adding security scopes before a route using the ^^ operator */
   implicit class SecOps(definitions: Map[String, List[String]]) {
     def ^^(method: Method): PathBuilder[HNil] = ^^(new PathBuilder[HNil](method, PathEmpty))
 

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
@@ -13,7 +13,7 @@ import scala.reflect._
 import scala.reflect.runtime.universe._
 import fs2.{Chunk, Stream, Task}
 import cats.syntax.all._
-import org.http4s.rho.bits.PathAST.{PathAnd, PathCapture}
+import org.http4s.rho.bits.PathAST.{PathCapture, PathAnd}
 
 object SwaggerModelsBuilderSpec {
   case class Foo(a: String, b: Int)
@@ -207,23 +207,18 @@ class SwaggerModelsBuilderSpec extends Specification {
       operationIds ==== List("getBar", "getBar-name", "getBar-name1-name2")
       }
 
-
     "Create Security Scope" in {
       val x:Map[String, List[String]]  = Map("oauth" -> List("admin"))
 
       val ra = x ^^ "foo1" ** GET / "bar" |>> { () => "" }
 
-
       sb.mkOperation("/foo", ra).security must_== List(x)
     }
-
 
     "Create Security Scopes" in {
       val x:Map[String, List[String]]  = Map("oauth" -> List("admin", "read"),"apiKey" -> List("read"))
 
-
       val ra = x ^^ "foo1" ** GET / "bar" |>> { () => "" }
-
 
       sb.mkOperation("/foo", ra).security must_== List(x)
     }

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
@@ -13,7 +13,7 @@ import scala.reflect._
 import scala.reflect.runtime.universe._
 import fs2.{Chunk, Stream, Task}
 import cats.syntax.all._
-import org.http4s.rho.bits.PathAST.{PathCapture, PathAnd}
+import org.http4s.rho.bits.PathAST.{PathAnd, PathCapture}
 
 object SwaggerModelsBuilderSpec {
   case class Foo(a: String, b: Int)
@@ -206,6 +206,27 @@ class SwaggerModelsBuilderSpec extends Specification {
 
       operationIds ==== List("getBar", "getBar-name", "getBar-name1-name2")
       }
+
+
+    "Create Security Scope" in {
+      val x:Map[String, List[String]]  = Map("oauth" -> List("admin"))
+
+      val ra = x ^^ "foo1" ** GET / "bar" |>> { () => "" }
+
+
+      sb.mkOperation("/foo", ra).security must_== List(x)
+    }
+
+
+    "Create Security Scopes" in {
+      val x:Map[String, List[String]]  = Map("oauth" -> List("admin", "read"),"apiKey" -> List("read"))
+
+
+      val ra = x ^^ "foo1" ** GET / "bar" |>> { () => "" }
+
+
+      sb.mkOperation("/foo", ra).security must_== List(x)
+    }
   }
 
   "SwaggerModelsBuilder.collectPaths" should {

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
@@ -39,7 +39,6 @@ class SwaggerSupportSpec extends Specification {
     Map("bye"->List("hello")) ^^ GET / "goodbye" |>> { () => Ok("goodbye world") }
   }
 
-
   "SwaggerSupport" should {
     "Expose an API listing" in {
       val service = baseService.toService(SwaggerSupport(swaggerRoutesInSwagger = true))
@@ -167,30 +166,21 @@ class SwaggerSupportSpec extends Specification {
       sec1 should_== Nil
     }
 
-
     "Check metadata in API listing" in {
       val service = metaDataService.toService(SwaggerSupport(swaggerRoutesInSwagger = true))
 
       val r = Request(GET, Uri(path = "/swagger.json"))
 
-      val data = RRunner(service).checkOk(r)
-
-      val json = parseJson(data)
+      val json = parseJson(RRunner(service).checkOk(r))
 
       val JObject(List((a, JArray(List(JObject(List((e,JArray(List(JString(f))))))))), (b, JArray(List(JObject(List((g,JArray(List(JString(h))))))))))) = json \\ "security"
-
       val JObject(List((c, JString(i)), (d, JString(j)), _)) = json \\ "summary"
 
       Set(a,b) should_== Set("security", "security")
       Set(c,d) should_== Set("summary", "summary")
-
       Set(e,f) should_== Set("hello", "bye")
       Set(g,h) should_== Set("bye", "hello")
-
       Set(i,j) should_== Set("Hello", "Bye")
     }
-
-
-
   }
 }


### PR DESCRIPTION
Added way to define security scopes to RhoRoute:
using ^^ syntax to prefix a Map[String, List[String]] of security scopes

eg:

`Map("auth0_jwk"->List("admin")) ^^ "Description" ** GET / "foo" |>> { () => Ok("bar") }`