### PR TITLE
Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 scala:
-- 2.11.11
-- 2.12.4
+- 2.11.12
+- 2.12.6
 jdk: oraclejdk8
 sudo: false
 cache:

--- a/build.sbt
+++ b/build.sbt
@@ -42,6 +42,7 @@ lazy val docs = project
       version.value,
       apiVersion.value
     ),
+    scalacOptions in (ScalaUnidoc, unidoc) += "-Ypartial-unification",
     unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(
       `rho-core`,
       `rho-hal`,

--- a/build.sbt
+++ b/build.sbt
@@ -94,8 +94,8 @@ lazy val license = licenses in ThisBuild := Seq(
 
 lazy val buildSettings = publishing ++
   Seq(
-    scalaVersion := "2.12.4",
-    crossScalaVersions := Seq(scalaVersion.value, "2.11.11"),
+    scalaVersion := "2.12.6",
+    crossScalaVersions := Seq(scalaVersion.value, "2.11.12"),
     scalacOptions ++= compileFlags,
     resolvers += Resolver.sonatypeRepo("snapshots"),
     fork in run := true,

--- a/core/src/test/scala/org/http4s/rho/bits/PathTreeSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/bits/PathTreeSpec.scala
@@ -5,7 +5,7 @@ package bits
 import java.nio.charset.StandardCharsets
 
 import cats.effect.IO
-import org.http4s.server.middleware.URITranslation
+import org.http4s.server.middleware.TranslateUri
 import org.specs2.mutable.Specification
 import scodec.bits.ByteVector
 
@@ -36,7 +36,7 @@ class PathTreeSpec extends Specification {
   }
 
   "Honor UriTranslations" in {
-    val svc = URITranslation.translateRoot[IO]("/bar")(new RhoService[IO] {
+    val svc = TranslateUri[IO]("/bar")(new RhoService[IO] {
       GET / "foo" |>> "foo"
     }.toService())
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,6 +18,7 @@ object Dependencies {
   lazy val logbackClassic      = "ch.qos.logback"              % "logback-classic"       % "1.2.3"
   lazy val uadetector          = "net.sf.uadetector"           % "uadetector-resources"  % "2014.10"
   lazy val shapeless           = "com.chuusai"                %% "shapeless"             % "2.3.3"
+  lazy val scalaXml            = "org.scala-lang.modules"     %% "scala-xml"             % "1.1.0"
 
   lazy val specs2              = Seq("org.specs2"              %% "specs2-core"          % specs2Version % "test",
                                      "org.specs2"              %% "specs2-scalacheck"    % specs2Version % "test" )
@@ -30,6 +31,7 @@ object Dependencies {
   lazy val swaggerDeps = libraryDependencies ++= Seq(
     json4s,
     json4sJackson,
+    scalaXml,
     swaggerCore,
     swaggerModels
   )

--- a/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
@@ -849,8 +849,8 @@ object models {
       sp.setDescription(fromOption(description))
       sp.setFormat(fromOption(format))
       sp.setEnum(fromList(enums.toList))
-      minLength.foreach(l => sp.setMinLength(new Integer(l)))
-      maxLength.foreach(l => sp.setMaxLength(new Integer(l)))
+      minLength.foreach(l => sp.setMinLength(Integer.valueOf(l)))
+      maxLength.foreach(l => sp.setMaxLength(Integer.valueOf(l)))
       sp.setPattern(fromOption(pattern))
       sp.setDefault(fromOption(default))
       sp


### PR DESCRIPTION
This merges in most of @scala-steward s suggested updates and fixes the build in the process.

The swagger dependency isn't updated as that deprecates and changes some API, that I didn't have time to look into properly.

If we start changing the code for that, we might as well go to the next major version of swagger, which covers OpenAPI 3.