### PR TITLE
Upgrade to http4s 0.16.5, Fixes #204

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 import RhoBuild._
 
-version       in ThisBuild := s"0.16.2${scalazCrossBuildSuffix(scalazVersion.value)}"
+version       in ThisBuild := s"0.16.5${scalazCrossBuildSuffix(scalazVersion.value)}"
 apiVersion    in ThisBuild <<= version.map(extractApiVersion)
 scalazVersion in ThisBuild := "7.1.11"

--- a/core/src/main/scala/org/http4s/rho/bits/ResponseGenerator.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/ResponseGenerator.scala
@@ -60,7 +60,7 @@ abstract class EntityResponseGenerator(val status: Status) extends ResponseGener
   def apply[A](body: A, headers: Headers)(implicit w: EntityEncoder[A]): Task[T[A]] = {
     w.toEntity(body).flatMap { case Entity(proc, len) =>
       val hs = len match {
-        case Some(l) => (w.headers ++ headers).put(`Content-Length`(l))
+        case Some(l) => (w.headers ++ headers).put(`Content-Length`.unsafeFromLong(l))
         case None    => (w.headers ++ headers)
       }
       Task.now(Result(Response(status = status, headers = hs, body = proc)).asInstanceOf[T[A]])
@@ -75,7 +75,7 @@ abstract class EntityResponseGenerator(val status: Status) extends ResponseGener
   def pure[A](body: A, headers: Headers)(implicit w: EntityEncoder[A]): Task[Response] = {
     w.toEntity(body).flatMap { case Entity(proc, len) =>
       val hs = len match {
-        case Some(l) => (w.headers ++ headers).put(`Content-Length`(l))
+        case Some(l) => (w.headers ++ headers).put(`Content-Length`.unsafeFromLong(l))
         case None    => (w.headers ++ headers)
       }
       Task.now(Response(status = status, headers = hs, body = proc))

--- a/core/src/main/scala/org/http4s/rho/bits/ResultResponse.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/ResultResponse.scala
@@ -1,6 +1,6 @@
 package org.http4s.rho.bits
 
-import org.http4s.{HttpService, Response}
+import org.http4s.{HttpService, MaybeResponse, Pass, Response}
 import org.http4s.rho.Result.BaseResult
 import org.http4s.rho.bits.FailureResponse._
 import org.http4s.rho.bits.ResponseGeneratorInstances.{BadRequest, InternalServerError}
@@ -19,9 +19,9 @@ sealed trait RouteResult[+T] {
     case _       => false
   }
 
-  final def toResponse(implicit ev: T <:< Task[Response]): Task[Response] = this match {
+  final def toResponse(implicit ev: T <:< Task[MaybeResponse]): Task[MaybeResponse] = this match {
       case SuccessResponse(t) => ev(t)
-      case NoMatch            => Response.fallthrough
+      case NoMatch            => Pass.now
       case FailureResponse(r) => r.toResponse
     }
 }

--- a/core/src/test/scala/org/http4s/rho/CodecRouterSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/CodecRouterSpec.scala
@@ -25,7 +25,7 @@ class CodecRouterSpec extends Specification {
       val b = Process.emit(ByteVector.view("hello".getBytes))
       val h = Headers(headers.`Content-Type`(MediaType.`text/plain`))
       val req = Request(Method.POST, Uri(path = "/foo"), headers = h, body = b)
-      val result = service(req).run
+      val result = service(req).run.orNotFound
       val (bb, s) = bodyAndStatus(result)
 
       s must_== Status.Ok
@@ -37,7 +37,7 @@ class CodecRouterSpec extends Specification {
       val h = Headers(headers.`Content-Type`(MediaType.`application/x-www-form-urlencoded`))
       val req = Request(Method.POST, Uri(path = "/form"), headers = h, body = b)
 
-      service(req).run.status must_== Status.BadRequest
+      service(req).run.orNotFound.status must_== Status.BadRequest
     }
   }
 

--- a/core/src/test/scala/org/http4s/rho/ParamDefaultValueSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/ParamDefaultValueSpec.scala
@@ -8,7 +8,7 @@ import scodec.bits.ByteVector
 class ParamDefaultValueSpec extends Specification {
 
   def body(service: HttpService, r: Request): String =
-    new String(service(r).run.body.runLog.run.foldLeft(ByteVector.empty)(_ ++ _).toArray)
+    new String(service(r).run.orNotFound.body.runLog.run.foldLeft(ByteVector.empty)(_ ++ _).toArray)
 
   def requestGet(s: String, h: Header*): Request =
     Request(bits.MethodAliases.GET, Uri.fromString(s).getOrElse(sys.error("Failed.")), headers = Headers(h: _*))

--- a/core/src/test/scala/org/http4s/rho/RequestRunner.scala
+++ b/core/src/test/scala/org/http4s/rho/RequestRunner.scala
@@ -14,7 +14,7 @@ trait RequestRunner {
   def checkError(r: Request): String = checkStatus(r)(_ != Status.Ok)
 
   def checkStatus(r: Request)(isSuccess: Status => Boolean) = {
-    val resp = service(r).run
+    val resp = service(r).run.orNotFound
     if (isSuccess(resp.status)) getBody(resp.body)
     else sys.error(s"Invalid response code: ${resp.status}")
   }

--- a/core/src/test/scala/org/http4s/rho/ResultSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/ResultSpec.scala
@@ -1,8 +1,6 @@
 package org.http4s.rho
 
-import java.time.Instant
-
-import org.http4s.AttributeKey
+import org.http4s.{AttributeKey, HttpDate}
 import org.http4s.headers._
 import org.specs2.mutable.Specification
 
@@ -12,47 +10,47 @@ class ResultSpec extends Specification with ResultSyntaxInstances {
 
   "ResultSyntax" should {
     "Add headers" in {
-      val date = Date(Instant.ofEpochMilli(0))
+      val date = Date(HttpDate.Epoch)
       val resp = Ok("Foo")
-                  .putHeaders(date)
-                  .run
-                  .resp
+        .putHeaders(date)
+        .run
+        .resp
 
-      resp.headers.get(Date) must_== Some(date)
+      resp.headers.get(Date) must beSome(date)
 
       val respNow = Ok("Foo").run
         .putHeaders(date)
         .resp
 
-      respNow.headers.get(Date) must_== Some(date)
+      respNow.headers.get(Date) must beSome(date)
     }
 
     "Add atributes" in {
-      val attrKey = AttributeKey[String]("foo")
+      val attrKey = AttributeKey[String]
       val resp = Ok("Foo")
         .withAttribute(attrKey, "foo")
         .run
         .resp
 
-      resp.attributes.get(attrKey) must_== Some("foo")
+      resp.attributes.get(attrKey) must beSome("foo")
 
       val resp2 = Ok("Foo")
         .run
         .withAttribute(attrKey, "foo")
         .resp
 
-      resp2.attributes.get(attrKey) must_== Some("foo")
+      resp2.attributes.get(attrKey) must beSome("foo")
     }
 
     "Add a body" in {
       val newbody = "foobar"
       val resp = Ok("foo")
-                  .withBody(newbody)
-                  .run
-                  .resp
+        .withBody(newbody)
+        .run
+        .resp
 
       new String(resp.body.runLog.run.head.toArray) must_== newbody
-      resp.headers.get(`Content-Length`) must_== Some(`Content-Length`(newbody.getBytes.length))
+      resp.headers.get(`Content-Length`) must beSome(`Content-Length`.unsafeFromLong(newbody.getBytes.length))
 
       val resp2 = Ok("foo")
         .run
@@ -61,7 +59,7 @@ class ResultSpec extends Specification with ResultSyntaxInstances {
         .resp
 
       new String(resp2.body.runLog.run.head.toArray) must_== newbody
-      resp2.headers.get(`Content-Length`) must_== Some(`Content-Length`(newbody.getBytes.length))
+      resp2.headers.get(`Content-Length`) must beSome(`Content-Length`.unsafeFromLong(newbody.getBytes.length))
     }
 
 

--- a/core/src/test/scala/org/http4s/rho/RhoServiceSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/RhoServiceSpec.scala
@@ -95,13 +95,13 @@ class RhoServiceSpec extends Specification with RequestRunner {
 
     "Return a 405 when a path is defined but the method doesn't match" in {
       val request = Request(Method.POST, uri("/hello"))
-      val resp = service(request).run
+      val resp = service(request).run.orNotFound
       resp.status must_== Status.MethodNotAllowed
       resp.headers.get("Allow".ci) must beSome(Header.Raw("Allow".ci, "GET"))
     }
 
     "Yield `MethodNotAllowed` when invalid method used" in {
-      service(Put("/one/two/three")).run.status must_== Status.MethodNotAllowed
+      service(Put("/one/two/three")).run.orNotFound.status must_== Status.MethodNotAllowed
     }
 
     "Consider PathMatch(\"\") a NOOP" in {
@@ -110,10 +110,10 @@ class RhoServiceSpec extends Specification with RequestRunner {
       }.toService()
 
       val req1 = Request(Method.GET, Uri(path = "/foo"))
-      getBody(service(req1).run.body) should_== "bar"
+      getBody(service(req1).run.orNotFound.body) should_== "bar"
 
       val req2 = Request(Method.GET, Uri(path = "//foo"))
-      getBody(service(req2).run.body) should_== "bar"
+      getBody(service(req2).run.orNotFound.body) should_== "bar"
     }
 
     "Execute a route with no params" in {
@@ -147,7 +147,7 @@ class RhoServiceSpec extends Specification with RequestRunner {
     }
 
     "NotFound on empty route" in {
-      service(Get("/one/two")).run.status must_== Status.NotFound
+      service(Get("/one/two")).run.orNotFound.status must_== Status.NotFound
     }
 
     "Fail a route with a missing query" in {
@@ -262,13 +262,13 @@ class RhoServiceSpec extends Specification with RequestRunner {
       }.toService()
 
       val req1 = Request(Method.GET, Uri(path = "/foo").+?("bar", "0"))
-      getBody(service(req1).run.body) must_== "Int: 0"
+      getBody(service(req1).run.orNotFound.body) must_== "Int: 0"
 
       val req2 = Request(Method.GET, Uri(path = "/foo").+?("bar", "s"))
-      getBody(service(req2).run.body) must_== "String: s"
+      getBody(service(req2).run.orNotFound.body) must_== "String: s"
 
       val req3 = Request(Method.GET, Uri(path = "/foo"))
-      getBody(service(req3).run.body) must_== "none"
+      getBody(service(req3).run.orNotFound.body) must_== "none"
     }
 
     "Fail to match more specific routes defined after a less specific route" in {
@@ -278,10 +278,10 @@ class RhoServiceSpec extends Specification with RequestRunner {
       }.toService()
 
       val req1 = Request(Method.GET, Uri(path = "/foo").+?("bar", "0"))
-      getBody(service(req1).run.body) must_== "String: 0"
+      getBody(service(req1).run.orNotFound.body) must_== "String: 0"
 
       val req2 = Request(Method.GET, Uri(path = "/foo").+?("bar", "s"))
-      getBody(service(req2).run.body) must_== "String: s"
+      getBody(service(req2).run.orNotFound.body) must_== "String: s"
     }
 
     "Match an empty Option over a bare route" in {
@@ -294,10 +294,10 @@ class RhoServiceSpec extends Specification with RequestRunner {
       }.toService()
 
       val req1 = Request(Method.GET, Uri(path = "/foo").+?("bar", "s"))
-      getBody(service(req1).run.body) must_== "String: s"
+      getBody(service(req1).run.orNotFound.body) must_== "String: s"
 
       val req2 = Request(Method.GET, Uri(path = "/foo"))
-      getBody(service(req2).run.body) must_== "none"
+      getBody(service(req2).run.orNotFound.body) must_== "none"
     }
 
     "work with all syntax elements" in {
@@ -313,10 +313,10 @@ class RhoServiceSpec extends Specification with RequestRunner {
       val uri = Uri.fromString("/foo/1?param=myparam").getOrElse(sys.error("Failed."))
       val req = Request(method = Method.POST, uri = uri, body = body)
                     .putHeaders(`Content-Type`(MediaType.`text/plain`),
-                                `Content-Length`("foo".length))
+                                `Content-Length`.unsafeFromLong("foo".length))
 
       val r = srvc.toService()(req)
-      getBody(r.run.body) must_== "success"
+      getBody(r.run.orNotFound.body) must_== "success"
 
     }
 
@@ -327,13 +327,13 @@ class RhoServiceSpec extends Specification with RequestRunner {
         GET / "error" |>> { () => throw new Error("an error"); Ok("Wont get here...") }
       }.toService()
       val req = Request(Method.GET, Uri(path = "/error"))
-      service(req).run.status must equalTo(Status.InternalServerError)
+      service(req).run.orNotFound.status must equalTo(Status.InternalServerError)
     }
 
     "give a None for missing route" in {
       val service = new RhoService {}.toService()
       val req = Request(Method.GET, Uri(path = "/missing"))
-      service(req).run.status must_== Status.NotFound
+      service(req).run.orNotFound.status must_== Status.NotFound
     }
   }
 
@@ -351,10 +351,10 @@ class RhoServiceSpec extends Specification with RequestRunner {
       both.getRoutes === srvc1.getRoutes ++ srvc2.getRoutes
 
       val req1 = Request(uri = uri("foo1"))
-      getBody(bothService(req1).run.body) === "Foo1"
+      getBody(bothService(req1).run.orNotFound.body) === "Foo1"
 
       val req2 = Request(uri = uri("foo2"))
-      getBody(bothService(req2).run.body) === "Foo2"
+      getBody(bothService(req2).run.orNotFound.body) === "Foo2"
     }
   }
 
@@ -367,7 +367,7 @@ class RhoServiceSpec extends Specification with RequestRunner {
       val srvc2 = "foo" /: srvc1 toService()
 
       val req1 = Request(uri = Uri(path ="/foo/bar"))
-      getBody(srvc2(req1).run.body) === "bar"
+      getBody(srvc2(req1).run.orNotFound.body) === "bar"
     }
   }
 

--- a/core/src/test/scala/org/http4s/rho/bits/HListToFuncSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/bits/HListToFuncSpec.scala
@@ -11,7 +11,7 @@ class HListToFuncSpec extends Specification {
     new String(b.runLog.run.foldLeft(ByteVector.empty)(_ ++ _).toArray)
   }
 
-  def checkOk(r: Request): String = getBody(service(r).run.body)
+  def checkOk(r: Request): String = getBody(service(r).run.orNotFound.body)
 
   def Get(s: String, h: Header*): Request =
     Request(bits.MethodAliases.GET, Uri.fromString(s).getOrElse(sys.error("Failed.")), headers = Headers(h:_*))

--- a/core/src/test/scala/org/http4s/rho/bits/PathTreeSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/bits/PathTreeSpec.scala
@@ -38,7 +38,7 @@ class PathTreeSpec extends Specification {
       GET / "foo" |>> "foo"
     }.toService())
     val req = Request(Method.GET, uri = Uri(path = "/bar/foo"))
-    val resp = svc(req).run
+    val resp = svc(req).run.orNotFound
 
     resp.status must_== Status.Ok
     val b = new String(resp.body.runLog.run.reduce(_ ++ _).toArray, StandardCharsets.UTF_8)
@@ -54,17 +54,17 @@ class PathTreeSpec extends Specification {
 
     "Handle a valid OPTIONS request" in {
       val req = Request(Method.OPTIONS, uri = uri("/bar"))
-      svc(req).run.status must_== Status.Ok
+      svc(req).run.orNotFound.status must_== Status.Ok
     }
 
     "Provide a 405 MethodNotAllowed when an incorrect method is used for a resource" in {
       val req = Request(Method.POST, uri = uri("/foo"))
-      svc(req).run.status must_== Status.MethodNotAllowed
+      svc(req).run.orNotFound.status must_== Status.MethodNotAllowed
     }
 
     "Provide a 404 NotFound when the OPTIONS method is used for a resource without an OPTIONS" in {
       val req = Request(Method.OPTIONS, uri = uri("/foo"))
-      svc(req).run.status must_== Status.NotFound
+      svc(req).run.orNotFound.status must_== Status.NotFound
     }
   }
 

--- a/core/src/test/scala/org/http4s/rho/bits/ResponseGeneratorSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/bits/ResponseGeneratorSpec.scala
@@ -17,7 +17,7 @@ class ResponseGeneratorSpec extends Specification {
       val str = new String(resp.body.runLog.run.reduce(_ ++ _).toArray)
       str must_== "Foo"
 
-      resp.headers.get(`Content-Length`) must_== Some(`Content-Length`("Foo".getBytes.length))
+      resp.headers.get(`Content-Length`) must_== Some(`Content-Length`.unsafeFromLong("Foo".getBytes.length))
       resp.headers.filterNot(_.is(`Content-Length`)).toList must_== EntityEncoder.stringEncoder.headers.toList
     }
 

--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/MyService.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/MyService.scala
@@ -3,10 +3,10 @@ package com.http4s.rho.swagger.demo
 import java.util.concurrent.atomic.AtomicInteger
 import java.time.Instant
 
-import org.http4s.Uri
+import org.http4s.{HttpDate, Uri}
 import org.http4s.rho.RhoService
-
 import JsonEncoder.AutoSerializable
+
 import scalaz.Scalaz._
 import scalaz.concurrent.Task
 import scalaz.stream.Process
@@ -77,7 +77,7 @@ object MyService extends RhoService {
       val hs = req.headers.get(headers.Cookie) match {
         case None => Headers.empty
         case Some(cookie) =>
-          Headers(cookie.values.toList.map { c => headers.`Set-Cookie`(c.copy(expires = Some(Instant.ofEpochMilli(0)), maxAge = Some(0)))})
+          Headers(cookie.values.toList.map { c => headers.`Set-Cookie`(c.copy(expires = Some(HttpDate.Epoch), maxAge = Some(0)))})
       }
 
       Ok("Deleted cookies!").replaceAllHeaders(hs)

--- a/project/build.scala
+++ b/project/build.scala
@@ -205,7 +205,7 @@ object Dependencies {
       case Seq(7, 2, _*) => "3.8.6"
     }
   def http4sVersion(scalazVersion: String) =
-    s"0.15.0${scalazCrossBuildSuffix(scalazVersion)}"
+    s"0.16.5${scalazCrossBuildSuffix(scalazVersion)}"
 
   def http4sServer(zv: String) = "org.http4s"                 %% "http4s-server"         % http4sVersion(zv)
   def http4sDSL(zv: String)    = "org.http4s"                 %% "http4s-dsl"            % http4sVersion(zv)


### PR DESCRIPTION
Upgrades the existing release-0.16.x branch to latest scalaz version of http4s (0.16.5).
Need to decide on a version number and create a new branch to merge into (if different branch is desired). 