### PR TITLE
swagger-middleware-extension

### DIFF
--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
@@ -4,9 +4,8 @@ package swagger
 
 import io.swagger.util.Json
 import headers.`Content-Type`
-import io.swagger.models.SecurityRequirement
 import org.http4s.rho.bits.PathAST.TypedPath
-import org.http4s.rho.swagger.models.{Info, Scheme, SecuritySchemeDefinition, Swagger}
+import org.http4s.rho.swagger.models.{Info, Scheme, SecuritySchemeDefinition, SecurityRequirement, Swagger}
 import shapeless._
 
 object SwaggerSupport {

--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
@@ -3,27 +3,31 @@ package rho
 package swagger
 
 import io.swagger.util.Json
-
 import headers.`Content-Type`
 import org.http4s.rho.bits.PathAST.TypedPath
-import org.http4s.rho.swagger.models.{Swagger, Info}
-
+import org.http4s.rho.swagger.models.{Info, Scheme, SecuritySchemeDefinition, Swagger}
 import shapeless._
 
 object SwaggerSupport {
 
   /**
-   * Create a RhoMiddleware adding a route to get the Swagger json file
-   * representing the full API
-   */
+    * Create a RhoMiddleware adding a route to get the Swagger json file
+    * representing the full API
+    */
   def apply(
-    swaggerFormats: SwaggerFormats = DefaultSwaggerFormats,
-    apiPath: TypedPath[HNil] = "swagger.json",
-    apiInfo: Info = Info(title = "My API", version = "1.0.0"),
-    swaggerRoutesInSwagger: Boolean = false): RhoMiddleware = { routes =>
+             swaggerFormats: SwaggerFormats = DefaultSwaggerFormats,
+             apiPath: TypedPath[HNil] = "swagger.json",
+             apiInfo: Info = Info(title = "My API", version = "1.0.0"),
+             swaggerRoutesInSwagger: Boolean = false,
+             host: Option[String] = None,
+             basePath: Option[String] = None,
+             schemes: List[Scheme] = Nil,
+             consumes: List[String] = Nil,
+             produces: List[String] = Nil,
+             securityDefinitions: Map[String, SecuritySchemeDefinition] = Map.empty): RhoMiddleware = { routes =>
 
     lazy val swaggerSpec: Swagger =
-      createSwagger(swaggerFormats, apiPath, apiInfo)(
+      createSwagger(swaggerFormats, apiPath, apiInfo, host, basePath, schemes, consumes, produces, securityDefinitions)(
         routes ++ (if(swaggerRoutesInSwagger) swaggerRoute else Seq.empty )
       )
 
@@ -34,24 +38,37 @@ object SwaggerSupport {
   }
 
   /**
-   * Create the swagger model for a set of routes
-   */
+    * Create the swagger model for a set of routes
+    */
   def createSwagger(
-             swaggerFormats: SwaggerFormats = DefaultSwaggerFormats,
-             apiPath: TypedPath[HNil] = "swagger.json",
-             apiInfo: Info = Info(title = "My API", version = "1.0.0"))(routes: Seq[RhoRoute[_]]): Swagger = {
+                     swaggerFormats: SwaggerFormats = DefaultSwaggerFormats,
+                     apiPath: TypedPath[HNil] = "swagger.json",
+                     apiInfo: Info = Info(title = "My API", version = "1.0.0"),
+                     host: Option[String] = None,
+                     basePath: Option[String] = None,
+                     schemes: List[Scheme] = Nil,
+                     consumes: List[String] = Nil,
+                     produces: List[String] = Nil,
+                     securityDefinitions: Map[String, SecuritySchemeDefinition] = Map.empty)(routes: Seq[RhoRoute[_]]): Swagger = {
     val sb = new SwaggerModelsBuilder(swaggerFormats)
-    routes.foldLeft(Swagger())((s, r) => sb.mkSwagger(apiInfo, r)(s))
+    routes.foldLeft(Swagger(
+      host = host
+      , basePath = basePath
+      , schemes = schemes
+      , consumes = consumes
+      , produces = produces
+      , securityDefinitions = securityDefinitions
+    ))((s, r) => sb.mkSwagger(apiInfo, r)(s))
   }
 
   /**
-   * Create a RhoService with the route to the Swagger json
-   * for the given Swagger Specification
-   */
+    * Create a RhoService with the route to the Swagger json
+    * for the given Swagger Specification
+    */
   def createSwaggerRoute(
-    swagger: => Swagger,
-    apiPath: TypedPath[HNil] = "swagger.json"
-  ): RhoService = new RhoService {
+                          swagger: => Swagger,
+                          apiPath: TypedPath[HNil] = "swagger.json"
+                        ): RhoService = new RhoService {
     lazy val response = Ok(
       Json.mapper()
         .writerWithDefaultPrettyPrinter()

--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
@@ -5,7 +5,7 @@ package swagger
 import io.swagger.util.Json
 import headers.`Content-Type`
 import org.http4s.rho.bits.PathAST.TypedPath
-import org.http4s.rho.swagger.models.{Info, Scheme, SecuritySchemeDefinition, SecurityRequirement, Swagger}
+import org.http4s.rho.swagger.models._
 import shapeless._
 
 object SwaggerSupport {
@@ -25,10 +25,11 @@ object SwaggerSupport {
              consumes: List[String] = Nil,
              produces: List[String] = Nil,
              security: List[SecurityRequirement] = Nil,
-             securityDefinitions: Map[String, SecuritySchemeDefinition] = Map.empty): RhoMiddleware = { routes =>
+             securityDefinitions: Map[String, SecuritySchemeDefinition] = Map.empty,
+             vendorExtensions: Map[String, AnyRef] = Map.empty): RhoMiddleware = { routes =>
 
     lazy val swaggerSpec: Swagger =
-      createSwagger(swaggerFormats, apiPath, apiInfo, host, basePath, schemes, consumes, produces, security, securityDefinitions)(
+      createSwagger(swaggerFormats, apiPath, apiInfo, host, basePath, schemes, consumes, produces, security, securityDefinitions, vendorExtensions)(
         routes ++ (if(swaggerRoutesInSwagger) swaggerRoute else Seq.empty )
       )
 
@@ -51,7 +52,8 @@ object SwaggerSupport {
                      consumes: List[String] = Nil,
                      produces: List[String] = Nil,
                      security: List[SecurityRequirement] = Nil,
-                     securityDefinitions: Map[String, SecuritySchemeDefinition] = Map.empty)(routes: Seq[RhoRoute[_]]): Swagger = {
+                     securityDefinitions: Map[String, SecuritySchemeDefinition] = Map.empty,
+                     vendorExtensions: Map[String, AnyRef] = Map.empty)(routes: Seq[RhoRoute[_]]): Swagger = {
     val sb = new SwaggerModelsBuilder(swaggerFormats)
     routes.foldLeft(Swagger(
       host = host
@@ -61,6 +63,7 @@ object SwaggerSupport {
       , produces = produces
       , security = security
       , securityDefinitions = securityDefinitions
+      , vendorExtensions = vendorExtensions
     ))((s, r) => sb.mkSwagger(apiInfo, r)(s))
   }
 

--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
@@ -55,16 +55,15 @@ object SwaggerSupport {
                      securityDefinitions: Map[String, SecuritySchemeDefinition] = Map.empty,
                      vendorExtensions: Map[String, AnyRef] = Map.empty)(routes: Seq[RhoRoute[_]]): Swagger = {
     val sb = new SwaggerModelsBuilder(swaggerFormats)
-    routes.foldLeft(Swagger(
-      host = host
+    routes.foldLeft(Swagger())((s, r) => sb.mkSwagger(apiInfo, r)(s)).copy(
+        host = host
       , basePath = basePath
       , schemes = schemes
       , consumes = consumes
       , produces = produces
       , security = security
       , securityDefinitions = securityDefinitions
-      , vendorExtensions = vendorExtensions
-    ))((s, r) => sb.mkSwagger(apiInfo, r)(s))
+      , vendorExtensions = vendorExtensions)
   }
 
   /**

--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
@@ -4,6 +4,7 @@ package swagger
 
 import io.swagger.util.Json
 import headers.`Content-Type`
+import io.swagger.models.SecurityRequirement
 import org.http4s.rho.bits.PathAST.TypedPath
 import org.http4s.rho.swagger.models.{Info, Scheme, SecuritySchemeDefinition, Swagger}
 import shapeless._
@@ -24,10 +25,11 @@ object SwaggerSupport {
              schemes: List[Scheme] = Nil,
              consumes: List[String] = Nil,
              produces: List[String] = Nil,
+             security: List[SecurityRequirement] = Nil,
              securityDefinitions: Map[String, SecuritySchemeDefinition] = Map.empty): RhoMiddleware = { routes =>
 
     lazy val swaggerSpec: Swagger =
-      createSwagger(swaggerFormats, apiPath, apiInfo, host, basePath, schemes, consumes, produces, securityDefinitions)(
+      createSwagger(swaggerFormats, apiPath, apiInfo, host, basePath, schemes, consumes, produces, security, securityDefinitions)(
         routes ++ (if(swaggerRoutesInSwagger) swaggerRoute else Seq.empty )
       )
 
@@ -49,6 +51,7 @@ object SwaggerSupport {
                      schemes: List[Scheme] = Nil,
                      consumes: List[String] = Nil,
                      produces: List[String] = Nil,
+                     security: List[SecurityRequirement] = Nil,
                      securityDefinitions: Map[String, SecuritySchemeDefinition] = Map.empty)(routes: Seq[RhoRoute[_]]): Swagger = {
     val sb = new SwaggerModelsBuilder(swaggerFormats)
     routes.foldLeft(Swagger(
@@ -57,6 +60,7 @@ object SwaggerSupport {
       , schemes = schemes
       , consumes = consumes
       , produces = produces
+      , security = security
       , securityDefinitions = securityDefinitions
     ))((s, r) => sb.mkSwagger(apiInfo, r)(s))
   }

--- a/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
@@ -41,7 +41,12 @@ object models {
       s.setDefinitions(fromMap(definitions.mapValues(_.toJModel)))
       s.setParameters(fromMap(parameters.mapValues(_.toJModel)))
       s.setExternalDocs(fromOption(externalDocs.map(_.toJModel)))
-      vendorExtensions.foreach { case (key, value) => s.setVendorExtension(key, value) }
+      vendorExtensions.foreach {
+        case (key, value:Map[_,_]) => s.setVendorExtension(key, fromMap(value))
+        case (key, value:Option[_]) => s.setVendorExtension(key, fromOption(value))
+        case (key, value:List[_]) => s.setVendorExtension(key, fromList(value))
+        case (key, value) => s.setVendorExtension(key, value)
+      }
       s
     }
   }

--- a/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
@@ -22,6 +22,7 @@ object models {
     , definitions         : Map[String, Model]                    = Map.empty
     , parameters          : Map[String, Parameter]                = Map.empty
     , externalDocs        : Option[ExternalDocs]                  = None
+    , security            : List[SecurityRequirement]             = Nil
     ) {
 
     def toJModel: jm.Swagger = {
@@ -33,6 +34,7 @@ object models {
       s.setConsumes(fromList(consumes))
       s.setProduces(fromList(produces))
       s.setPaths(fromMap(paths.mapValues(_.toJModel)))
+      s.setSecurity(fromList(security.map(_.toJModel)))
       s.setSecurityDefinitions(fromMap(securityDefinitions.mapValues(_.toJModel)))
       s.setDefinitions(fromMap(definitions.mapValues(_.toJModel)))
       s.setParameters(fromMap(parameters.mapValues(_.toJModel)))

--- a/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
@@ -122,6 +122,31 @@ object models {
     }
   }
 
+  case class OAuth2VendorExtensionsDefinition
+  (
+      authorizationUrl : String
+    , vendorExtensions : Map[String, AnyRef]
+    , flow             : String
+    , scopes           : Map[String, String]
+    , tokenUrl         : Option[String] = None
+  ) extends SecuritySchemeDefinition {
+
+    override val `type` = "oauth2"
+
+    def toJModel: jm.auth.OAuth2Definition = {
+      val oa2d = new jm.auth.OAuth2Definition
+      oa2d.setAuthorizationUrl(authorizationUrl)
+      oa2d.setVendorExtensions(fromMap(vendorExtensions))
+      oa2d.setFlow(flow)
+      oa2d.setScopes(fromMap(scopes))
+
+      if(tokenUrl.isDefined)
+        oa2d.setTokenUrl(tokenUrl.get)
+
+      oa2d
+    }
+  }
+
   case class ApiKeyAuthDefinition
   (
     name : String

--- a/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
@@ -23,10 +23,12 @@ object models {
     , parameters          : Map[String, Parameter]                = Map.empty
     , externalDocs        : Option[ExternalDocs]                  = None
     , security            : List[SecurityRequirement]             = Nil
+    , vendorExtensions    : Map[String, Any]                      = Map.empty
     ) {
 
     def toJModel: jm.Swagger = {
       val s = new jm.Swagger
+
       s.info(fromOption(info.map(_.toJModel)))
       s.host(fromOption(host))
       s.basePath(fromOption(basePath))
@@ -39,6 +41,7 @@ object models {
       s.setDefinitions(fromMap(definitions.mapValues(_.toJModel)))
       s.setParameters(fromMap(parameters.mapValues(_.toJModel)))
       s.setExternalDocs(fromOption(externalDocs.map(_.toJModel)))
+      vendorExtensions.foreach { case (key, value) => s.setVendorExtension(key, value) }
       s
     }
   }

--- a/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
@@ -192,8 +192,7 @@ object models {
 
     def toJModel: jm.SecurityRequirement = {
       val sr = new jm.SecurityRequirement
-      sr.setName(name)
-      sr.setScopes(fromList(scopes))
+      sr.setRequirements(name, scopes.asJava)
       sr
     }
   }

--- a/swagger/src/test/scala/org/http4s/rho/swagger/Arbitraries.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/Arbitraries.scala
@@ -191,6 +191,7 @@ object Arbitraries {
   def genSecurityDefinition: Gen[SecuritySchemeDefinition] =
     Gen.oneOf(
       OAuth2Definition("authorizationUrl", "tokenUrl", "flow", Map.empty),
+      OAuth2VendorExtensionsDefinition("authorizationUrl", Map("x-issuer"->"issuer", "x-audiences"->"audience"), "flow", Map.empty),
       ApiKeyAuthDefinition("name", In.HEADER),
       BasicAuthDefinition)
 

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
@@ -2,10 +2,10 @@ package org.http4s
 package rho
 package swagger
 
-import org.specs2.mutable.Specification
 import cats.data.NonEmptyList
-import cats.syntax.all._
 import org.http4s.rho.bits.MethodAliases.GET
+import org.http4s.rho.swagger.models._
+import org.specs2.mutable.Specification
 
 class SwaggerSupportSpec extends Specification {
 
@@ -106,7 +106,60 @@ class SwaggerSupportSpec extends Specification {
       Set(a, b, c, d, e, f, g) should_== Set("/hello", "/hello/{string}", "/goodbye", "/goodbye/{string}", "/foo/", "/foo", "/bar")
     }
 
+    "Swagger support for complex meta data" in {
+      val service = baseService.toService(SwaggerSupport(
+        apiPath = "swagger-test.json",
+        apiInfo =  Info(
+          title = "Complex Meta Data API",
+          description = Some("Complex Meta Data API to verify in unit test"),
+          version = "1.0.0",
+          contact = Some(Contact("Name", Some("http://www.test.com/contact"), Some("test@test.com"))),
+          license = Some(License("Apache 2.0", "http://www.apache.org/licenses/LICENSE-2.0.html")),
+          termsOfService = Some("http://www.test.com/tos")
+        ),
+        swaggerRoutesInSwagger = true,
+        host = Some("www.test.com"),
+        schemes = List(Scheme.HTTP, Scheme.HTTPS),
+        basePath = Some("/v1"),
+        consumes = List("application/json"),
+        produces = List("application/json"),
+        security= List(SecurityRequirement("apiKey", Nil),SecurityRequirement("vendor_jwk", List("admin"))),
+        securityDefinitions = Map(
+          "api_key" -> ApiKeyAuthDefinition("key", In.QUERY, None),
+          "vendor_jwk" -> OAuth2VendorExtensionsDefinition(
+            authorizationUrl = "https://www.test.com/authorize",
+            flow = "implicit",
+            vendorExtensions = Map(
+              "x-vendor-issuer" -> "https://www.test.com/",
+              "x-vendor-jwks_uri" -> "https://www.test.com/.well-known/jwks.json",
+              "x-vendor-audiences" -> "clientid",
+            ),
+            scopes = Map("openid" -> "Open ID info", "admin" -> "Admin rights")
+          )
+        ),
+        vendorExtensions = Map(
+          "x-vendor-endpoints" -> Map("name" -> "www.test.com", "target" -> "298.0.0.1")
+        )
+      ))
 
+      val r = Request(GET, Uri(path = "/swagger-test.json"))
+      val json = parseJson(RRunner(service).checkOk(r))
+
+      val JString(icn) = json \ "info" \ "contact" \ "name"
+      val JString(h) = json \ "host"
+      val JArray(List(JString(s1), JString(s2)))  = json \ "schemes"
+      val JString(bp) = json \ "basePath"
+      val JArray(List(JString(c))) = json \ "consumes"
+      val JArray(List(JString(p))) = json \ "produces"
+      val JArray(List(JArray(sec1))) =json \ "security" \ "apiKey"
+      val JArray(List(JArray(List(JString(sec2))))) =json \ "security" \ "vendor_jwk"
+      val JString(t) = json \ "securityDefinitions" \ "api_key" \ "type"
+      val JString(vi) = json \ "securityDefinitions" \ "vendor_jwk" \ "x-vendor-issuer"
+      val JString(ve) = json \ "x-vendor-endpoints" \ "target"
+
+      Set(icn, h, s1, s2, bp, c, p, sec2, t, vi, ve) should_== Set("Name", "www.test.com", "http", "https", "/v1","application/json","application/json", "admin", "apiKey","https://www.test.com/", "298.0.0.1")
+      sec1 should_== Nil
+    }
 
 
   }

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
@@ -132,7 +132,7 @@ class SwaggerSupportSpec extends Specification {
             vendorExtensions = Map(
               "x-vendor-issuer" -> "https://www.test.com/",
               "x-vendor-jwks_uri" -> "https://www.test.com/.well-known/jwks.json",
-              "x-vendor-audiences" -> "clientid",
+              "x-vendor-audiences" -> "clientid"
             ),
             scopes = Map("openid" -> "Open ID info", "admin" -> "Admin rights")
           )


### PR DESCRIPTION
The current implementation of the SwaggerSupport Middleware hid/didn't expose many of the available swagger configurations, like:
host, schemes, basePath, consumes, produces, security, securityDefinitions & vendorExtensions

Also The OAuth2Definition for security required a didn't allow for vendorExtensions and required tokenUrl.
So added OAuth2VendorExtensionsDefinition not to break compatibility.