### PR TITLE
Fix examples with different response codes

### DIFF
--- a/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/RestService.scala
+++ b/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/RestService.scala
@@ -1,15 +1,13 @@
 package com.http4s.rho.hal.plus.swagger.demo
 
 import cats.Monad
-import cats.syntax.functor._
-import org.http4s.rho.Result.BaseResult
 import org.http4s.rho.RhoService
 import org.http4s.rho.hal.{ResourceObjectBuilder => ResObjBuilder, _}
 import org.http4s.{Request, Uri}
 
 import scala.collection.mutable.ListBuffer
 
-class RestService[F[_]: Monad](val businessLayer: BusinessLayer) extends RhoService[F] {
+class RestService[F[+_]: Monad](val businessLayer: BusinessLayer) extends RhoService[F] {
 
   // # Query Parameters
 
@@ -47,10 +45,7 @@ class RestService[F[_]: Monad](val businessLayer: BusinessLayer) extends RhoServ
       Ok(b.build())
     }
 
-    val res: F[BaseResult[F]] =
-      (found getOrElse NotFound(warning(s"Browser $id not found"))).widen
-
-    res
+    found getOrElse NotFound(warning(s"Browser $id not found"))
   }
 
   val browserPatternsById = browsers / id / "patterns"
@@ -58,10 +53,7 @@ class RestService[F[_]: Monad](val businessLayer: BusinessLayer) extends RhoServ
     val found = for { patterns <- businessLayer.findBrowserPatternsByBrowserId(id) }
       yield Ok(browserPatternsAsResource(request, 0, Int.MaxValue, patterns, patterns.size).build())
 
-    val res: F[BaseResult[F]] =
-      (found getOrElse NotFound(warning(s"Browser $id not found"))).widen
-
-    res
+    found getOrElse NotFound(warning(s"Browser $id not found"))
   }
 
   val browserPatterns = "browser-patterns"
@@ -85,10 +77,7 @@ class RestService[F[_]: Monad](val businessLayer: BusinessLayer) extends RhoServ
       Ok(b.build())
     }
 
-    val res: F[BaseResult[F]] =
-      (found getOrElse NotFound(warning(s"Browser $id not found"))).widen
-
-    res
+    found getOrElse NotFound(warning(s"Browser $id not found"))
   }
 
   val browserTypes = "browser-types"
@@ -110,10 +99,7 @@ class RestService[F[_]: Monad](val businessLayer: BusinessLayer) extends RhoServ
       Ok(b.build())
     }
 
-    val res: F[BaseResult[F]] =
-      (found getOrElse NotFound(warning(s"Browser type $id not found"))).widen
-
-    res
+    found getOrElse NotFound(warning(s"Browser type $id not found"))
   }
 
   val browsersByBrowserTypeId = browserTypes / id / "browsers"
@@ -121,12 +107,10 @@ class RestService[F[_]: Monad](val businessLayer: BusinessLayer) extends RhoServ
     val browsers = businessLayer.findBrowsersByBrowserTypeId(id, first, max)
     val total = businessLayer.countBrowsersByBrowserTypeId(id)
 
-    val res: F[BaseResult[F]] = if (browsers.nonEmpty)
-      Ok(browsersAsResource(request, first, max, browsers, total).build()).widen
+    if (browsers.nonEmpty)
+      Ok(browsersAsResource(request, first, max, browsers, total).build())
     else
-      NotFound(warning(s"No browsers for type $id found")).widen
-
-    res
+      NotFound(warning(s"No browsers for type $id found"))
   }
 
   val operatingSystems = "operating-systems"
@@ -149,34 +133,27 @@ class RestService[F[_]: Monad](val businessLayer: BusinessLayer) extends RhoServ
       Ok(b.build())
     }
 
