### PR TITLE
Handle Collection[A] in body parameter

### DIFF
--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
@@ -254,6 +254,10 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
     val model = if (tpe.isPrimitive) {
       val name = TypeBuilder.DataType(tpe).name
       ModelImpl(id = tpe.fullName, id2 = name, `type` = name.some, isSimple = true)
+    } else if (tpe.isCollection) {
+      val pType = tpe.dealias.typeArgs.head
+      ArrayModel(id = tpe.fullName, id2 = tpe.fullName, `type` = "array".some,
+        items = RefProperty(title = pType.simpleName.some, ref = pType.simpleName).some)
     } else RefModel(tpe.fullName, tpe.fullName, tpe.simpleName)
     BodyParameter(
       schema      = model.some,

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
@@ -227,6 +227,27 @@ class SwaggerModelsBuilderSpec extends Specification {
 
       sb.mkOperation("/foo", ra).security must_== List(x)
     }
+
+    "Handle collection params in body" in {
+      val dec = new EntityDecoder[IO, List[String]] {
+        override def decode(msg: Message[IO], strict: Boolean): DecodeResult[IO, List[String]] = ???
+        override def consumes: Set[MediaRange] = Set.empty
+      }
+
+      val ra = POST / "foo" ^ dec |>> { (l: List[String]) => "" }
+
+      sb.mkOperation("/foo", ra).parameters must_== List(
+        BodyParameter(
+          schema = ArrayModel(
+            id = "scala.collection.immutable.List«java.lang.String»",
+            id2 = "scala.collection.immutable.List«java.lang.String»",
+            `type` = "array".some,
+            items = RefProperty(ref = "String", title = "String".some).some).some,
+          name = "body".some,
+          description = "List«String»".some
+        )
+      )
+    }
   }
 
   "SwaggerModelsBuilder.collectPaths" should {


### PR DESCRIPTION
Right now if the body is a List[A] or some collection, the generated swagger lists the parameter as List«A».
This PR fixes that and now we correctly encode it as an ArrayProperty.