-    val res: F[BaseResult[F]] =
-      (found getOrElse NotFound(warning(s"OperatingSystem $id not found"))).widen
-
-    res
+    found getOrElse NotFound(warning(s"OperatingSystem $id not found"))
   }
 
   val browsersByOperatingSystem = operatingSystemById / "browsers"
   GET / browsersByOperatingSystem |>> { (request: Request[F], id: Int) =>
     val browsers = businessLayer.findBrowsersByOperatingSystemId(id)
 
-    val res: F[BaseResult[F]] = if (browsers.nonEmpty)
-      Ok(browsersAsResource(request, 0, Int.MaxValue, browsers, browsers.size).build()).widen
+    if (browsers.nonEmpty)
+      Ok(browsersAsResource(request, 0, Int.MaxValue, browsers, browsers.size).build())
     else
-      NotFound(warning(s"No Browsers for operating system $id found")).widen
-
-    res
+      NotFound(warning(s"No Browsers for operating system $id found"))
   }
 
   val operatingSystemsByBrowser = browserById / "operating-systems"
   GET / operatingSystemsByBrowser |>> { (request: Request[F], id: Int) =>
     val operatingSystems = businessLayer.findOperatingSystemsByBrowserId(id)
 
-    val res: F[BaseResult[F]] = if (operatingSystems.nonEmpty)
-      Ok(operatingSystemsAsResource(request, 0, Int.MaxValue, operatingSystems, operatingSystems.size).build()).widen
+    if (operatingSystems.nonEmpty)
+      Ok(operatingSystemsAsResource(request, 0, Int.MaxValue, operatingSystems, operatingSystems.size).build())
     else
-      NotFound(warning(s"No operating systems for browser $id found")).widen
-
-    res
+      NotFound(warning(s"No operating systems for browser $id found"))
   }
 
   GET / "" |>> { request: Request[F] =>

--- a/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/RestService.scala
+++ b/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/RestService.scala
@@ -45,7 +45,7 @@ class RestService[F[+_]: Monad](val businessLayer: BusinessLayer) extends RhoSer
       Ok(b.build())
     }
 
-    found getOrElse NotFound(warning(s"Browser $id not found"))
+    found.getOrElse(NotFound(warning(s"Browser $id not found")))
   }
 
   val browserPatternsById = browsers / id / "patterns"
@@ -53,7 +53,7 @@ class RestService[F[+_]: Monad](val businessLayer: BusinessLayer) extends RhoSer
     val found = for { patterns <- businessLayer.findBrowserPatternsByBrowserId(id) }
       yield Ok(browserPatternsAsResource(request, 0, Int.MaxValue, patterns, patterns.size).build())
 
-    found getOrElse NotFound(warning(s"Browser $id not found"))
+    found.getOrElse(NotFound(warning(s"Browser $id not found")))
   }
 
   val browserPatterns = "browser-patterns"
@@ -77,7 +77,7 @@ class RestService[F[+_]: Monad](val businessLayer: BusinessLayer) extends RhoSer
       Ok(b.build())
     }
 
-    found getOrElse NotFound(warning(s"Browser $id not found"))
+    found.getOrElse(NotFound(warning(s"Browser $id not found")))
   }
 
   val browserTypes = "browser-types"
@@ -99,7 +99,7 @@ class RestService[F[+_]: Monad](val businessLayer: BusinessLayer) extends RhoSer
       Ok(b.build())
     }
 
-    found getOrElse NotFound(warning(s"Browser type $id not found"))
+    found.getOrElse(NotFound(warning(s"Browser type $id not found")))
   }
 
   val browsersByBrowserTypeId = browserTypes / id / "browsers"
@@ -133,7 +133,7 @@ class RestService[F[+_]: Monad](val businessLayer: BusinessLayer) extends RhoSer
       Ok(b.build())
     }
 
-    found getOrElse NotFound(warning(s"OperatingSystem $id not found"))
+    found.getOrElse(NotFound(warning(s"OperatingSystem $id not found")))
   }
 
   val browsersByOperatingSystem = operatingSystemById / "browsers"

--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/MyService.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/MyService.scala
@@ -10,7 +10,6 @@ import cats.syntax.option._
 import com.http4s.rho.swagger.demo.JsonEncoder.{AutoSerializable, _}
 import com.http4s.rho.swagger.demo.MyService._
 import fs2.Stream
-import org.http4s.rho.Result.BaseResult
 import org.http4s.rho.RhoService
 import org.http4s.rho.bits._
 import org.http4s.rho.swagger.{SwaggerFileResponse, SwaggerSyntax}
@@ -21,7 +20,7 @@ import shapeless.HNil
 
 import scala.reflect.ClassTag
 
-abstract class MyService[F[_] : Effect](swaggerSyntax: SwaggerSyntax[F])(implicit F: Monad[F])
+abstract class MyService[F[+_] : Effect](swaggerSyntax: SwaggerSyntax[F])(implicit F: Monad[F])
   extends RhoService[F] {
 
   import swaggerSyntax._
@@ -55,12 +54,8 @@ abstract class MyService[F[_] : Effect](swaggerSyntax: SwaggerSyntax[F])(implici
 
   "Two different response codes can result from this route based on the number given" **
     GET / "differentstatus" / pathVar[Int] |>> { i: Int =>
-      val res: F[BaseResult[F]] = if (i >= 0)
-        Ok(JsonResult("Good result", i)).widen
-      else
-        BadRequest(s"Negative number: $i").widen
-
-      res
+      if (i >= 0) Ok(JsonResult("Good result", i))
+      else BadRequest(s"Negative number: $i")
     }
 
   "This gets a simple counter for the number of times this route has been requested" **


### PR DESCRIPTION
Widening response types to `F[BaseResult[F]]` loses information
about the actual responses.
We can make this compile by making `F` covariant.