### PR TITLE
0.19

### DIFF
--- a/core/src/main/scala/org/http4s/rho/AuthedContext.scala
+++ b/core/src/main/scala/org/http4s/rho/AuthedContext.scala
@@ -10,6 +10,8 @@ import org.http4s.rho.bits.{FailureResponseOps, SuccessResponse, TypedHeader}
 
 /** The [[AuthedContext]] provides a convenient way to define a RhoRoutes
   * which works with http4s authentication middleware.
+  * Please note that `AuthMiddleware`-wrapping is mandatory, otherwise context
+  * doesn't take effect.
   * {{{
   *     case class User(name: String, id: UUID)
   *
@@ -48,7 +50,7 @@ class AuthedContext[F[_]: Monad, U] extends FailureResponseOps[F] {
     }
   }
 
-  /** Get the authInfo object from request */
+  /** Get the authInfo object from request if `AuthMiddleware` provided one */
   def getAuth(req: Request[F]): Option[U] =
     req.attributes.get(authKey)
 

--- a/core/src/main/scala/org/http4s/rho/AuthedContext.scala
+++ b/core/src/main/scala/org/http4s/rho/AuthedContext.scala
@@ -19,13 +19,13 @@ import org.http4s.rho.bits.{FailureResponseOps, SuccessResponse, TypedHeader}
   *
   *     object Auth extends AuthedContext[IO, User]
   *
-  *     object BobService extends RhoRoutes[IO] {
+  *     object BobRoutes extends RhoRoutes[IO] {
   *       GET +? param("foo", "bar") >>> Auth.auth |>> { (foo: String, user: User) =>
   *         Ok(s"Bob with id ${user.id}, foo $foo")
   *       }
   *     }
   *
-  *     val service = middleware.apply(Auth.toService(BobService.toRoutes()))
+  *     val service = middleware.apply(Auth.toService(BobRoutes.toRoutes()))
   * }}}
   *
   * @tparam U authInfo type for this service.

--- a/core/src/main/scala/org/http4s/rho/AuthedContext.scala
+++ b/core/src/main/scala/org/http4s/rho/AuthedContext.scala
@@ -49,7 +49,7 @@ class AuthedContext[F[_]: Monad, U] extends FailureResponseOps[F] {
     * @param service [[HttpService]] to convert
     * @return An `AuthedService` which can be mounted by http4s servers.
     */
-  def toService(service: HttpService[F]): AuthedService[U, F] = {
+  def toService(service: HttpRoutes[F]): AuthedService[U, F] = {
     type O[A] = OptionT[F, A]
 
     Kleisli[O, AuthedRequest[F, U], Response[F]] { (a: AuthedRequest[F, U]) =>

--- a/core/src/main/scala/org/http4s/rho/AuthedContext.scala
+++ b/core/src/main/scala/org/http4s/rho/AuthedContext.scala
@@ -44,16 +44,16 @@ class AuthedContext[F[_]: Monad, U] extends FailureResponseOps[F] {
   /* Attribute key to lookup authInfo in request attributeMap . */
   final private val authKey = AttributeKey[U]
 
-  /** Turn the [[HttpService]] into an `AuthedService`
+  /** Turn the [[HttpRoutes§]] into an `AuthedService`
     *
-    * @param service [[HttpService]] to convert
+    * @param routes [[HttpRoutes]] to convert
     * @return An `AuthedService` which can be mounted by http4s servers.
     */
-  def toService(service: HttpRoutes[F]): AuthedService[U, F] = {
+  def toService(routes: HttpRoutes[F]): AuthedService[U, F] = {
     type O[A] = OptionT[F, A]
 
-    Kleisli[O, AuthedRequest[F, U], Response[F]] { (a: AuthedRequest[F, U]) =>
-      service(a.req.withAttribute[U](authKey, a.authInfo))
+    Kleisli[O, AuthedRequest[F, U], Response[F]] { a: AuthedRequest[F, U] =>
+      routes(a.req.withAttribute[U](authKey, a.authInfo))
     }
   }
 

--- a/core/src/main/scala/org/http4s/rho/AuthedContext.scala
+++ b/core/src/main/scala/org/http4s/rho/AuthedContext.scala
@@ -8,7 +8,7 @@ import shapeless.{::, HNil}
 import org.http4s.rho.bits.{FailureResponseOps, SuccessResponse, TypedHeader}
 
 
-/** The [[AuthedContext]] provides a convenient way to define a RhoService
+/** The [[AuthedContext]] provides a convenient way to define a RhoRoutes
   * which works with http4s authentication middleware.
   * {{{
   *     case class User(name: String, id: UUID)
@@ -19,7 +19,7 @@ import org.http4s.rho.bits.{FailureResponseOps, SuccessResponse, TypedHeader}
   *
   *     object Auth extends AuthedContext[IO, User]
   *
-  *     object BobService extends RhoService[IO] {
+  *     object BobService extends RhoRoutes[IO] {
   *       GET +? param("foo", "bar") >>> Auth.auth |>> { (foo: String, user: User) =>
   *         Ok(s"Bob with id ${user.id}, foo $foo")
   *       }

--- a/core/src/main/scala/org/http4s/rho/CompileRoutes.scala
+++ b/core/src/main/scala/org/http4s/rho/CompileRoutes.scala
@@ -36,15 +36,13 @@ object CompileRoutes {
     implicit def compiler[F[_]]: CompileRoutes[F, RhoRoute.Tpe[F]] = identityCompiler[F]
   }
 
-
-  /** Convert the `Seq` of [[RhoRoute]]'s into a `HttpService`
+  /** Convert the `Seq` of [[RhoRoute]]'s into a `HttpRoutes`
     *
     * @param routes `Seq` of routes to bundle into a service.
-    * @param filter [[RhoMiddleware]] to apply to the routes.
-    * @return An `HttpService`
+    * @return An `HttpRoutes`
     */
-  def foldRoutes[F[_]: Monad](routes: Seq[RhoRoute.Tpe[F]], filter: RhoMiddleware[F]): HttpRoutes[F] = {
-    val tree = filter(routes).foldLeft(PathTree[F]()){ (t, r) => t.appendRoute(r) }
+  def foldRoutes[F[_]: Monad](routes: Seq[RhoRoute.Tpe[F]]): HttpRoutes[F] = {
+    val tree = routes.foldLeft(PathTree[F]()){ (t, r) => t.appendRoute(r) }
     Kleisli((req: Request[F]) => tree.getResult(req).toResponse)
   }
 }

--- a/core/src/main/scala/org/http4s/rho/CompileService.scala
+++ b/core/src/main/scala/org/http4s/rho/CompileService.scala
@@ -42,7 +42,7 @@ object CompileService {
     * @param filter [[RhoMiddleware]] to apply to the routes.
     * @return An `HttpService`
     */
-  def foldServices[F[_]: Monad](routes: Seq[RhoRoute.Tpe[F]], filter: RhoMiddleware[F]): HttpService[F] = {
+  def foldServices[F[_]: Monad](routes: Seq[RhoRoute.Tpe[F]], filter: RhoMiddleware[F]): HttpRoutes[F] = {
     val tree = filter(routes).foldLeft(PathTree[F]()){ (t, r) => t.appendRoute(r) }
     Kleisli((req: Request[F]) => tree.getResult(req).toResponse)
   }

--- a/core/src/main/scala/org/http4s/rho/Result.scala
+++ b/core/src/main/scala/org/http4s/rho/Result.scala
@@ -100,6 +100,6 @@ trait ResultSyntaxInstances[F[_]] {
       Result(r.resp.withAttribute(key, value))
 
     def withBody[U](b: U)(implicit F: Monad[F], w: EntityEncoder[F, U]): F[Self] =
-      F.map(r.resp.withBody(b))(Result(_))
+      F.pure(Result(r.resp.withEntity(b)))
   }
 }

--- a/core/src/main/scala/org/http4s/rho/Result.scala
+++ b/core/src/main/scala/org/http4s/rho/Result.scala
@@ -99,6 +99,10 @@ trait ResultSyntaxInstances[F[_]] {
     override def withAttribute[A](key: AttributeKey[A], value: A)(implicit F: Functor[F]): Self =
       Result(r.resp.withAttribute(key, value))
 
+    def withEntity[E](b: E)(implicit w: EntityEncoder[F, E]): Self =
+      Result(r.resp.withEntity(b))
+
+    @deprecated("Use withEntity", "0.19")
     def withBody[U](b: U)(implicit F: Monad[F], w: EntityEncoder[F, U]): F[Self] =
       F.pure(Result(r.resp.withEntity(b)))
   }

--- a/core/src/main/scala/org/http4s/rho/RhoRoutes.scala
+++ b/core/src/main/scala/org/http4s/rho/RhoRoutes.scala
@@ -8,12 +8,12 @@ import shapeless.{HList, HNil}
 
 /** Constructor class for defining routes
   *
-  * The [[RhoService]] provides a convenient way to define routes in a style
+  * The [[RhoRoutes]] provides a convenient way to define routes in a style
   * similar to scalatra etc by providing implicit conversions and an implicit
   * [[CompileRoutes]] inside the constructor.
   *
   * {{{
-  *   val srvc = new RhoService[IO] {
+  *   new RhoRoutes[IO] {
   *     POST / "foo" / pathVar[Int] +? param[String]("param") |>> { (p1: Int, param: String) =>
   *       Ok("success")
   *     }
@@ -22,10 +22,10 @@ import shapeless.{HList, HNil}
   *
   * @param routes Routes to prepend before elements in the constructor.
   */
-class RhoService[F[_]: Monad](routes: Seq[RhoRoute[F, _ <: HList]] = Vector.empty)
+class RhoRoutes[F[_]: Monad](routes: Seq[RhoRoute[F, _ <: HList]] = Vector.empty)
     extends bits.MethodAliases
     with bits.ResponseGeneratorInstances[F]
-    with RoutePrependable[F, RhoService[F]]
+    with RoutePrependable[F, RhoRoutes[F]]
     with EntityEncoderInstances
     with RhoDsl[F]
 {
@@ -35,13 +35,13 @@ class RhoService[F[_]: Monad](routes: Seq[RhoRoute[F, _ <: HList]] = Vector.empt
 
   final implicit protected def compileService: CompileRoutes[F, RhoRoute.Tpe[F]] = serviceBuilder
 
-  /** Create a new [[RhoService]] by appending the routes of the passed [[RhoService]]
+  /** Create a new [[RhoRoutes]] by appending the routes of the passed [[RhoRoutes]]
     *
-    * @param other [[RhoService]] whos routes are to be appended.
-    * @return A new [[RhoService]] that contains the routes of the other service appended
+    * @param other [[RhoRoutes]] whos routes are to be appended.
+    * @return A new [[RhoRoutes]] that contains the routes of the other service appended
     *         the the routes contained in this service.
     */
-  final def and(other: RhoService[F]): RhoService[F] = new RhoService(this.getRoutes ++ other.getRoutes)
+  final def and(other: RhoRoutes[F]): RhoRoutes[F] = new RhoRoutes(this.getRoutes ++ other.getRoutes)
 
   /** Get a snapshot of the collection of [[RhoRoute]]'s accumulated so far */
   final def getRoutes: Seq[RhoRoute[F, _ <: HList]] = serviceBuilder.routes()
@@ -50,9 +50,9 @@ class RhoService[F[_]: Monad](routes: Seq[RhoRoute[F, _ <: HList]] = Vector.empt
   final def toRoutes(middleware: RhoMiddleware[F] = identity): HttpRoutes[F] =
     serviceBuilder.toRoutes(middleware)
 
-  final override def toString: String = s"RhoService(${serviceBuilder.routes().toString()})"
+  final override def toString: String = s"RhoRoutes(${serviceBuilder.routes().toString()})"
 
-  final override def /:(prefix: TypedPath[F, HNil]): RhoService[F] = {
-    new RhoService(serviceBuilder.routes().map { prefix /: _ })
+  final override def /:(prefix: TypedPath[F, HNil]): RhoRoutes[F] = {
+    new RhoRoutes(serviceBuilder.routes().map { prefix /: _ })
   }
 }

--- a/core/src/main/scala/org/http4s/rho/RhoRoutes.scala
+++ b/core/src/main/scala/org/http4s/rho/RhoRoutes.scala
@@ -29,11 +29,11 @@ class RhoRoutes[F[_]: Monad](routes: Seq[RhoRoute[F, _ <: HList]] = Vector.empty
     with EntityEncoderInstances
     with RhoDsl[F]
 {
-  final private val serviceBuilder = ServiceBuilder[F](routes)
+  final private val routesBuilder = RoutesBuilder[F](routes)
 
   final protected val logger = getLogger
 
-  final implicit protected def compileService: CompileRoutes[F, RhoRoute.Tpe[F]] = serviceBuilder
+  final implicit protected def compileRoutes: CompileRoutes[F, RhoRoute.Tpe[F]] = routesBuilder
 
   /** Create a new [[RhoRoutes]] by appending the routes of the passed [[RhoRoutes]]
     *
@@ -44,15 +44,15 @@ class RhoRoutes[F[_]: Monad](routes: Seq[RhoRoute[F, _ <: HList]] = Vector.empty
   final def and(other: RhoRoutes[F]): RhoRoutes[F] = new RhoRoutes(this.getRoutes ++ other.getRoutes)
 
   /** Get a snapshot of the collection of [[RhoRoute]]'s accumulated so far */
-  final def getRoutes: Seq[RhoRoute[F, _ <: HList]] = serviceBuilder.routes()
+  final def getRoutes: Seq[RhoRoute[F, _ <: HList]] = routesBuilder.routes()
 
   /** Convert the [[RhoRoute]]'s accumulated into a `HttpRoutes` */
   final def toRoutes(middleware: RhoMiddleware[F] = identity): HttpRoutes[F] =
-    serviceBuilder.toRoutes(middleware)
+    routesBuilder.toRoutes(middleware)
 
-  final override def toString: String = s"RhoRoutes(${serviceBuilder.routes().toString()})"
+  final override def toString: String = s"RhoRoutes(${routesBuilder.routes().toString()})"
 
   final override def /:(prefix: TypedPath[F, HNil]): RhoRoutes[F] = {
-    new RhoRoutes(serviceBuilder.routes().map { prefix /: _ })
+    new RhoRoutes(routesBuilder.routes().map { prefix /: _ })
   }
 }

--- a/core/src/main/scala/org/http4s/rho/RhoService.scala
+++ b/core/src/main/scala/org/http4s/rho/RhoService.scala
@@ -13,12 +13,11 @@ import shapeless.{HList, HNil}
   * [[CompileRoutes]] inside the constructor.
   *
   * {{{
-  *   val srvc = new RhoService {
+  *   val srvc = new RhoService[IO] {
   *     POST / "foo" / pathVar[Int] +? param[String]("param") |>> { (p1: Int, param: String) =>
   *       Ok("success")
   *     }
   *   }
-  *
   * }}}
   *
   * @param routes Routes to prepend before elements in the constructor.
@@ -47,8 +46,9 @@ class RhoService[F[_]: Monad](routes: Seq[RhoRoute[F, _ <: HList]] = Vector.empt
   /** Get a snapshot of the collection of [[RhoRoute]]'s accumulated so far */
   final def getRoutes: Seq[RhoRoute[F, _ <: HList]] = serviceBuilder.routes()
 
-  /** Convert the [[RhoRoute]]'s accumulated into a `HttpService` */
-  final def toRoutes(filter: RhoMiddleware[F] = identity): HttpRoutes[F] = serviceBuilder.toService(filter)
+  /** Convert the [[RhoRoute]]'s accumulated into a `HttpRoutes` */
+  final def toRoutes(middleware: RhoMiddleware[F] = identity): HttpRoutes[F] =
+    serviceBuilder.toRoutes(middleware)
 
   final override def toString: String = s"RhoService(${serviceBuilder.routes().toString()})"
 

--- a/core/src/main/scala/org/http4s/rho/RhoService.scala
+++ b/core/src/main/scala/org/http4s/rho/RhoService.scala
@@ -48,7 +48,7 @@ class RhoService[F[_]: Monad](routes: Seq[RhoRoute[F, _ <: HList]] = Vector.empt
   final def getRoutes: Seq[RhoRoute[F, _ <: HList]] = serviceBuilder.routes()
 
   /** Convert the [[RhoRoute]]'s accumulated into a `HttpService` */
-  final def toService(filter: RhoMiddleware[F] = identity): HttpService[F] = serviceBuilder.toService(filter)
+  final def toRoutes(filter: RhoMiddleware[F] = identity): HttpRoutes[F] = serviceBuilder.toService(filter)
 
   final override def toString: String = s"RhoService(${serviceBuilder.routes().toString()})"
 

--- a/core/src/main/scala/org/http4s/rho/RhoService.scala
+++ b/core/src/main/scala/org/http4s/rho/RhoService.scala
@@ -10,7 +10,7 @@ import shapeless.{HList, HNil}
   *
   * The [[RhoService]] provides a convenient way to define routes in a style
   * similar to scalatra etc by providing implicit conversions and an implicit
-  * [[CompileService]] inside the constructor.
+  * [[CompileRoutes]] inside the constructor.
   *
   * {{{
   *   val srvc = new RhoService {
@@ -34,7 +34,7 @@ class RhoService[F[_]: Monad](routes: Seq[RhoRoute[F, _ <: HList]] = Vector.empt
 
   final protected val logger = getLogger
 
-  final implicit protected def compileService: CompileService[F, RhoRoute.Tpe[F]] = serviceBuilder
+  final implicit protected def compileService: CompileRoutes[F, RhoRoute.Tpe[F]] = serviceBuilder
 
   /** Create a new [[RhoService]] by appending the routes of the passed [[RhoService]]
     *

--- a/core/src/main/scala/org/http4s/rho/RouteExecutable.scala
+++ b/core/src/main/scala/org/http4s/rho/RouteExecutable.scala
@@ -19,6 +19,6 @@ trait RouteExecutable[F[_], T <: HList] extends TypedBuilder[F, T] { exec =>
   def makeRoute(action: Action[F, T]): RhoRoute[F, T]
 
   /** Compiles a HTTP request definition into an action */
-  final def |>>[U, R](f: U)(implicit hltf: HListToFunc[F, T, U], srvc: CompileService[F, R]): R =
+  final def |>>[U, R](f: U)(implicit hltf: HListToFunc[F, T, U], srvc: CompileRoutes[F, R]): R =
     srvc.compile(makeRoute(hltf.toAction(f)))
 }

--- a/core/src/main/scala/org/http4s/rho/RoutesBuilder.scala
+++ b/core/src/main/scala/org/http4s/rho/RoutesBuilder.scala
@@ -5,8 +5,8 @@ import cats.Monad
 import shapeless.HList
 import org.http4s._
 
-/** CompileService which accumulates routes and can build a `HttpRoutes` */
-final class ServiceBuilder[F[_]: Monad] private(internalRoutes: VectorBuilder[RhoRoute.Tpe[F]]) extends CompileRoutes[F, RhoRoute.Tpe[F]] {
+/** CompileRoutes which accumulates routes and can build a `HttpRoutes` */
+final class RoutesBuilder[F[_]: Monad] private(internalRoutes: VectorBuilder[RhoRoute.Tpe[F]]) extends CompileRoutes[F, RhoRoute.Tpe[F]] {
 
   /** Turn the accumulated routes into an `HttpRoutes`
     *
@@ -19,7 +19,7 @@ final class ServiceBuilder[F[_]: Monad] private(internalRoutes: VectorBuilder[Rh
   /** Get a snapshot of the currently acquired routes */
   def routes(): Seq[RhoRoute.Tpe[F]] = internalRoutes.result()
 
-  /** Append the routes into this [[ServiceBuilder]]
+  /** Append the routes into this [[RoutesBuilder]]
     *
     * @param routes Routes to accumulate.
     * @return `this` instance with its internal state mutated.
@@ -29,7 +29,7 @@ final class ServiceBuilder[F[_]: Monad] private(internalRoutes: VectorBuilder[Rh
     this
   }
 
-  /** Accumulate the [[RhoRoute]] into this [[ServiceBuilder]]
+  /** Accumulate the [[RhoRoute]] into this [[RoutesBuilder]]
     *
     * This is the same as appending a the single route and returning the same route.
     *
@@ -43,15 +43,15 @@ final class ServiceBuilder[F[_]: Monad] private(internalRoutes: VectorBuilder[Rh
   }
 }
 
-object ServiceBuilder {
-  /** Constructor method for new `ServiceBuilder` instances */
-  def apply[F[_]: Monad](): ServiceBuilder[F] = apply(Seq.empty)
+object RoutesBuilder {
+  /** Constructor method for new `RoutesBuilder` instances */
+  def apply[F[_]: Monad](): RoutesBuilder[F] = apply(Seq.empty)
 
-  /** Constructor method for new `ServiceBuilder` instances with existing routes */
-  def apply[F[_]: Monad](routes: Seq[RhoRoute.Tpe[F]]): ServiceBuilder[F] = {
+  /** Constructor method for new `RoutesBuilder` instances with existing routes */
+  def apply[F[_]: Monad](routes: Seq[RhoRoute.Tpe[F]]): RoutesBuilder[F] = {
     val builder = new VectorBuilder[RhoRoute.Tpe[F]]
     builder ++= routes
 
-    new ServiceBuilder(builder)
+    new RoutesBuilder(builder)
   }
 }

--- a/core/src/main/scala/org/http4s/rho/ServiceBuilder.scala
+++ b/core/src/main/scala/org/http4s/rho/ServiceBuilder.scala
@@ -7,7 +7,7 @@ import shapeless.HList
 import scala.collection.immutable.VectorBuilder
 
 /** CompileService which accumulates routes and can build a `HttpService` */
-final class ServiceBuilder[F[_]: Monad] private(internalRoutes: VectorBuilder[RhoRoute.Tpe[F]]) extends CompileService[F, RhoRoute.Tpe[F]] {
+final class ServiceBuilder[F[_]: Monad] private(internalRoutes: VectorBuilder[RhoRoute.Tpe[F]]) extends CompileRoutes[F, RhoRoute.Tpe[F]] {
 
   /** Turn the accumulated routes into an `HttpService`
     *
@@ -15,7 +15,7 @@ final class ServiceBuilder[F[_]: Monad] private(internalRoutes: VectorBuilder[Rh
     * @return An `HttpService` which can be mounted by http4s servers.
     */
   def toService(filter: RhoMiddleware[F] = identity): HttpRoutes[F] =
-    CompileService.foldServices(internalRoutes.result(), filter)
+    CompileRoutes.foldRoutes(internalRoutes.result(), filter)
 
   /** Get a snapshot of the currently acquired routes */
   def routes(): Seq[RhoRoute.Tpe[F]] = internalRoutes.result()

--- a/core/src/main/scala/org/http4s/rho/ServiceBuilder.scala
+++ b/core/src/main/scala/org/http4s/rho/ServiceBuilder.scala
@@ -1,21 +1,20 @@
 package org.http4s.rho
 
-import cats.Monad
-import org.http4s._
-import shapeless.HList
-
 import scala.collection.immutable.VectorBuilder
+import cats.Monad
+import shapeless.HList
+import org.http4s._
 
-/** CompileService which accumulates routes and can build a `HttpService` */
+/** CompileService which accumulates routes and can build a `HttpRoutes` */
 final class ServiceBuilder[F[_]: Monad] private(internalRoutes: VectorBuilder[RhoRoute.Tpe[F]]) extends CompileRoutes[F, RhoRoute.Tpe[F]] {
 
-  /** Turn the accumulated routes into an `HttpService`
+  /** Turn the accumulated routes into an `HttpRoutes`
     *
-    * @param filter [[RhoMiddleware]] to apply to the collection of routes.
-    * @return An `HttpService` which can be mounted by http4s servers.
+    * @param middleware [[RhoMiddleware]] to apply to the collection of routes.
+    * @return An `HttpRoutes` which can be mounted by http4s servers.
     */
-  def toService(filter: RhoMiddleware[F] = identity): HttpRoutes[F] =
-    CompileRoutes.foldRoutes(internalRoutes.result(), filter)
+  def toRoutes(middleware: RhoMiddleware[F] = identity): HttpRoutes[F] =
+    CompileRoutes.foldRoutes(middleware.apply(internalRoutes.result()))
 
   /** Get a snapshot of the currently acquired routes */
   def routes(): Seq[RhoRoute.Tpe[F]] = internalRoutes.result()

--- a/core/src/main/scala/org/http4s/rho/ServiceBuilder.scala
+++ b/core/src/main/scala/org/http4s/rho/ServiceBuilder.scala
@@ -14,7 +14,7 @@ final class ServiceBuilder[F[_]: Monad] private(internalRoutes: VectorBuilder[Rh
     * @param filter [[RhoMiddleware]] to apply to the collection of routes.
     * @return An `HttpService` which can be mounted by http4s servers.
     */
-  def toService(filter: RhoMiddleware[F] = identity): HttpService[F] =
+  def toService(filter: RhoMiddleware[F] = identity): HttpRoutes[F] =
     CompileService.foldServices(internalRoutes.result(), filter)
 
   /** Get a snapshot of the currently acquired routes */

--- a/core/src/main/scala/org/http4s/rho/bits/ResponseGenerator.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/ResponseGenerator.scala
@@ -39,7 +39,7 @@ abstract class EntityResponseGenerator[F[_]](val status: Status) extends Respons
 
   /** Generate a [[Result]] that carries the type information */
   def apply[A](body: A, headers: Headers)(implicit F: Monad[F], w: EntityEncoder[F, A]): F[T[A]] = {
-    F.flatMap(w.toEntity(body)) { case Entity(proc, len) =>
+    w.toEntity(body) match { case Entity(proc, len) =>
       val hs = len match {
         case Some(l) => (w.headers ++ headers).put(`Content-Length`.unsafeFromLong(l))
         case None    => w.headers ++ headers
@@ -54,7 +54,7 @@ abstract class EntityResponseGenerator[F[_]](val status: Status) extends Respons
 
   /** Generate wrapper free `Response` */
   def pure[A](body: A, headers: Headers)(implicit F: Monad[F], w: EntityEncoder[F, A]): F[Response[F]] = {
-    F.flatMap(w.toEntity(body)) { case Entity(proc, len) =>
+    w.toEntity(body) match { case Entity(proc, len) =>
       val hs = len match {
         case Some(l) => (w.headers ++ headers).put(`Content-Length`.unsafeFromLong(l))
         case None    => w.headers ++ headers

--- a/core/src/test/scala/ApiExamples.scala
+++ b/core/src/test/scala/ApiExamples.scala
@@ -5,7 +5,7 @@ import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.http4s.headers.{ETag, `Content-Length`}
-import org.http4s.rho.RhoService
+import org.http4s.rho.RhoRoutes
 import org.http4s.rho.bits.TypedQuery
 import org.http4s.server.websocket.WebSocketBuilder
 import org.http4s.{Request, UrlForm}
@@ -18,13 +18,13 @@ class ApiExamples extends Specification {
     "Make it easy to compose routes" in {
 
       /// src_inlined SimplePath
-      new RhoService[IO] {
+      new RhoRoutes[IO] {
         GET / "hello" |>> { () => Ok("Hello, world!") }
       }
       /// end_src_inlined
 
       /// src_inlined ReusePath
-      new RhoService[IO] {
+      new RhoRoutes[IO] {
         // A path can be built up in multiple steps and the parts reused
         val pathPart1 = GET / "hello"
 
@@ -34,7 +34,7 @@ class ApiExamples extends Specification {
       /// end_src_inlined
 
       /// src_inlined PathCapture
-      new RhoService[IO] {
+      new RhoRoutes[IO] {
         // Use combinators to parse and capture path parameters
         GET / "helloworldnumber" / pathVar[Int] / "foo" |>> { i: Int =>
           Ok("Received $i")
@@ -59,7 +59,7 @@ class ApiExamples extends Specification {
       /// end_src_inlined
 
       /// src_inlined CaptureTail
-      new RhoService[IO] {
+      new RhoRoutes[IO] {
         // You can capture the entire rest of the tail using *
         GET / "hello" / * |>> { r: List[String] =>
           Ok(s"Got the rest: ${r.mkString}")
@@ -68,7 +68,7 @@ class ApiExamples extends Specification {
       /// end_src_inlined
 
       /// src_inlined QueryCapture
-      new RhoService[IO] {
+      new RhoRoutes[IO] {
         // Query parameters can be captured in a similar manner as path fragments
         GET / "hello" +? param[Int]("fav") |>> { i: Int =>
           Ok(s"Query 'fav' had Int value $i")
@@ -77,7 +77,7 @@ class ApiExamples extends Specification {
       /// end_src_inlined
 
       /// src_inlined MultiCapture
-      new RhoService[IO] {
+      new RhoRoutes[IO] {
         // A Path can be made all at once
         POST / pathVar[Int] +? param[Int]("fav") |>> { (i1: Int, i2: Int) =>
           Ok(s"Sum of the number is ${i1 + i2}")
@@ -86,7 +86,7 @@ class ApiExamples extends Specification {
       /// end_src_inlined
 
       /// src_inlined HeaderCapture
-      new RhoService[IO] {
+      new RhoRoutes[IO] {
         GET / "hello" >>> capture(ETag) |>> { tag: ETag =>
           Ok(s"Thanks for the tag: $tag")
         }
@@ -94,7 +94,7 @@ class ApiExamples extends Specification {
       /// end_src_inlined
 
       /// src_inlined HeaderRuleCombine
-      new RhoService[IO] {
+      new RhoRoutes[IO] {
         // Header rules are composable
         val ensureLength = existsAnd(`Content-Length`)(_.length > 0)
         val getTag = capture(ETag)
@@ -106,7 +106,7 @@ class ApiExamples extends Specification {
       /// end_src_inlined
 
       /// src_inlined BooleanOperators
-      new RhoService[IO] {
+      new RhoRoutes[IO] {
         /*
          * Boolean logic
          * Just as you can perform 'and' operations which have the effect of
@@ -127,7 +127,7 @@ class ApiExamples extends Specification {
       /// end_src_inlined
 
       /// src_inlined RequestAccess
-      new RhoService[IO] {
+      new RhoRoutes[IO] {
         /* Access the `Request` by making it the first param of the
            handler function.
          */
@@ -141,7 +141,7 @@ class ApiExamples extends Specification {
       /// end_src_inlined
 
       /// src_inlined ResultTypes
-      new RhoService[IO] {
+      new RhoRoutes[IO] {
         private val counter = new AtomicInteger(0)
         private def getCount(): String = counter.incrementAndGet().toString
         // Don't want status codes? Anything with an `EntityEncoder` will work.
@@ -162,7 +162,7 @@ class ApiExamples extends Specification {
       /// end_src_inlined
 
       /// src_inlined StatusCodes
-      new RhoService[IO] {
+      new RhoRoutes[IO] {
         GET / "twoResults" |>> { () =>
           if (true) Ok("bytes result".getBytes())
           else NotFound("Boo... Not found...")
@@ -171,7 +171,7 @@ class ApiExamples extends Specification {
       /// end_src_inlined
 
       /// src_inlined Decoders
-      new RhoService[IO] {
+      new RhoRoutes[IO] {
         // Using decoders you can parse the body as well
         POST / "postSomething" ^ UrlForm.entityDecoder[IO] |>> { m: UrlForm =>
           Ok(s"You posted these things: $m")
@@ -181,7 +181,7 @@ class ApiExamples extends Specification {
 
       /// src_inlined Composed parameters
 
-      new RhoService[IO] {
+      new RhoRoutes[IO] {
         import shapeless.{::, HNil}
         case class Foo(i: Int, v: String, a: Double)
 

--- a/core/src/test/scala/ApiExamples.scala
+++ b/core/src/test/scala/ApiExamples.scala
@@ -4,13 +4,13 @@ import java.util.UUID
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
 
-import cats.effect.IO
 import org.http4s.headers.{ETag, `Content-Length`}
-import org.http4s.rho._
+import org.http4s.rho.RhoService
 import org.http4s.rho.bits.TypedQuery
-import org.http4s.server.websocket._
+import org.http4s.server.websocket.WebSocketBuilder
 import org.http4s.{Request, UrlForm}
 import org.specs2.mutable.Specification
+import cats.effect.IO
 import cats.implicits._
 
 class ApiExamples extends Specification {

--- a/core/src/test/scala/org/http4s/rho/ApiTest.scala
+++ b/core/src/test/scala/org/http4s/rho/ApiTest.scala
@@ -100,24 +100,23 @@ class ApiTest extends Specification {
     }
 
 
-//    "map simple header params into a complex type" in {
-//      case class Foo(age: Long, s: HttpDate)
-//      val paramFoo = (captureMap(headers.`Content-Length`)(_.length) &&
-//        captureMap(headers.Date)(_.date)).map(Foo.apply(_))
-//
-//      val path = GET / "hello" >>> paramFoo
-//      val req = Request[IO](
-//        uri = Uri.fromString("/hello?i=32&f=3.2&s=Asdf").right.getOrElse(sys.error("Failed.")),
-//        headers = Headers(headers.`Content-Length`.unsafeFromLong(10), headers.Date(HttpDate.now))
-//      )
-//
-//      val expectedFoo = Foo(10, HttpDate.now)
-//      val route = runWith(path) { (f: Foo) => Ok(s"stuff $f") }
-//
-//      val result = route(req).value.unsafeRunSync().getOrElse(Response.notFound)
-//      result.status should_== Status.Ok
-//      RequestRunner.getBody(result.body) should_== s"stuff $expectedFoo"
-//    }
+    "map simple header params into a complex type" in {
+      case class Foo(age: Long, s: HttpDate)
+      val paramFoo = captureMap(headers.`Content-Length`)(_.length) && captureMap(headers.Date)(_.date) map Foo.apply _
+
+      val path = GET / "hello" >>> paramFoo
+      val req = Request[IO](
+        uri = Uri.fromString("/hello?i=32&f=3.2&s=Asdf").right.getOrElse(sys.error("Failed.")),
+        headers = Headers(headers.`Content-Length`.unsafeFromLong(10), headers.Date(HttpDate.now))
+      )
+
+      val expectedFoo = Foo(10, HttpDate.now)
+      val route = runWith(path) { (f: Foo) => Ok(s"stuff $f") }
+
+      val result = route(req).value.unsafeRunSync().getOrElse(Response.notFound)
+      result.status should_== Status.Ok
+      RequestRunner.getBody(result.body) should_== s"stuff $expectedFoo"
+    }
 
     "Map with possible default" in {
       val req = Request[IO]().putHeaders(etag, lenheader)

--- a/core/src/test/scala/org/http4s/rho/ApiTest.scala
+++ b/core/src/test/scala/org/http4s/rho/ApiTest.scala
@@ -18,7 +18,7 @@ class ApiTest extends Specification {
   object ruleExecutor extends RuleExecutor[IO]
 
   def runWith[F[_]: Monad, T <: HList, FU](exec: RouteExecutable[F, T])(f: FU)(implicit hltf: HListToFunc[F, T, FU]): Request[F] => OptionT[F, Response[F]] = {
-    val srvc = new RhoService[F] { exec |>> f }.toRoutes()
+    val srvc = new RhoRoutes[F] { exec |>> f }.toRoutes()
     srvc.apply(_: Request[F])
   }
 

--- a/core/src/test/scala/org/http4s/rho/ApiTest.scala
+++ b/core/src/test/scala/org/http4s/rho/ApiTest.scala
@@ -12,7 +12,6 @@ import org.http4s.rho.io._
 import org.specs2.matcher.MatchResult
 import org.specs2.mutable._
 import shapeless.{HList, HNil}
-import shapeless._
 
 class ApiTest extends Specification {
 

--- a/core/src/test/scala/org/http4s/rho/AuthedContextSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/AuthedContextSpec.scala
@@ -26,7 +26,7 @@ object MyAuth extends AuthedContext[IO, User]
 object MyRoutes extends RhoRoutes[IO] {
   import MyAuth._
 
-  GET +? param("foo", "bar") >>> auth |>> { (_: Request[IO], foo: String, user: User) =>
+  GET +? param("foo", "bar") >>> auth |>> { (foo: String, user: User) =>
     if (user.name == "Test User") {
       Ok(s"just root with parameter 'foo=$foo'")
     } else {

--- a/core/src/test/scala/org/http4s/rho/AuthedContextSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/AuthedContextSpec.scala
@@ -23,7 +23,7 @@ object Auth {
 
 object MyAuth extends AuthedContext[IO, User]
 
-object MyService extends RhoService[IO] {
+object MyRoutes extends RhoRoutes[IO] {
   import MyAuth._
 
   GET +? param("foo", "bar") >>> auth |>> { (_: Request[IO], foo: String, user: User) =>
@@ -46,7 +46,7 @@ object MyService extends RhoService[IO] {
 
 class AuthedContextSpec extends Specification {
 
-  val routes = Auth.authenticated(MyAuth.toService(MyService.toRoutes()))
+  val routes = Auth.authenticated(MyAuth.toService(MyRoutes.toRoutes()))
 
   "AuthedContext execution" should {
 

--- a/core/src/test/scala/org/http4s/rho/AuthedContextSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/AuthedContextSpec.scala
@@ -37,13 +37,13 @@ object MyService extends RhoService[IO] {
 
 class AuthedContextSpec extends Specification {
 
-  val service = Auth.authenticated(MyAuth.toService(MyService.toRoutes()))
+  val routes = Auth.authenticated(MyAuth.toService(MyService.toRoutes()))
 
   "AuthedContext execution" should {
 
     "Be able to have access to authInfo" in {
       val request = Request[IO](Method.GET, Uri(path = "/"))
-      val resp = service.run(request).value.unsafeRunSync().getOrElse(Response.notFound)
+      val resp = routes.run(request).value.unsafeRunSync().getOrElse(Response.notFound)
       if (resp.status == Status.Ok) {
         val body = new String(resp.body.compile.toVector.unsafeRunSync().foldLeft(Array[Byte]())(_ :+ _))
         body should_== "just root with parameter 'foo=bar'"

--- a/core/src/test/scala/org/http4s/rho/AuthedContextSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/AuthedContextSpec.scala
@@ -7,7 +7,6 @@ import cats.data.{Kleisli, OptionT}
 import cats.effect.IO
 import org.http4s.server.AuthMiddleware
 import org.specs2.mutable.Specification
-import scodec.bits.ByteVector
 
 case class User(name: String, id: UUID)
 
@@ -38,7 +37,7 @@ object MyService extends RhoService[IO] {
 
 class AuthedContextSpec extends Specification {
 
-  val service = Auth.authenticated(MyAuth.toService(MyService.toService()))
+  val service = Auth.authenticated(MyAuth.toService(MyService.toRoutes()))
 
   "AuthedContext execution" should {
 
@@ -46,7 +45,7 @@ class AuthedContextSpec extends Specification {
       val request = Request[IO](Method.GET, Uri(path = "/"))
       val resp = service.run(request).value.unsafeRunSync().getOrElse(Response.notFound)
       if (resp.status == Status.Ok) {
-        val body = new String(resp.body.compile.toVector.unsafeRunSync().foldLeft(ByteVector.empty)(_ :+ _).toArray)
+        val body = new String(resp.body.compile.toVector.unsafeRunSync().foldLeft(Array[Byte]())(_ :+ _))
         body should_== "just root with parameter 'foo=bar'"
       } else sys.error(s"Invalid response code: ${resp.status}")
     }

--- a/core/src/test/scala/org/http4s/rho/CodecRouterSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/CodecRouterSpec.scala
@@ -12,9 +12,9 @@ class CodecRouterSpec extends Specification {
     (rbody, resp.status)
   }
 
-  "A CodecRouter in a RhoService" should {
+  "A CodecRouter in a RhoRoutes" should {
 
-    val routes = new RhoService[IO] {
+    val routes = new RhoRoutes[IO] {
       (POST / "foo" decoding(EntityDecoder.text[IO])) |>> { s: String => Ok(s"Received: $s") }
       (POST / "form" decoding(UrlForm.entityDecoder[IO])) |>> { m: UrlForm => Ok("success") }
     }.toRoutes()

--- a/core/src/test/scala/org/http4s/rho/CodecRouterSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/CodecRouterSpec.scala
@@ -4,12 +4,11 @@ package rho
 import cats.effect.IO
 import fs2.Stream
 import org.specs2.mutable.Specification
-import scodec.bits.ByteVector
 
 class CodecRouterSpec extends Specification {
 
   def bodyAndStatus(resp: Response[IO]): (String, Status) = {
-    val rbody = new String(resp.body.compile.toVector.unsafeRunSync.foldLeft(ByteVector.empty)(_ :+ _).toArray)
+    val rbody = new String(resp.body.compile.toVector.unsafeRunSync.foldLeft(Array[Byte]())(_ :+ _))
     (rbody, resp.status)
   }
 
@@ -18,12 +17,12 @@ class CodecRouterSpec extends Specification {
     val service = new RhoService[IO] {
       (POST / "foo" decoding(EntityDecoder.text[IO])) |>> { s: String => Ok(s"Received: $s") }
       (POST / "form" decoding(UrlForm.entityDecoder[IO])) |>> { m: UrlForm => Ok("success") }
-    }.toService()
+    }.toRoutes()
 
     "Decode a valid body" in {
 
       val b = Stream.emits("hello".getBytes)
-      val h = Headers(headers.`Content-Type`(MediaType.`text/plain`))
+      val h = Headers(headers.`Content-Type`(MediaType.text.plain))
       val req = Request[IO](Method.POST, Uri(path = "/foo"), headers = h, body = b)
       val result = service(req).value.unsafeRunSync().getOrElse(Response.notFound)
       val (bb, s) = bodyAndStatus(result)
@@ -34,7 +33,7 @@ class CodecRouterSpec extends Specification {
 
     "Fail on invalid body" in {
       val b = Stream.emits("hello =".getBytes)
-      val h = Headers(headers.`Content-Type`(MediaType.`application/x-www-form-urlencoded`))
+      val h = Headers(headers.`Content-Type`(MediaType.application.`x-www-form-urlencoded`))
       val req = Request[IO](Method.POST, Uri(path = "/form"), headers = h, body = b)
 
       service(req).value.unsafeRunSync().map(_.status) must be some Status.BadRequest

--- a/core/src/test/scala/org/http4s/rho/CodecRouterSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/CodecRouterSpec.scala
@@ -14,7 +14,7 @@ class CodecRouterSpec extends Specification {
 
   "A CodecRouter in a RhoService" should {
 
-    val service = new RhoService[IO] {
+    val routes = new RhoService[IO] {
       (POST / "foo" decoding(EntityDecoder.text[IO])) |>> { s: String => Ok(s"Received: $s") }
       (POST / "form" decoding(UrlForm.entityDecoder[IO])) |>> { m: UrlForm => Ok("success") }
     }.toRoutes()
@@ -24,7 +24,7 @@ class CodecRouterSpec extends Specification {
       val b = Stream.emits("hello".getBytes)
       val h = Headers(headers.`Content-Type`(MediaType.text.plain))
       val req = Request[IO](Method.POST, Uri(path = "/foo"), headers = h, body = b)
-      val result = service(req).value.unsafeRunSync().getOrElse(Response.notFound)
+      val result = routes(req).value.unsafeRunSync().getOrElse(Response.notFound)
       val (bb, s) = bodyAndStatus(result)
 
       s must_== Status.Ok
@@ -36,7 +36,7 @@ class CodecRouterSpec extends Specification {
       val h = Headers(headers.`Content-Type`(MediaType.application.`x-www-form-urlencoded`))
       val req = Request[IO](Method.POST, Uri(path = "/form"), headers = h, body = b)
 
-      service(req).value.unsafeRunSync().map(_.status) must be some Status.BadRequest
+      routes(req).value.unsafeRunSync().map(_.status) must be some Status.BadRequest
     }
   }
 }

--- a/core/src/test/scala/org/http4s/rho/CompileRoutesSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/CompileRoutesSpec.scala
@@ -21,7 +21,7 @@ class CompileRoutesSpec extends Specification {
       val c = ServiceBuilder[IO]()
       getFoo(c)
 
-      "GetFoo" === RRunner(c.toService()).checkOk(Request(uri=Uri(path="/hello")))
+      "GetFoo" === RRunner(c.toRoutes()).checkOk(Request(uri=Uri(path="/hello")))
     }
 
     "Build multiple routes" in {
@@ -29,8 +29,8 @@ class CompileRoutesSpec extends Specification {
       getFoo(c)
       putFoo(c)
 
-      "GetFoo" === RRunner(c.toService()).checkOk(Request(uri=Uri(path="/hello")))
-      "PutFoo" === RRunner(c.toService()).checkOk(Request(method = Method.PUT, uri=Uri(path="/hello")))
+      "GetFoo" === RRunner(c.toRoutes()).checkOk(Request(uri=Uri(path="/hello")))
+      "PutFoo" === RRunner(c.toRoutes()).checkOk(Request(method = Method.PUT, uri=Uri(path="/hello")))
     }
 
     "Make routes from a collection of RhoRoutes" in {
@@ -39,7 +39,7 @@ class CompileRoutesSpec extends Specification {
         (GET / "hello" |>> "GetFoo") ::
         (PUT / "hello" |>> "PutFoo") :: Nil
 
-      val srvc = CompileRoutes.foldRoutes[IO](routes, identity)
+      val srvc = CompileRoutes.foldRoutes[IO](routes)
       "GetFoo" === RRunner(srvc).checkOk(Request(uri=Uri(path="/hello")))
       "PutFoo" === RRunner(srvc).checkOk(Request(method = Method.PUT, uri=Uri(path="/hello")))
     }
@@ -48,7 +48,7 @@ class CompileRoutesSpec extends Specification {
       val c1 = ServiceBuilder[IO](); getFoo(c1)
       val c2 = ServiceBuilder[IO](); putFoo(c2)
 
-      val srvc = c1.append(c2.routes()).toService()
+      val srvc = c1.append(c2.routes()).toRoutes()
       "GetFoo" === RRunner(srvc).checkOk(Request(uri=Uri(path="/hello")))
       "PutFoo" === RRunner(srvc).checkOk(Request(method = Method.PUT, uri=Uri(path="/hello")))
     }

--- a/core/src/test/scala/org/http4s/rho/CompileRoutesSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/CompileRoutesSpec.scala
@@ -6,13 +6,13 @@ import org.http4s.rho.io._
 import org.http4s.{Method, Request, Uri}
 import org.specs2.mutable.Specification
 
-class CompileServiceSpec extends Specification {
+class CompileRoutesSpec extends Specification {
 
-  def getFoo(implicit c: CompileService[IO, _]): Unit = {
+  def getFoo(implicit c: CompileRoutes[IO, _]): Unit = {
     GET / "hello" |>> "GetFoo"
   }
 
-  def putFoo(implicit c: CompileService[IO, _]): Unit = {
+  def putFoo(implicit c: CompileRoutes[IO, _]): Unit = {
     PUT / "hello" |>> "PutFoo"
   }
 
@@ -34,12 +34,12 @@ class CompileServiceSpec extends Specification {
     }
 
     "Make routes from a collection of RhoRoutes" in {
-      import CompileService.Implicit.compiler
+      import CompileRoutes.Implicit.compiler
       val routes =
         (GET / "hello" |>> "GetFoo") ::
         (PUT / "hello" |>> "PutFoo") :: Nil
 
-      val srvc = CompileService.foldServices[IO](routes, identity)
+      val srvc = CompileRoutes.foldRoutes[IO](routes, identity)
       "GetFoo" === RRunner(srvc).checkOk(Request(uri=Uri(path="/hello")))
       "PutFoo" === RRunner(srvc).checkOk(Request(method = Method.PUT, uri=Uri(path="/hello")))
     }

--- a/core/src/test/scala/org/http4s/rho/CompileRoutesSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/CompileRoutesSpec.scala
@@ -18,14 +18,14 @@ class CompileRoutesSpec extends Specification {
 
   "CompileService" should {
     "Build a single route" in {
-      val c = ServiceBuilder[IO]()
+      val c = RoutesBuilder[IO]()
       getFoo(c)
 
       "GetFoo" === RRunner(c.toRoutes()).checkOk(Request(uri=Uri(path="/hello")))
     }
 
     "Build multiple routes" in {
-      val c = ServiceBuilder[IO]()
+      val c = RoutesBuilder[IO]()
       getFoo(c)
       putFoo(c)
 
@@ -45,8 +45,8 @@ class CompileRoutesSpec extends Specification {
     }
 
     "Concatenate correctly" in {
-      val c1 = ServiceBuilder[IO](); getFoo(c1)
-      val c2 = ServiceBuilder[IO](); putFoo(c2)
+      val c1 = RoutesBuilder[IO](); getFoo(c1)
+      val c2 = RoutesBuilder[IO](); putFoo(c2)
 
       val srvc = c1.append(c2.routes()).toRoutes()
       "GetFoo" === RRunner(srvc).checkOk(Request(uri=Uri(path="/hello")))

--- a/core/src/test/scala/org/http4s/rho/ParamDefaultValueSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/ParamDefaultValueSpec.scala
@@ -13,7 +13,7 @@ class ParamDefaultValueSpec extends Specification {
     Request(bits.MethodAliases.GET, Uri.fromString(s).right.getOrElse(sys.error("Failed.")), headers = Headers(h: _*))
 
   "GET /test1" should {
-    val routes = new RhoService[IO] {
+    val routes = new RhoRoutes[IO] {
       GET / "test1" +? param[String]("param1") |>> { param1: String => Ok("test1:" + param1) }
     }.toRoutes()
 
@@ -32,7 +32,7 @@ class ParamDefaultValueSpec extends Specification {
   }
 
   "GET /test2" should {
-    val routes = new RhoService[IO] {
+    val routes = new RhoRoutes[IO] {
       GET / "test2" +? param[String]("param1", "default1") |>> { param1: String => Ok("test2:" + param1) }
     }.toRoutes()
 
@@ -52,7 +52,7 @@ class ParamDefaultValueSpec extends Specification {
   }
 
   "GET /test3" should {
-    val routes = new RhoService[IO] {
+    val routes = new RhoRoutes[IO] {
       GET / "test3" +? param[Int]("param1", 1) |>> { param1: Int => Ok("test3:" + param1) }
     }.toRoutes()
 
@@ -75,7 +75,7 @@ class ParamDefaultValueSpec extends Specification {
   }
 
   "GET /test4" should {
-    val routes = new RhoService[IO] {
+    val routes = new RhoRoutes[IO] {
       GET / "test4" +? param[Option[String]]("param1") |>> { os: Option[String] => Ok("test4:" + os.getOrElse("")) }
     }.toRoutes()
 
@@ -95,7 +95,7 @@ class ParamDefaultValueSpec extends Specification {
   }
 
   "GET /test5" should {
-    val routes = new RhoService[IO] {
+    val routes = new RhoRoutes[IO] {
       GET / "test5" +? param[Option[Int]]("param1", Some(100)) |>> { os: Option[Int] => Ok("test5:" + os.getOrElse("")) }
     }.toRoutes()
 
@@ -118,7 +118,7 @@ class ParamDefaultValueSpec extends Specification {
   }
 
   "GET /test6" should {
-    val routes = new RhoService[IO] {
+    val routes = new RhoRoutes[IO] {
       GET / "test6" +? param[Option[String]]("param1", Some("default1")) |>> { os: Option[String] => Ok("test6:" + os.getOrElse("")) }
     }.toRoutes()
 
@@ -138,7 +138,7 @@ class ParamDefaultValueSpec extends Specification {
   }
 
   "GET /test7" should {
-    val routes = new RhoService[IO] {
+    val routes = new RhoRoutes[IO] {
       GET / "test7" +? param[Seq[String]]("param1", Seq("a", "b")) |>> { os: Seq[String] => Ok("test7:" + os.mkString(",")) }
     }.toRoutes()
 
@@ -161,7 +161,7 @@ class ParamDefaultValueSpec extends Specification {
   }
 
   "GET /test8" should {
-    val routes = new RhoService[IO] {
+    val routes = new RhoRoutes[IO] {
       GET / "test8" +? param[Seq[Int]]("param1", Seq(3, 5, 8)) |>> { os: Seq[Int] => Ok("test8:" + os.mkString(",")) }
     }.toRoutes()
 
@@ -190,7 +190,7 @@ class ParamDefaultValueSpec extends Specification {
   }
 
   "GET /test9" should {
-    val routes = new RhoService[IO] {
+    val routes = new RhoRoutes[IO] {
       GET / "test9" +? param("param1", "default1", (p: String) => !p.isEmpty && p != "fail") |>> { param1: String => Ok("test9:" + param1) }
     }.toRoutes()
 
@@ -213,7 +213,7 @@ class ParamDefaultValueSpec extends Specification {
   }
 
   "GET /test10" should {
-    val routes = new RhoService[IO] {
+    val routes = new RhoRoutes[IO] {
       GET / "test10" +? param[Int]("param1", 1, (p: Int) => p >= 0) |>> { param1: Int => Ok("test10:" + param1) }
     }.toRoutes()
 
@@ -239,7 +239,7 @@ class ParamDefaultValueSpec extends Specification {
   }
 
   "GET /test11" should {
-    val routes = new RhoService[IO] {
+    val routes = new RhoRoutes[IO] {
       GET / "test11" +? param[Option[Int]]("param1", Some(100), (p: Option[Int]) => p != Some(0)) |>> { os: Option[Int] => Ok("test11:" + os.getOrElse("")) }
     }.toRoutes()
 
@@ -265,7 +265,7 @@ class ParamDefaultValueSpec extends Specification {
   }
 
   "GET /test12" should {
-    val routes = new RhoService[IO] {
+    val routes = new RhoRoutes[IO] {
       GET / "test12" +? param[Option[String]]("param1", Some("default1"), (p: Option[String]) => p != Some("fail") && p != Some("")) |>> { os: Option[String] => Ok("test12:" + os.getOrElse("")) }
     }.toRoutes()
 
@@ -288,7 +288,7 @@ class ParamDefaultValueSpec extends Specification {
   }
 
   "GET /test13" should {
-    val routes = new RhoService[IO] {
+    val routes = new RhoRoutes[IO] {
       GET / "test13" +? param[Seq[String]]("param1", Seq("a", "b"), (p: Seq[String]) => !p.contains("") && !p.contains("z")) |>> { os: Seq[String] => Ok("test13:" + os.mkString(",")) }
     }.toRoutes()
 
@@ -315,7 +315,7 @@ class ParamDefaultValueSpec extends Specification {
 
   "GET /test14" should {
 
-    val routes = new RhoService[IO] {
+    val routes = new RhoRoutes[IO] {
       GET / "test14" +? param[Seq[Int]]("param1", Seq(3, 5, 8), (p: Seq[Int]) => p != Seq(8, 5, 3)) |>> { os: Seq[Int] => Ok("test14:" + os.mkString(",")) }
     }.toRoutes()
 

--- a/core/src/test/scala/org/http4s/rho/ParamDefaultValueSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/ParamDefaultValueSpec.scala
@@ -6,340 +6,340 @@ import org.specs2.mutable.Specification
 
 class ParamDefaultValueSpec extends Specification {
 
-  def body(service: HttpRoutes[IO], r: Request[IO]): String =
-    new String(service(r).value.unsafeRunSync().getOrElse(Response.notFound).body.compile.toVector.unsafeRunSync().foldLeft(Array[Byte]())(_ :+ _))
+  def body(routes: HttpRoutes[IO], r: Request[IO]): String =
+    new String(routes(r).value.unsafeRunSync().getOrElse(Response.notFound).body.compile.toVector.unsafeRunSync().foldLeft(Array[Byte]())(_ :+ _))
 
   def requestGet(s: String, h: Header*): Request[IO] =
     Request(bits.MethodAliases.GET, Uri.fromString(s).right.getOrElse(sys.error("Failed.")), headers = Headers(h: _*))
 
   "GET /test1" should {
-    val service = new RhoService[IO] {
+    val routes = new RhoService[IO] {
       GET / "test1" +? param[String]("param1") |>> { param1: String => Ok("test1:" + param1) }
     }.toRoutes()
 
     "map parameter with default value" in {
-      body(service, requestGet("/test1")) must be equalTo "Missing query param: param1"
+      body(routes, requestGet("/test1")) must be equalTo "Missing query param: param1"
     }
     "map parameter with empty value" in {
-      body(service, requestGet("/test1?param1=")) must be equalTo "test1:"
+      body(routes, requestGet("/test1?param1=")) must be equalTo "test1:"
     }
     "map parameter with value" in {
-      body(service, requestGet("/test1?param1=value1")) must be equalTo "test1:value1"
+      body(routes, requestGet("/test1?param1=value1")) must be equalTo "test1:value1"
     }
     "map parameter without value" in {
-      body(service, requestGet("/test1?param1")) must be equalTo "Value of query parameter 'param1' missing"
+      body(routes, requestGet("/test1?param1")) must be equalTo "Value of query parameter 'param1' missing"
     }
   }
 
   "GET /test2" should {
-    val service = new RhoService[IO] {
+    val routes = new RhoService[IO] {
       GET / "test2" +? param[String]("param1", "default1") |>> { param1: String => Ok("test2:" + param1) }
     }.toRoutes()
 
     val default = "test2:default1"
     "map parameter with default value" in {
-      body(service, requestGet("/test2")) must be equalTo default
+      body(routes, requestGet("/test2")) must be equalTo default
     }
     "map parameter with empty value" in {
-      body(service, requestGet("/test2?param1=")) must be equalTo "test2:"
+      body(routes, requestGet("/test2?param1=")) must be equalTo "test2:"
     }
     "map parameter with value" in {
-      body(service, requestGet("/test2?param1=value1")) must be equalTo "test2:value1"
+      body(routes, requestGet("/test2?param1=value1")) must be equalTo "test2:value1"
     }
     "map parameter without value" in {
-      body(service, requestGet("/test2?param1")) must be equalTo default
+      body(routes, requestGet("/test2?param1")) must be equalTo default
     }
   }
 
   "GET /test3" should {
-    val service = new RhoService[IO] {
+    val routes = new RhoService[IO] {
       GET / "test3" +? param[Int]("param1", 1) |>> { param1: Int => Ok("test3:" + param1) }
     }.toRoutes()
 
     val default = "test3:1"
     "map parameter with default value" in {
-      body(service, requestGet("/test3")) must be equalTo default
+      body(routes, requestGet("/test3")) must be equalTo default
     }
     "fail to map parameter with empty value" in {
-      body(service, requestGet("/test3?param1=")) must be equalTo "Invalid number format: ''"
+      body(routes, requestGet("/test3?param1=")) must be equalTo "Invalid number format: ''"
     }
     "map parameter with numeric value" in {
-      body(service, requestGet("/test3?param1=12345")) must be equalTo "test3:12345"
+      body(routes, requestGet("/test3?param1=12345")) must be equalTo "test3:12345"
     }
     "fail to map parameter with non-numeric value" in {
-      body(service, requestGet("/test3?param1=value1")) must be equalTo "Invalid number format: 'value1'"
+      body(routes, requestGet("/test3?param1=value1")) must be equalTo "Invalid number format: 'value1'"
     }
     "map parameter without value" in {
-      body(service, requestGet("/test3?param1")) must be equalTo default
+      body(routes, requestGet("/test3?param1")) must be equalTo default
     }
   }
 
   "GET /test4" should {
-    val service = new RhoService[IO] {
+    val routes = new RhoService[IO] {
       GET / "test4" +? param[Option[String]]("param1") |>> { os: Option[String] => Ok("test4:" + os.getOrElse("")) }
     }.toRoutes()
 
     val default = "test4:"
     "map parameter with default value" in {
-      body(service, requestGet("/test4")) must be equalTo default
+      body(routes, requestGet("/test4")) must be equalTo default
     }
     "map parameter with empty value" in {
-      body(service, requestGet("/test4?param1=")) must be equalTo "test4:"
+      body(routes, requestGet("/test4?param1=")) must be equalTo "test4:"
     }
     "map parameter with value" in {
-      body(service, requestGet("/test4?param1=value1")) must be equalTo "test4:value1"
+      body(routes, requestGet("/test4?param1=value1")) must be equalTo "test4:value1"
     }
     "map parameter without value" in {
-      body(service, requestGet("/test4?param1")) must be equalTo "test4:"
+      body(routes, requestGet("/test4?param1")) must be equalTo "test4:"
     }
   }
 
   "GET /test5" should {
-    val service = new RhoService[IO] {
+    val routes = new RhoService[IO] {
       GET / "test5" +? param[Option[Int]]("param1", Some(100)) |>> { os: Option[Int] => Ok("test5:" + os.getOrElse("")) }
     }.toRoutes()
 
     val default = "test5:100"
     "map parameter with default value" in {
-      body(service, requestGet("/test5")) must be equalTo default
+      body(routes, requestGet("/test5")) must be equalTo default
     }
     "fail on parameter with empty value" in {
-      body(service, requestGet("/test5?param1=")) must be equalTo "Invalid number format: ''"
+      body(routes, requestGet("/test5?param1=")) must be equalTo "Invalid number format: ''"
     }
     "map parameter with numeric value" in {
-      body(service, requestGet("/test5?param1=12345")) must be equalTo "test5:12345"
+      body(routes, requestGet("/test5?param1=12345")) must be equalTo "test5:12345"
     }
     "fail on parameter with non-numeric value" in {
-      body(service, requestGet("/test5?param1=value1")) must be equalTo "Invalid number format: 'value1'"
+      body(routes, requestGet("/test5?param1=value1")) must be equalTo "Invalid number format: 'value1'"
     }
     "map parameter without value" in {
-      body(service, requestGet("/test5?param1")) must be equalTo default
+      body(routes, requestGet("/test5?param1")) must be equalTo default
     }
   }
 
   "GET /test6" should {
-    val service = new RhoService[IO] {
+    val routes = new RhoService[IO] {
       GET / "test6" +? param[Option[String]]("param1", Some("default1")) |>> { os: Option[String] => Ok("test6:" + os.getOrElse("")) }
     }.toRoutes()
 
     val default = "test6:default1"
     "map parameter with default value" in {
-      body(service, requestGet("/test6")) must be equalTo default
+      body(routes, requestGet("/test6")) must be equalTo default
     }
     "map parameter with empty value" in {
-      body(service, requestGet("/test6?param1=")) must be equalTo "test6:"
+      body(routes, requestGet("/test6?param1=")) must be equalTo "test6:"
     }
     "map parameter with value" in {
-      body(service, requestGet("/test6?param1=test12345")) must be equalTo "test6:test12345"
+      body(routes, requestGet("/test6?param1=test12345")) must be equalTo "test6:test12345"
     }
     "map parameter without value" in {
-      body(service, requestGet("/test6?param1")) must be equalTo default
+      body(routes, requestGet("/test6?param1")) must be equalTo default
     }
   }
 
   "GET /test7" should {
-    val service = new RhoService[IO] {
+    val routes = new RhoService[IO] {
       GET / "test7" +? param[Seq[String]]("param1", Seq("a", "b")) |>> { os: Seq[String] => Ok("test7:" + os.mkString(",")) }
     }.toRoutes()
 
     val default = "test7:a,b"
     "map parameter with default value" in {
-      body(service, requestGet("/test7")) must be equalTo default
+      body(routes, requestGet("/test7")) must be equalTo default
     }
     "map parameter with empty value" in {
-      body(service, requestGet("/test7?param1=")) must be equalTo "test7:"
+      body(routes, requestGet("/test7?param1=")) must be equalTo "test7:"
     }
     "map parameter with one value" in {
-      body(service, requestGet("/test7?param1=test12345")) must be equalTo "test7:test12345"
+      body(routes, requestGet("/test7?param1=test12345")) must be equalTo "test7:test12345"
     }
     "map parameter with many values" in {
-      body(service, requestGet("/test7?param1=test123&param1=test456&param1=test889")) must be equalTo "test7:test123,test456,test889"
+      body(routes, requestGet("/test7?param1=test123&param1=test456&param1=test889")) must be equalTo "test7:test123,test456,test889"
     }
     "map parameter without value" in {
-      body(service, requestGet("/test7?param1")) must be equalTo default
+      body(routes, requestGet("/test7?param1")) must be equalTo default
     }
   }
 
   "GET /test8" should {
-    val service = new RhoService[IO] {
+    val routes = new RhoService[IO] {
       GET / "test8" +? param[Seq[Int]]("param1", Seq(3, 5, 8)) |>> { os: Seq[Int] => Ok("test8:" + os.mkString(",")) }
     }.toRoutes()
 
     val default = "test8:3,5,8"
     "map parameter with default value" in {
-      body(service, requestGet("/test8")) must be equalTo default
+      body(routes, requestGet("/test8")) must be equalTo default
     }
     "fail to map parameter with empty value" in {
-      body(service, requestGet("/test8?param1=")) must be equalTo "Invalid number format: ''"
+      body(routes, requestGet("/test8?param1=")) must be equalTo "Invalid number format: ''"
     }
     "map parameter with one numeric value" in {
-      body(service, requestGet("/test8?param1=12345")) must be equalTo "test8:12345"
+      body(routes, requestGet("/test8?param1=12345")) must be equalTo "test8:12345"
     }
     "fail to map parameter with one non-numeric value" in {
-      body(service, requestGet("/test8?param1=test")) must be equalTo "Invalid number format: 'test'"
+      body(routes, requestGet("/test8?param1=test")) must be equalTo "Invalid number format: 'test'"
     }
     "map parameter with many numeric values" in {
-      body(service, requestGet("/test8?param1=123&param1=456&param1=789")) must be equalTo "test8:123,456,789"
+      body(routes, requestGet("/test8?param1=123&param1=456&param1=789")) must be equalTo "test8:123,456,789"
     }
     "fail to map parameter with many non-numeric values" in {
-      body(service, requestGet("/test8?param1=abc&param1=def")) must be equalTo "Invalid number format: 'abc'"
+      body(routes, requestGet("/test8?param1=abc&param1=def")) must be equalTo "Invalid number format: 'abc'"
     }
     "map parameter without value" in {
-      body(service, requestGet("/test8?param1")) must be equalTo default
+      body(routes, requestGet("/test8?param1")) must be equalTo default
     }
   }
 
   "GET /test9" should {
-    val service = new RhoService[IO] {
+    val routes = new RhoService[IO] {
       GET / "test9" +? param("param1", "default1", (p: String) => !p.isEmpty && p != "fail") |>> { param1: String => Ok("test9:" + param1) }
     }.toRoutes()
 
     val default = "test9:default1"
     "map parameter with default value" in {
-      body(service, requestGet("/test9")) must be equalTo default
+      body(routes, requestGet("/test9")) must be equalTo default
     }
     "fail to map parameter with empty value" in {
-      body(service, requestGet("/test9?param1=")) must be equalTo "Invalid query parameter: \"param1\" = \"\""
+      body(routes, requestGet("/test9?param1=")) must be equalTo "Invalid query parameter: \"param1\" = \"\""
     }
     "fail to map parameter with invalid value" in {
-      body(service, requestGet("/test9?param1=fail")) must be equalTo "Invalid query parameter: \"param1\" = \"fail\""
+      body(routes, requestGet("/test9?param1=fail")) must be equalTo "Invalid query parameter: \"param1\" = \"fail\""
     }
     "map parameter with valid value" in {
-      body(service, requestGet("/test9?param1=pass")) must be equalTo "test9:pass"
+      body(routes, requestGet("/test9?param1=pass")) must be equalTo "test9:pass"
     }
     "map parameter without value" in {
-      body(service, requestGet("/test9?param1")) must be equalTo default
+      body(routes, requestGet("/test9?param1")) must be equalTo default
     }
   }
 
   "GET /test10" should {
-    val service = new RhoService[IO] {
+    val routes = new RhoService[IO] {
       GET / "test10" +? param[Int]("param1", 1, (p: Int) => p >= 0) |>> { param1: Int => Ok("test10:" + param1) }
     }.toRoutes()
 
     val default = "test10:1"
     "map parameter with default value" in {
-      body(service, requestGet("/test10")) must be equalTo default
+      body(routes, requestGet("/test10")) must be equalTo default
     }
     "fail to map parameter with empty value" in {
-      body(service, requestGet("/test10?param1=")) must be equalTo "Invalid number format: ''"
+      body(routes, requestGet("/test10?param1=")) must be equalTo "Invalid number format: ''"
     }
     "fail to map parameter with invalid numeric value" in {
-      body(service, requestGet("/test10?param1=-4")) must be equalTo "Invalid query parameter: \"param1\" = \"-4\""
+      body(routes, requestGet("/test10?param1=-4")) must be equalTo "Invalid query parameter: \"param1\" = \"-4\""
     }
     "fail to map parameter with non-numeric value" in {
-      body(service, requestGet("/test10?param1=value1")) must be equalTo "Invalid number format: 'value1'"
+      body(routes, requestGet("/test10?param1=value1")) must be equalTo "Invalid number format: 'value1'"
     }
     "map parameter with valid numeric value" in {
-      body(service, requestGet("/test10?param1=10")) must be equalTo "test10:10"
+      body(routes, requestGet("/test10?param1=10")) must be equalTo "test10:10"
     }
     "map parameter without value" in {
-      body(service, requestGet("/test10?param1")) must be equalTo default
+      body(routes, requestGet("/test10?param1")) must be equalTo default
     }
   }
 
   "GET /test11" should {
-    val service = new RhoService[IO] {
+    val routes = new RhoService[IO] {
       GET / "test11" +? param[Option[Int]]("param1", Some(100), (p: Option[Int]) => p != Some(0)) |>> { os: Option[Int] => Ok("test11:" + os.getOrElse("")) }
     }.toRoutes()
 
     val default = "test11:100"
     "map parameter with default value" in {
-      body(service, requestGet("/test11")) must be equalTo default
+      body(routes, requestGet("/test11")) must be equalTo default
     }
     "fail to map parameter with empty value" in {
-      body(service, requestGet("/test11?param1=")) must be equalTo "Invalid number format: ''"
+      body(routes, requestGet("/test11?param1=")) must be equalTo "Invalid number format: ''"
     }
     "fail to map parameter with invalid numeric value" in {
-      body(service, requestGet("/test11?param1=0")) must be equalTo "Invalid query parameter: \"param1\" = \"Some(0)\""
+      body(routes, requestGet("/test11?param1=0")) must be equalTo "Invalid query parameter: \"param1\" = \"Some(0)\""
     }
     "fail to map parameter with non-numeric value" in {
-      body(service, requestGet("/test11?param1=value1")) must be equalTo "Invalid number format: 'value1'"
+      body(routes, requestGet("/test11?param1=value1")) must be equalTo "Invalid number format: 'value1'"
     }
     "map parameter with valid numeric value" in {
-      body(service, requestGet("/test11?param1=1")) must be equalTo "test11:1"
+      body(routes, requestGet("/test11?param1=1")) must be equalTo "test11:1"
     }
     "map parameter without value" in {
-      body(service, requestGet("/test11?param1")) must be equalTo default
+      body(routes, requestGet("/test11?param1")) must be equalTo default
     }
   }
 
   "GET /test12" should {
-    val service = new RhoService[IO] {
+    val routes = new RhoService[IO] {
       GET / "test12" +? param[Option[String]]("param1", Some("default1"), (p: Option[String]) => p != Some("fail") && p != Some("")) |>> { os: Option[String] => Ok("test12:" + os.getOrElse("")) }
     }.toRoutes()
 
     val default = "test12:default1"
     "map parameter with default value" in {
-      body(service, requestGet("/test12")) must be equalTo default
+      body(routes, requestGet("/test12")) must be equalTo default
     }
     "fail to map parameter with empty value" in {
-      body(service, requestGet("/test12?param1=")) must be equalTo "Invalid query parameter: \"param1\" = \"Some()\""
+      body(routes, requestGet("/test12?param1=")) must be equalTo "Invalid query parameter: \"param1\" = \"Some()\""
     }
     "fail to map parameter with invalid value" in {
-      body(service, requestGet("/test12?param1=fail")) must be equalTo "Invalid query parameter: \"param1\" = \"Some(fail)\""
+      body(routes, requestGet("/test12?param1=fail")) must be equalTo "Invalid query parameter: \"param1\" = \"Some(fail)\""
     }
     "map parameter with valid value" in {
-      body(service, requestGet("/test12?param1=pass")) must be equalTo "test12:pass"
+      body(routes, requestGet("/test12?param1=pass")) must be equalTo "test12:pass"
     }
     "map parameter without value" in {
-      body(service, requestGet("/test12?param1")) must be equalTo default
+      body(routes, requestGet("/test12?param1")) must be equalTo default
     }
   }
 
   "GET /test13" should {
-    val service = new RhoService[IO] {
+    val routes = new RhoService[IO] {
       GET / "test13" +? param[Seq[String]]("param1", Seq("a", "b"), (p: Seq[String]) => !p.contains("") && !p.contains("z")) |>> { os: Seq[String] => Ok("test13:" + os.mkString(",")) }
     }.toRoutes()
 
     val default = "test13:a,b"
     "map parameter with default value" in {
-      body(service, requestGet("/test13")) must be equalTo default
+      body(routes, requestGet("/test13")) must be equalTo default
     }
     "fail to map parameter with empty value" in {
-      body(service, requestGet("/test13?param1=")) must be equalTo "Invalid query parameter: \"param1\" = \"List()\""
+      body(routes, requestGet("/test13?param1=")) must be equalTo "Invalid query parameter: \"param1\" = \"List()\""
     }
     "fail to map parameter with one invalid value" in {
-      body(service, requestGet("/test13?param1=z")) must be equalTo "Invalid query parameter: \"param1\" = \"List(z)\""
+      body(routes, requestGet("/test13?param1=z")) must be equalTo "Invalid query parameter: \"param1\" = \"List(z)\""
     }
     "map parameter with many values and one invalid" in {
-      body(service, requestGet("/test13?param1=z&param1=aa&param1=bb")) must be equalTo "Invalid query parameter: \"param1\" = \"List(z, aa, bb)\""
+      body(routes, requestGet("/test13?param1=z&param1=aa&param1=bb")) must be equalTo "Invalid query parameter: \"param1\" = \"List(z, aa, bb)\""
     }
     "map parameter with many valid values" in {
-      body(service, requestGet("/test13?param1=c&param1=d")) must be equalTo "test13:c,d"
+      body(routes, requestGet("/test13?param1=c&param1=d")) must be equalTo "test13:c,d"
     }
     "map parameter without value" in {
-      body(service, requestGet("/test13?param1")) must be equalTo default
+      body(routes, requestGet("/test13?param1")) must be equalTo default
     }
   }
 
   "GET /test14" should {
 
-    val service = new RhoService[IO] {
+    val routes = new RhoService[IO] {
       GET / "test14" +? param[Seq[Int]]("param1", Seq(3, 5, 8), (p: Seq[Int]) => p != Seq(8, 5, 3)) |>> { os: Seq[Int] => Ok("test14:" + os.mkString(",")) }
     }.toRoutes()
 
     val default = "test14:3,5,8"
     "map parameter with default value" in {
-      body(service, requestGet("/test14")) must be equalTo default
+      body(routes, requestGet("/test14")) must be equalTo default
     }
     "fail to map parameter with empty value" in {
-      body(service, requestGet("/test14?param1=")) must be equalTo "Invalid number format: ''"
+      body(routes, requestGet("/test14?param1=")) must be equalTo "Invalid number format: ''"
     }
     "fail to map parameter with one invalid numeric value" in {
-      body(service, requestGet("/test14?param1=8&param1=5&param1=3")) must be equalTo "Invalid query parameter: \"param1\" = \"List(8, 5, 3)\""
+      body(routes, requestGet("/test14?param1=8&param1=5&param1=3")) must be equalTo "Invalid query parameter: \"param1\" = \"List(8, 5, 3)\""
     }
     "fail to map parameter with one non-numeric value" in {
-      body(service, requestGet("/test14?param1=test")) must be equalTo "Invalid number format: 'test'"
+      body(routes, requestGet("/test14?param1=test")) must be equalTo "Invalid number format: 'test'"
     }
     "fail to map parameter with many non-numeric values" in {
-      body(service, requestGet("/test14?param1=abc&param1=def")) must be equalTo "Invalid number format: 'abc'"
+      body(routes, requestGet("/test14?param1=abc&param1=def")) must be equalTo "Invalid number format: 'abc'"
     }
     "map parameter with many valid numeric values" in {
-      body(service, requestGet("/test14?param1=1&param1=2&param1=3")) must be equalTo "test14:1,2,3"
+      body(routes, requestGet("/test14?param1=1&param1=2&param1=3")) must be equalTo "test14:1,2,3"
     }
     "map parameter without value" in {
-      body(service, requestGet("/test14?param1")) must be equalTo default
+      body(routes, requestGet("/test14?param1")) must be equalTo default
     }
   }
 }

--- a/core/src/test/scala/org/http4s/rho/RequestRunner.scala
+++ b/core/src/test/scala/org/http4s/rho/RequestRunner.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 import org.http4s._
 import org.http4s.HttpRoutes
 
-/** Helper for collecting a the body from a `RhoService` */
+/** Helper for collecting a the body from a `RhoRoutes` */
 trait RequestRunner {
 
   def httpRoutes: HttpRoutes[IO]

--- a/core/src/test/scala/org/http4s/rho/RequestRunner.scala
+++ b/core/src/test/scala/org/http4s/rho/RequestRunner.scala
@@ -7,24 +7,25 @@ import org.http4s.HttpRoutes
 /** Helper for collecting a the body from a `RhoService` */
 trait RequestRunner {
 
-  def service: HttpRoutes[IO]
+  def httpRoutes: HttpRoutes[IO]
 
-  def checkOk(r: Request[IO]): String = checkStatus(r)(_ == Status.Ok)
+  def checkOk(req: Request[IO]): String = checkStatus(req)(_ == Status.Ok)
 
-  def checkError(r: Request[IO]): String = checkStatus(r)(_ != Status.Ok)
+  def checkError(req: Request[IO]): String = checkStatus(req)(_ != Status.Ok)
 
-  def checkStatus(r: Request[IO])(isSuccess: Status => Boolean) = {
-    val resp = service(r).value.unsafeRunSync().getOrElse(Response.notFound)
+  def checkStatus(req: Request[IO])(isSuccess: Status => Boolean): String = {
+    val resp = httpRoutes(req).value.unsafeRunSync().getOrElse(Response.notFound)
     if (isSuccess(resp.status)) getBody(resp.body)
     else sys.error(s"Invalid response code: ${resp.status}")
   }
 
   val getBody = RequestRunner.getBody _
 }
+
 object RequestRunner {
   def getBody(b: EntityBody[IO]): String = {
     new String(b.compile.toVector.unsafeRunSync.foldLeft(Array[Byte]())(_ :+ _))
   }
 }
 
-case class RRunner(service: HttpRoutes[IO]) extends RequestRunner
+case class RRunner(httpRoutes: HttpRoutes[IO]) extends RequestRunner

--- a/core/src/test/scala/org/http4s/rho/RequestRunner.scala
+++ b/core/src/test/scala/org/http4s/rho/RequestRunner.scala
@@ -2,13 +2,12 @@ package org.http4s.rho
 
 import cats.effect.IO
 import org.http4s._
-import org.http4s.HttpService
-import scodec.bits.ByteVector
+import org.http4s.HttpRoutes
 
 /** Helper for collecting a the body from a `RhoService` */
 trait RequestRunner {
 
-  def service: HttpService[IO]
+  def service: HttpRoutes[IO]
 
   def checkOk(r: Request[IO]): String = checkStatus(r)(_ == Status.Ok)
 
@@ -24,8 +23,8 @@ trait RequestRunner {
 }
 object RequestRunner {
   def getBody(b: EntityBody[IO]): String = {
-    new String(b.compile.toVector.unsafeRunSync.foldLeft(ByteVector.empty)(_ :+ _).toArray)
+    new String(b.compile.toVector.unsafeRunSync.foldLeft(Array[Byte]())(_ :+ _))
   }
 }
 
-case class RRunner(service: HttpService[IO]) extends RequestRunner
+case class RRunner(service: HttpRoutes[IO]) extends RequestRunner

--- a/core/src/test/scala/org/http4s/rho/ResultSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/ResultSpec.scala
@@ -45,7 +45,7 @@ class ResultSpec extends Specification {
     "Add a body" in {
       val newbody = "foobar"
       val resp = Ok("foo")
-        .flatMap(_.withBody(newbody))
+        .map(_.withEntity(newbody))
         .unsafeRunSync()
         .resp
 
@@ -53,7 +53,7 @@ class ResultSpec extends Specification {
       resp.headers.get(`Content-Length`) must beSome(`Content-Length`.unsafeFromLong(newbody.getBytes.length))
 
       val resp2 = Ok("foo")
-        .flatMap(_.withBody(newbody))
+        .map(_.withEntity(newbody))
         .unsafeRunSync()
         .resp
 

--- a/core/src/test/scala/org/http4s/rho/RhoRoutesSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/RhoRoutesSpec.scala
@@ -348,15 +348,15 @@ class RhoRoutesSpec extends Specification with RequestRunner {
         GET / "foo2" |>> "Foo2"
       }
       val both: RhoRoutes[IO] = routes1 and routes2
-      val bothService = both.toRoutes()
+      val bothRoutes = both.toRoutes()
 
       both.getRoutes === routes1.getRoutes ++ routes2.getRoutes
 
       val req1 = Request[IO](uri = uri("foo1"))
-      getBody(bothService(req1).value.unsafeRunSync().getOrElse(Response.notFound).body) === "Foo1"
+      getBody(bothRoutes(req1).value.unsafeRunSync().getOrElse(Response.notFound).body) === "Foo1"
 
       val req2 = Request[IO](uri = uri("foo2"))
-      getBody(bothService(req2).value.unsafeRunSync().getOrElse(Response.notFound).body) === "Foo2"
+      getBody(bothRoutes(req2).value.unsafeRunSync().getOrElse(Response.notFound).body) === "Foo2"
     }
   }
 

--- a/core/src/test/scala/org/http4s/rho/bits/HListToFuncSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/bits/HListToFuncSpec.scala
@@ -4,11 +4,10 @@ package bits
 
 import cats.effect.IO
 import org.specs2.mutable.Specification
-import scodec.bits.ByteVector
 
 class HListToFuncSpec extends Specification {
   def getBody(b: EntityBody[IO]): String = {
-    new String(b.compile.toVector.unsafeRunSync().foldLeft(ByteVector.empty)(_ :+ _).toArray)
+    new String(b.compile.toVector.unsafeRunSync().foldLeft(Array[Byte]())(_ :+ _))
   }
 
   def checkOk(r: Request[IO]): String = getBody(service(r).value.unsafeRunSync().getOrElse(Response.notFound).body)
@@ -18,7 +17,7 @@ class HListToFuncSpec extends Specification {
 
   val service = new RhoService[IO] {
     GET / "route1" |>> { () => Ok("foo") }
-  }.toService()
+  }.toRoutes()
 
   "HListToFunc" should {
     "Work for methods of type _ => Task[Response]" in {
@@ -28,10 +27,9 @@ class HListToFuncSpec extends Specification {
 
     // Tests issue 218 https://github.com/http4s/rho/issues/218
     "Work with cats.implicits" in {
-      import cats.implicits._
       new RhoService[IO] {
         // `.pure[IO]` used to require the cats.implicits under test
-        GET / "route1" |>> { () => Ok("foo".pure[IO]) }
+        GET / "route1" |>> { () => Ok("foo") }
       }
       success
     }

--- a/core/src/test/scala/org/http4s/rho/bits/HListToFuncSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/bits/HListToFuncSpec.scala
@@ -15,7 +15,7 @@ class HListToFuncSpec extends Specification {
   def Get(s: String, h: Header*): Request[IO] =
     Request(bits.MethodAliases.GET, Uri.fromString(s).right.getOrElse(sys.error("Failed.")), headers = Headers(h:_*))
 
-  val service = new RhoService[IO] {
+  val service = new RhoRoutes[IO] {
     GET / "route1" |>> { () => Ok("foo") }
   }.toRoutes()
 
@@ -28,7 +28,7 @@ class HListToFuncSpec extends Specification {
     // Tests issue 218 https://github.com/http4s/rho/issues/218
     "Work with cats.implicits" in {
       import cats.implicits._
-      new RhoService[IO] {
+      new RhoRoutes[IO] {
         // `.pure[IO]` used to require the cats.implicits under test
         GET / "route1" |>> { () => "foo".pure[IO].flatMap(Ok(_)) }
       }

--- a/core/src/test/scala/org/http4s/rho/bits/HListToFuncSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/bits/HListToFuncSpec.scala
@@ -27,9 +27,10 @@ class HListToFuncSpec extends Specification {
 
     // Tests issue 218 https://github.com/http4s/rho/issues/218
     "Work with cats.implicits" in {
+      import cats.implicits._
       new RhoService[IO] {
         // `.pure[IO]` used to require the cats.implicits under test
-        GET / "route1" |>> { () => Ok("foo") }
+        GET / "route1" |>> { () => "foo".pure[IO].flatMap(Ok(_)) }
       }
       success
     }

--- a/core/src/test/scala/org/http4s/rho/bits/PathTreeSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/bits/PathTreeSpec.scala
@@ -36,7 +36,7 @@ class PathTreeSpec extends Specification {
   }
 
   "Honor UriTranslations" in {
-    val svc = TranslateUri("/bar")(Router.define[IO](("/", new RhoService[IO] {
+    val svc = TranslateUri("/bar")(Router.define[IO](("/", new RhoRoutes[IO] {
       GET / "foo" |>> "foo"
     }.toRoutes()))(HttpRoutes.empty[IO]))
 
@@ -49,7 +49,7 @@ class PathTreeSpec extends Specification {
   }
 
   "PathTree OPTIONS" should {
-    val svc = new RhoService[IO] {
+    val svc = new RhoRoutes[IO] {
       GET / "foo" |>> "foo"
 
       OPTIONS / "bar" |>> "foo"

--- a/core/src/test/scala/org/http4s/rho/bits/PathTreeSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/bits/PathTreeSpec.scala
@@ -5,9 +5,9 @@ package bits
 import java.nio.charset.StandardCharsets
 
 import cats.effect.IO
+import org.http4s.server.Router
 import org.http4s.server.middleware.TranslateUri
 import org.specs2.mutable.Specification
-import scodec.bits.ByteVector
 
 class PathTreeSpec extends Specification {
   import PathTree._
@@ -36,15 +36,15 @@ class PathTreeSpec extends Specification {
   }
 
   "Honor UriTranslations" in {
-    val svc = TranslateUri[IO]("/bar")(new RhoService[IO] {
+    val svc = TranslateUri("/bar")(Router.define[IO](("/", new RhoService[IO] {
       GET / "foo" |>> "foo"
-    }.toService())
+    }.toRoutes()))(HttpRoutes.empty[IO]))
 
     val req = Request[IO](Method.GET, uri = Uri(path = "/bar/foo"))
     val resp = svc(req).value.unsafeRunSync().getOrElse(Response.notFound)
 
     resp.status must_== Status.Ok
-    val b = new String(resp.body.compile.toVector.unsafeRunSync().foldLeft(ByteVector.empty)(_ :+ _).toArray, StandardCharsets.UTF_8)
+    val b = new String(resp.body.compile.toVector.unsafeRunSync().foldLeft(Array[Byte]())(_ :+ _), StandardCharsets.UTF_8)
     b must_== "foo"
   }
 
@@ -53,7 +53,7 @@ class PathTreeSpec extends Specification {
       GET / "foo" |>> "foo"
 
       OPTIONS / "bar" |>> "foo"
-    }.toService()
+    }.toRoutes()
 
     "Handle a valid OPTIONS request" in {
       val req = Request[IO](Method.OPTIONS, uri = uri("/bar"))

--- a/core/src/test/scala/org/http4s/rho/bits/ResponseGeneratorSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/bits/ResponseGeneratorSpec.scala
@@ -5,7 +5,6 @@ import org.http4s._
 import org.http4s.headers.{Location, `Content-Length`, `Content-Type`, `Transfer-Encoding`}
 import org.http4s.rho.io._
 import org.specs2.mutable.Specification
-import scodec.bits.ByteVector
 
 class ResponseGeneratorSpec extends Specification {
   "ResponseGenerator" should {
@@ -13,7 +12,7 @@ class ResponseGeneratorSpec extends Specification {
       val result = Ok("Foo").unsafeRunSync()
       val resp = result.resp
 
-      val str = new String(resp.body.compile.toVector.unsafeRunSync().foldLeft(ByteVector.empty)(_ :+ _).toArray)
+      val str = new String(resp.body.compile.toVector.unsafeRunSync().foldLeft(Array[Byte]())(_ :+ _))
       str must_== "Foo"
 
       resp.headers.get(`Content-Length`) must beSome(`Content-Length`.unsafeFromLong("Foo".getBytes.length))
@@ -44,10 +43,10 @@ class ResponseGeneratorSpec extends Specification {
 
     "Explicitly added headers have priority" in {
       implicit val w: EntityEncoder[IO, String] =
-        EntityEncoder.encodeBy[IO, String](`Content-Type`(MediaType.`text/html`))(EntityEncoder.stringEncoder[IO].toEntity(_))
+        EntityEncoder.encodeBy[IO, String](`Content-Type`(MediaType.text.html))(EntityEncoder.stringEncoder[IO].toEntity(_))
 
-      Ok("some content", Headers(`Content-Type`(MediaType.`application/json`)))
-        .unsafeRunSync().resp.headers.get(`Content-Type`).get must_== `Content-Type`(MediaType.`application/json`)
+      Ok("some content", Headers(`Content-Type`(MediaType.application.json)))
+        .unsafeRunSync().resp.headers.get(`Content-Type`).get must_== `Content-Type`(MediaType.application.json)
     }
   }
 }

--- a/core/src/test/scala/org/http4s/rho/bits/ResultMatcherSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/bits/ResultMatcherSpec.scala
@@ -17,8 +17,8 @@ class ResultMatcherSpec extends Specification {
   class TRhoService[F[_]] extends bits.MethodAliases {
     var statuses: Set[(Status, Type)] = Set.empty
 
-    implicit final protected def compileSrvc: CompileService[F, RhoRoute.Tpe[F]] = {
-      new CompileService[F, RhoRoute.Tpe[F]] {
+    implicit final protected def compileSrvc: CompileRoutes[F, RhoRoute.Tpe[F]] = {
+      new CompileRoutes[F, RhoRoute.Tpe[F]] {
         override def compile[T <: HList](route: RhoRoute[F, T]): RhoRoute.Tpe[F] = {
           statuses = route.resultInfo.collect { case StatusAndType(s, t) => (s, t) }
           route

--- a/core/src/test/scala/org/http4s/rho/bits/ResultMatcherSpec.scala
+++ b/core/src/test/scala/org/http4s/rho/bits/ResultMatcherSpec.scala
@@ -14,7 +14,7 @@ import scala.reflect.runtime.universe._
 
 class ResultMatcherSpec extends Specification {
 
-  class TRhoService[F[_]] extends bits.MethodAliases {
+  class TRhoRoutes[F[_]] extends bits.MethodAliases {
     var statuses: Set[(Status, Type)] = Set.empty
 
     implicit final protected def compileSrvc: CompileRoutes[F, RhoRoute.Tpe[F]] = {
@@ -29,7 +29,7 @@ class ResultMatcherSpec extends Specification {
 
   "ResponseGenerator" should {
     "Match a single result type" in {
-      val srvc = new TRhoService[IO] {
+      val srvc = new TRhoRoutes[IO] {
         PUT / "foo" |>> { () => Ok("updated").unsafeRunSync() }
       }
 
@@ -37,7 +37,7 @@ class ResultMatcherSpec extends Specification {
     }
 
     "Match two results with different status with different result type" in {
-      val srvc = new TRhoService[IO] {
+      val srvc = new TRhoRoutes[IO] {
         PUT / "foo" |>> { () =>
           val a = 0
           a match {
@@ -53,7 +53,7 @@ class ResultMatcherSpec extends Specification {
     }
 
     "Match two results with same stat different result type" in {
-      val srvc = new TRhoService[IO] {
+      val srvc = new TRhoRoutes[IO] {
         PUT / "foo" |>> { () =>
           val a = 0
           a match {
@@ -67,7 +67,7 @@ class ResultMatcherSpec extends Specification {
     }
 
     "Match an empty result type" in {
-      val srvc = new TRhoService[IO] {
+      val srvc = new TRhoRoutes[IO] {
         PUT / "foo" |>> { () => NoContent.apply }
       }
 
@@ -76,7 +76,7 @@ class ResultMatcherSpec extends Specification {
     }
 
     "Match three results with different status but same result type" in {
-      val srvc = new TRhoService[IO] {
+      val srvc = new TRhoRoutes[IO] {
         PUT / "foo" |>> { () =>
           val a = 0
           a match {
@@ -91,7 +91,7 @@ class ResultMatcherSpec extends Specification {
     }
 
     "Match four results with different status but same result type" in {
-      val srvc = new TRhoService[IO] {
+      val srvc = new TRhoRoutes[IO] {
         PUT / "foo" |>> { () =>
           val a = 0
           a match {
@@ -117,7 +117,7 @@ class ResultMatcherSpec extends Specification {
       implicit def w2[F[_]: Applicative]: EntityEncoder[F, ModelB] =
         EntityEncoder.simple[F, ModelB]()(_ => Chunk.bytes("B".getBytes))
 
-      val srvc = new TRhoService[IO] {
+      val srvc = new TRhoRoutes[IO] {
         GET / "foo" |>> { () =>
           if (true) Ok(ModelA("test ok", 1))
           else NotFound(ModelB("test not found", 234))
@@ -134,7 +134,7 @@ class ResultMatcherSpec extends Specification {
     "Match complex models as well as simple ones" in {
       import Foo._
 
-      val srvc = new TRhoService[IO] {
+      val srvc = new TRhoRoutes[IO] {
         GET / "foo" |>> { () =>
           if (true) Ok(FooA("test ok", 1))
           else NotFound(FooB("test not found", 234))

--- a/examples/project/build.properties
+++ b/examples/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.5

--- a/examples/project/build.properties
+++ b/examples/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.5
+sbt.version=1.2.3

--- a/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/Main.scala
+++ b/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/Main.scala
@@ -16,8 +16,7 @@ object Main extends IOApp {
   logger.info(s"Starting Hal example on '$port'")
 
   def run(args: List[String]): IO[ExitCode] = {
-    val businessLayer =
-      new UADetectorDatabase(new ResourceModuleXmlDataStore())
+    val businessLayer = new UADetectorDatabase(new ResourceModuleXmlDataStore())
 
     val routes =
       new Routes(businessLayer)

--- a/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/Main.scala
+++ b/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/Main.scala
@@ -1,7 +1,8 @@
 package com.http4s.rho.hal.plus.swagger.demo
 
-import cats.effect.{ExitCode, IO, IOApp}
 import cats.syntax.semigroupk._
+import cats.syntax.functor._
+import cats.effect.{ExitCode, IO, IOApp}
 import net.sf.uadetector.service.UADetectorServiceFactory.ResourceModuleXmlDataStore
 import org.http4s.server.blaze.BlazeBuilder
 import org.log4s.getLogger
@@ -24,6 +25,6 @@ object Main extends IOApp {
     BlazeBuilder[IO]
       .mountService(routes.staticContent combineK routes.dynamicContent, "")
       .bindLocal(port)
-      .serve.compile.toList.map(_.head)
+      .serve.compile.drain.as(ExitCode.Success)
   }
 }

--- a/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/Main.scala
+++ b/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/Main.scala
@@ -1,15 +1,12 @@
 package com.http4s.rho.hal.plus.swagger.demo
 
-import cats.effect.IO
+import cats.effect.{ExitCode, IO, IOApp}
 import cats.syntax.semigroupk._
-import fs2.StreamApp.ExitCode
-import fs2.{Stream, StreamApp}
 import net.sf.uadetector.service.UADetectorServiceFactory.ResourceModuleXmlDataStore
 import org.http4s.server.blaze.BlazeBuilder
 import org.log4s.getLogger
-import scala.concurrent.ExecutionContext.Implicits.global
 
-object Main extends StreamApp[IO] {
+object Main extends IOApp {
   private val logger = getLogger
 
   val port: Int = Option(System.getenv("HTTP_PORT"))
@@ -18,7 +15,7 @@ object Main extends StreamApp[IO] {
 
   logger.info(s"Starting Hal example on '$port'")
 
-  def stream(args: List[String], requestShutdown: IO[Unit]): Stream[IO, ExitCode] = {
+  def run(args: List[String]): IO[ExitCode] = {
     val businessLayer =
       new UADetectorDatabase(new ResourceModuleXmlDataStore())
 
@@ -28,6 +25,6 @@ object Main extends StreamApp[IO] {
     BlazeBuilder[IO]
       .mountService(routes.staticContent combineK routes.dynamicContent, "")
       .bindLocal(port)
-      .serve
+      .serve.compile.toList.map(_.head)
   }
 }

--- a/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/RestRoutes.scala
+++ b/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/RestRoutes.scala
@@ -1,13 +1,13 @@
 package com.http4s.rho.hal.plus.swagger.demo
 
 import cats.Monad
-import org.http4s.rho.RhoService
+import org.http4s.rho.RhoRoutes
 import org.http4s.rho.hal.{ResourceObjectBuilder => ResObjBuilder, _}
 import org.http4s.{Request, Uri}
 
 import scala.collection.mutable.ListBuffer
 
-class RestService[F[+_]: Monad](val businessLayer: BusinessLayer) extends RhoService[F] {
+class RestRoutes[F[+_]: Monad](val businessLayer: BusinessLayer) extends RhoRoutes[F] {
 
   // # Query Parameters
 

--- a/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/Routes.scala
+++ b/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/Routes.scala
@@ -11,7 +11,7 @@ class Routes(businessLayer: BusinessLayer)(implicit T: Timer[IO], cs: ContextShi
     createRhoMiddleware()
 
   val dynamicContent: HttpRoutes[IO] =
-    new RestService[IO](businessLayer).toRoutes(middleware)
+    new RestRoutes[IO](businessLayer).toRoutes(middleware)
 
   /**
    * Routes for getting static resources. These might be served more efficiently by apache2 or nginx,

--- a/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/Routes.scala
+++ b/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/Routes.scala
@@ -1,7 +1,7 @@
 package com.http4s.rho.hal.plus.swagger.demo
 
 import cats.effect.IO
-import org.http4s.HttpService
+import org.http4s.{HttpRoutes}
 import org.http4s.rho.RhoMiddleware
 import org.http4s.rho.swagger.syntax.io._
 
@@ -10,14 +10,14 @@ class Routes(businessLayer: BusinessLayer) {
   val middleware: RhoMiddleware[IO] =
     createRhoMiddleware()
 
-  val dynamicContent: HttpService[IO] =
-    new RestService[IO](businessLayer).toService(middleware)
+  val dynamicContent: HttpRoutes[IO] =
+    new RestService[IO](businessLayer).toRoutes(middleware)
 
   /**
    * Routes for getting static resources. These might be served more efficiently by apache2 or nginx,
    * but its nice to keep it self contained
    */
-  val staticContent: HttpService[IO] =
+  val staticContent: HttpRoutes[IO] =
     new StaticContentService[IO](org.http4s.dsl.io) {}.routes
 
 }

--- a/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/Routes.scala
+++ b/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/Routes.scala
@@ -1,11 +1,11 @@
 package com.http4s.rho.hal.plus.swagger.demo
 
-import cats.effect.IO
-import org.http4s.{HttpRoutes}
+import cats.effect.{ContextShift, IO, Timer}
+import org.http4s.HttpRoutes
 import org.http4s.rho.RhoMiddleware
 import org.http4s.rho.swagger.syntax.io._
 
-class Routes(businessLayer: BusinessLayer) {
+class Routes(businessLayer: BusinessLayer)(implicit T: Timer[IO], cs: ContextShift[IO]) {
 
   val middleware: RhoMiddleware[IO] =
     createRhoMiddleware()

--- a/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/StaticContentService.scala
+++ b/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/StaticContentService.scala
@@ -1,18 +1,20 @@
 package com.http4s.rho.hal.plus.swagger.demo
 
 import cats.data.OptionT
-import cats.effect.Sync
+import cats.effect.{ContextShift, Sync, Timer}
 import org.http4s.dsl.Http4sDsl
 import org.http4s.{HttpRoutes, Request, Response, StaticFile}
 
-abstract class StaticContentService[F[_]: Sync](dsl: Http4sDsl[F]) {
+import scala.concurrent.ExecutionContext.global
+
+abstract class StaticContentService[F[_]: Sync : Timer : ContextShift](dsl: Http4sDsl[F]) {
   import dsl._
 
   private val halUiDir = "/hal-browser"
   private val swaggerUiDir = "/swagger-ui"
 
   def fetchResource(path: String, req: Request[F]): OptionT[F, Response[F]] = {
-    StaticFile.fromResource(path, Some(req))
+    StaticFile.fromResource(path, global, Some(req))
   }
 
   /**

--- a/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/StaticContentService.scala
+++ b/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/StaticContentService.scala
@@ -1,8 +1,9 @@
 package com.http4s.rho.hal.plus.swagger.demo
 
+import cats.data.OptionT
 import cats.effect.Sync
 import org.http4s.dsl.Http4sDsl
-import org.http4s.{HttpService, Request, Response, StaticFile}
+import org.http4s.{HttpRoutes, Request, Response, StaticFile}
 
 abstract class StaticContentService[F[_]: Sync](dsl: Http4sDsl[F]) {
   import dsl._
@@ -10,15 +11,15 @@ abstract class StaticContentService[F[_]: Sync](dsl: Http4sDsl[F]) {
   private val halUiDir = "/hal-browser"
   private val swaggerUiDir = "/swagger-ui"
 
-  def fetchResource(path: String, req: Request[F]): F[Response[F]] = {
-    StaticFile.fromResource(path, Some(req)).getOrElseF(NotFound())
+  def fetchResource(path: String, req: Request[F]): OptionT[F, Response[F]] = {
+    StaticFile.fromResource(path, Some(req))
   }
 
   /**
    * Routes for getting static resources. These might be served more efficiently by apache2 or nginx,
    * but its nice to keep it self contained.
    */
-  def routes: HttpService[F] = HttpService[F] {
+  def routes: HttpRoutes[F] = HttpRoutes[F] {
 
     // JSON HAL User Interface
     case req if req.uri.path.startsWith("/js/") => fetchResource(halUiDir + req.pathInfo, req)

--- a/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/package.scala
+++ b/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/package.scala
@@ -1,7 +1,5 @@
 package com.http4s.rho.hal.plus.swagger
 
-import cats.Applicative
-
 import scala.language.implicitConversions
 import scala.util.Failure
 import scala.util.Success
@@ -33,17 +31,17 @@ package object demo {
       new LinkObjectSerializer +
       new ResourceObjectSerializer
 
-  implicit def resourceObjectAsJsonEncoder[F[_], A, B](implicit F: Applicative[F]): EntityEncoder[F, ResourceObject[A, B]] =
+  implicit def resourceObjectAsJsonEncoder[F[_], A, B]: EntityEncoder[F, ResourceObject[A, B]] =
     EntityEncoder
-      .stringEncoder[F](F, Charset.`UTF-8`)
+      .stringEncoder[F](Charset.`UTF-8`)
       .contramap { r: ResourceObject[A, B] => compact(render(json(r))) }
-      .withContentType(`Content-Type`(MediaType.`application/hal+json`, Charset.`UTF-8`))
+      .withContentType(`Content-Type`(MediaType.application.`vnd.hal+json`, Charset.`UTF-8`))
 
-  implicit def messageAsJsonEncoder[F[_]](implicit F: Applicative[F]): EntityEncoder[F, Message] =
+  implicit def messageAsJsonEncoder[F[_]]: EntityEncoder[F, Message] =
     EntityEncoder
-      .stringEncoder[F](F, Charset.`UTF-8`)
+      .stringEncoder[F](Charset.`UTF-8`)
       .contramap { r: Message => compact(render(json(r))) }
-      .withContentType(`Content-Type`(MediaType.`application/json`, Charset.`UTF-8`))
+      .withContentType(`Content-Type`(MediaType.application.json, Charset.`UTF-8`))
 
   /** Extracts the name of the first query parameter as string */
   implicit def paramName[F[_]](q: TypedQuery[F, _]): String = q.names.head

--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/JsonEncoder.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/JsonEncoder.scala
@@ -2,7 +2,6 @@ package com.http4s.rho.swagger.demo
 
 import java.nio.charset.StandardCharsets
 
-import cats.Applicative
 import org.http4s.headers.`Content-Type`
 import org.http4s.{Entity, EntityEncoder, MediaType}
 
@@ -17,8 +16,8 @@ object JsonEncoder {
   private implicit val formats: Formats =
     Serialization.formats(NoTypeHints)
 
-  implicit def autoSerializableEntityEncoder[F[_], A <: AutoSerializable](implicit F: Applicative[F]): EntityEncoder[F, A] =
-    EntityEncoder.encodeBy(`Content-Type`(MediaType.`application/json`))(a => F.pure {
+  implicit def autoSerializableEntityEncoder[F[_], A <: AutoSerializable]: EntityEncoder[F, A] =
+    EntityEncoder.encodeBy(`Content-Type`(MediaType.application.json))(a => {
       val bytes = write(a).getBytes(StandardCharsets.UTF_8)
       Entity(Stream.emits(bytes), Some(bytes.length))
     })

--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/Main.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/Main.scala
@@ -1,14 +1,15 @@
 package com.http4s.rho.swagger.demo
 
 import cats.effect.IO
-import cats.syntax.semigroupk._
 import fs2.StreamApp.ExitCode
 import fs2.{Stream, StreamApp}
-import org.http4s.HttpService
+import org.http4s.HttpRoutes
+import cats.syntax.semigroupk._
 import org.http4s.rho.swagger.syntax.{io => ioSwagger}
 import org.http4s.rho.swagger.syntax.io._
 import org.http4s.server.blaze.BlazeBuilder
 import org.log4s.getLogger
+
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object Main extends StreamApp[IO] {
@@ -23,11 +24,11 @@ object Main extends StreamApp[IO] {
   def stream(args: List[String], requestShutdown: IO[Unit]): Stream[IO, ExitCode] = {
     val middleware = createRhoMiddleware()
 
-    val myService: HttpService[IO] =
-      new MyService[IO](ioSwagger) {}.toService(middleware)
+    val myService: HttpRoutes[IO] =
+      new MyService[IO](ioSwagger) {}.toRoutes(middleware)
 
     BlazeBuilder[IO]
-      .mountService(StaticContentService.routes combineK myService)
+      .mountService((StaticContentService.routes <+> myService))
       .bindLocal(port)
       .serve
   }

--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/Main.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/Main.scala
@@ -1,15 +1,16 @@
 package com.http4s.rho.swagger.demo
 
 import cats.effect.{ExitCode, IO, IOApp}
+import cats.syntax.semigroupk._
+import cats.syntax.functor._
 import org.http4s.HttpRoutes
-import org.http4s.rho.swagger.syntax.io._
 import org.http4s.rho.swagger.syntax.{io => ioSwagger}
 import org.http4s.server.blaze.BlazeBuilder
 import org.log4s.getLogger
-import cats.syntax.semigroupk._
 
 object Main extends IOApp {
   private val logger = getLogger
+  import ioSwagger._
 
   val port: Int = Option(System.getenv("HTTP_PORT"))
     .map(_.toInt)
@@ -26,6 +27,6 @@ object Main extends IOApp {
     BlazeBuilder[IO]
       .mountService(StaticContentService.routes combineK myService, "")
       .bindLocal(port)
-      .serve.compile.toList.map(_.head)
+      .serve.compile.drain.as(ExitCode.Success)
   }
 }

--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/Main.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/Main.scala
@@ -1,18 +1,14 @@
 package com.http4s.rho.swagger.demo
 
-import cats.effect.IO
-import fs2.StreamApp.ExitCode
-import fs2.{Stream, StreamApp}
+import cats.effect.{ExitCode, IO, IOApp}
 import org.http4s.HttpRoutes
-import cats.syntax.semigroupk._
-import org.http4s.rho.swagger.syntax.{io => ioSwagger}
 import org.http4s.rho.swagger.syntax.io._
+import org.http4s.rho.swagger.syntax.{io => ioSwagger}
 import org.http4s.server.blaze.BlazeBuilder
 import org.log4s.getLogger
+import cats.syntax.semigroupk._
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
-object Main extends StreamApp[IO] {
+object Main extends IOApp {
   private val logger = getLogger
 
   val port: Int = Option(System.getenv("HTTP_PORT"))
@@ -21,7 +17,7 @@ object Main extends StreamApp[IO] {
 
   logger.info(s"Starting Swagger example on '$port'")
 
-  def stream(args: List[String], requestShutdown: IO[Unit]): Stream[IO, ExitCode] = {
+  def run(args: List[String]): IO[ExitCode] = {
     val middleware = createRhoMiddleware()
 
     val myService: HttpRoutes[IO] =
@@ -30,6 +26,6 @@ object Main extends StreamApp[IO] {
     BlazeBuilder[IO]
       .mountService((StaticContentService.routes <+> myService))
       .bindLocal(port)
-      .serve
+      .serve.compile.toList.map(_.head)
   }
 }

--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/Main.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/Main.scala
@@ -24,7 +24,7 @@ object Main extends IOApp {
       new MyService[IO](ioSwagger) {}.toRoutes(middleware)
 
     BlazeBuilder[IO]
-      .mountService((StaticContentService.routes <+> myService))
+      .mountService(StaticContentService.routes combineK myService, "")
       .bindLocal(port)
       .serve.compile.toList.map(_.head)
   }

--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/Main.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/Main.scala
@@ -22,7 +22,7 @@ object Main extends IOApp {
     val middleware = createRhoMiddleware()
 
     val myService: HttpRoutes[IO] =
-      new MyService[IO](ioSwagger) {}.toRoutes(middleware)
+      new MyRoutes[IO](ioSwagger) {}.toRoutes(middleware)
 
     BlazeBuilder[IO]
       .mountService(StaticContentService.routes combineK myService, "")

--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/MyRoutes.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/MyRoutes.scala
@@ -8,9 +8,9 @@ import cats.syntax.either._
 import cats.syntax.functor._
 import cats.syntax.option._
 import com.http4s.rho.swagger.demo.JsonEncoder.{AutoSerializable, _}
-import com.http4s.rho.swagger.demo.MyService._
+import com.http4s.rho.swagger.demo.MyRoutes._
 import fs2.Stream
-import org.http4s.rho.RhoService
+import org.http4s.rho.RhoRoutes
 import org.http4s.rho.bits._
 import org.http4s.rho.swagger.{SwaggerFileResponse, SwaggerSyntax}
 import org.http4s.{EntityDecoder, Headers, HttpDate, Request, ResponseCookie, Uri, headers}
@@ -20,8 +20,8 @@ import shapeless.HNil
 
 import scala.reflect.ClassTag
 
-abstract class MyService[F[+_] : Effect](swaggerSyntax: SwaggerSyntax[F])(implicit F: Monad[F])
-  extends RhoService[F] {
+abstract class MyRoutes[F[+_] : Effect](swaggerSyntax: SwaggerSyntax[F])(implicit F: Monad[F])
+  extends RhoRoutes[F] {
 
   import swaggerSyntax._
 
@@ -110,7 +110,7 @@ abstract class MyService[F[+_] : Effect](swaggerSyntax: SwaggerSyntax[F])(implic
   }
 }
 
-object MyService {
+object MyRoutes {
   import scala.reflect.runtime.universe.TypeTag
 
   case class Foo(k: String, v: Int)

--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/MyService.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/MyService.scala
@@ -13,7 +13,7 @@ import fs2.Stream
 import org.http4s.rho.RhoService
 import org.http4s.rho.bits._
 import org.http4s.rho.swagger.{SwaggerFileResponse, SwaggerSyntax}
-import org.http4s.{EntityDecoder, Headers, HttpDate, Request, Uri, headers}
+import org.http4s.{EntityDecoder, Headers, HttpDate, Request, ResponseCookie, Uri, headers}
 import org.json4s.DefaultFormats
 import org.json4s.jackson.JsonMethods
 import shapeless.HNil
@@ -82,7 +82,7 @@ abstract class MyService[F[+_] : Effect](swaggerSyntax: SwaggerSyntax[F])(implic
       val hs = req.headers.get(headers.Cookie) match {
         case None => Headers.empty
         case Some(cookie) =>
-          Headers(cookie.values.toList.map { c => headers.`Set-Cookie`(c.copy(expires = Some(HttpDate.Epoch), maxAge = Some(0)))})
+          Headers(cookie.values.toList.map { c => headers.`Set-Cookie`(ResponseCookie(c.name, c.content, expires = Some(HttpDate.Epoch), maxAge = Some(0)))})
       }
 
       Ok("Deleted cookies!").map(_.replaceAllHeaders(hs))

--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/StaticContentService.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/StaticContentService.scala
@@ -1,7 +1,7 @@
 package com.http4s.rho.swagger.demo
 
 import cats.effect.IO
-import org.http4s.{HttpService, Request, Response, StaticFile}
+import org.http4s.{HttpRoutes, Request, Response, StaticFile}
 import org.http4s.dsl.io._
 
 object StaticContentService {
@@ -15,7 +15,7 @@ object StaticContentService {
    * Routes for getting static resources. These might be served more efficiently by apache2 or nginx,
    * but its nice to keep it self contained
    */
-  def routes: HttpService[IO] = HttpService {
+  def routes: HttpRoutes[IO] = HttpRoutes.of {
     // Swagger User Interface
     case req @ GET -> Root / "css" / _       => fetchResource(swaggerUiDir + req.pathInfo, req)
     case req @ GET -> Root / "images" / _    => fetchResource(swaggerUiDir + req.pathInfo, req)

--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/StaticContentService.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/StaticContentService.scala
@@ -1,21 +1,23 @@
 package com.http4s.rho.swagger.demo
 
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import org.http4s.{HttpRoutes, Request, Response, StaticFile}
 import org.http4s.dsl.io._
+
+import scala.concurrent.ExecutionContext.global
 
 object StaticContentService {
   private val swaggerUiDir = "/swagger-ui"
 
-  def fetchResource(path: String, req: Request[IO]): IO[Response[IO]] = {
-    StaticFile.fromResource(path, Some(req)).getOrElseF(NotFound())
+  def fetchResource(path: String, req: Request[IO])(implicit cs: ContextShift[IO]): IO[Response[IO]] = {
+    StaticFile.fromResource(path, global, Some(req)).getOrElseF(NotFound())
   }
 
   /**
    * Routes for getting static resources. These might be served more efficiently by apache2 or nginx,
    * but its nice to keep it self contained
    */
-  def routes: HttpRoutes[IO] = HttpRoutes.of {
+  def routes(implicit cs: ContextShift[IO]): HttpRoutes[IO] = HttpRoutes.of {
     // Swagger User Interface
     case req @ GET -> Root / "css" / _       => fetchResource(swaggerUiDir + req.pathInfo, req)
     case req @ GET -> Root / "images" / _    => fetchResource(swaggerUiDir + req.pathInfo, req)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 import Keys._
 
 object Dependencies {
-  lazy val http4sVersion = "0.18.19"
+  lazy val http4sVersion = "0.19.0-M2-ak"
   lazy val specs2Version = "4.3.4"
 
   lazy val http4sServer        = "org.http4s"                 %% "http4s-server"         % http4sVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 import Keys._
 
 object Dependencies {
-  lazy val http4sVersion = "0.19.0"
+  lazy val http4sVersion = "0.20.0-M1"
   lazy val specs2Version = "4.3.4"
 
   lazy val http4sServer        = "org.http4s"                 %% "http4s-server"         % http4sVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   lazy val logbackClassic      = "ch.qos.logback"              % "logback-classic"       % "1.2.3"
   lazy val uadetector          = "net.sf.uadetector"           % "uadetector-resources"  % "2014.10"
   lazy val shapeless           = "com.chuusai"                %% "shapeless"             % "2.3.3"
-  lazy val scalaXml            = "org.scala-lang.modules"     %% "scala-xml"             % "1.1.0"
+  lazy val scalaXml            = "org.scala-lang.modules"     %% "scala-xml"             % "1.1.1"
 
   lazy val specs2              = Seq("org.specs2"              %% "specs2-core"          % specs2Version % "test",
                                      "org.specs2"              %% "specs2-scalacheck"    % specs2Version % "test" )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 import Keys._
 
 object Dependencies {
-  lazy val http4sVersion = "0.19.0-M2-ak"
+  lazy val http4sVersion = "0.19.0"
   lazy val specs2Version = "4.3.4"
 
   lazy val http4sServer        = "org.http4s"                 %% "http4s-server"         % http4sVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,11 +29,12 @@ object Dependencies {
   lazy val halDeps = libraryDependencies ++= Seq(json4sJackson)
 
   lazy val swaggerDeps = libraryDependencies ++= Seq(
-    json4s,
-    json4sJackson,
     scalaXml,
     swaggerCore,
-    swaggerModels
+    swaggerModels,
+
+    json4s % "test",
+    json4sJackson % "test"
   )
 
   lazy val exampleDeps = libraryDependencies ++= Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 import Keys._
 
 object Dependencies {
-  lazy val http4sVersion = "0.18.18"
+  lazy val http4sVersion = "0.18.19"
   lazy val specs2Version = "4.3.4"
 
   lazy val http4sServer        = "org.http4s"                 %% "http4s-server"         % http4sVersion

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.2.3

--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
@@ -3,6 +3,7 @@ package rho
 package swagger
 
 import cats.syntax.option._
+import cats.syntax.show._
 import org.http4s.rho.bits.PathAST._
 import org.http4s.rho.bits.RequestAST._
 import org.http4s.rho.bits._
@@ -228,8 +229,8 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
     Operation(
       tags        = pathStr.split("/").filterNot(_ == "").headOption.getOrElse("/") :: Nil,
       summary     = collectSummary(rr),
-      consumes    = rr.validMedia.toList.map(_.toString),
-      produces    = rr.responseEncodings.toList.map(_.toString),
+      consumes    = rr.validMedia.toList.map(_.show),
+      produces    = rr.responseEncodings.toList.map(_.show),
       operationId = mkOperationId(pathStr, rr.method, parameters).some,
       parameters  = parameters,
       security    = collectSecurityScopes(rr),

--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
@@ -228,8 +228,8 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
     Operation(
       tags        = pathStr.split("/").filterNot(_ == "").headOption.getOrElse("/") :: Nil,
       summary     = collectSummary(rr),
-      consumes    = rr.validMedia.toList.map(_.renderString),
-      produces    = rr.responseEncodings.toList.map(_.renderString),
+      consumes    = rr.validMedia.toList.map(_.toString),
+      produces    = rr.responseEncodings.toList.map(_.toString),
       operationId = mkOperationId(pathStr, rr.method, parameters).some,
       parameters  = parameters,
       security    = collectSecurityScopes(rr),

--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
@@ -75,12 +75,12 @@ abstract class SwaggerSupport[F[_]](implicit F: Monad[F], etag: WeakTypeTag[F[_]
   }
 
   /**
-   * Create a RhoService with the route to the Swagger json for the given Swagger Specification.
+   * Create a RhoRoutes with the route to the Swagger json for the given Swagger Specification.
    */
   def createSwaggerRoute(
     swagger: => Swagger,
     apiPath: TypedPath[F, HNil] = TypedPath(PathMatch("swagger.json"))
-  ): RhoService[F] = new RhoService[F] {
+  ): RhoRoutes[F] = new RhoRoutes[F] {
 
     lazy val response: F[OK[String]] = {
       val fOk = Ok.apply(

--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
@@ -90,7 +90,7 @@ abstract class SwaggerSupport[F[_]](implicit F: Monad[F], etag: WeakTypeTag[F[_]
       )
 
       F.map(fOk) { ok =>
-        ok.copy(resp = ok.resp.putHeaders(`Content-Type`(MediaType.`application/json`)))
+        ok.copy(resp = ok.resp.putHeaders(`Content-Type`(MediaType.application.json)))
       }
     }
 

--- a/swagger/src/test/scala/org/http4s/rho/swagger/Arbitraries.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/Arbitraries.scala
@@ -65,7 +65,7 @@ object Arbitraries {
       application.json,
       audio.midi,
       image.gif,
-      text.html,
+      text.html
     ).map(_.toString)
 
   def listOf[T : Arbitrary]: Gen[List[T]] =

--- a/swagger/src/test/scala/org/http4s/rho/swagger/Arbitraries.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/Arbitraries.scala
@@ -62,11 +62,11 @@ object Arbitraries {
 
   def genMediaType: Gen[String] =
     oneOf(
-      `application/json`,
-      `audio/midi`,
-      `image/gif`,
-      `text/html`
-    ).map(_.renderString)
+      application.json,
+      audio.midi,
+      image.gif,
+      text.html,
+    ).map(_.toString)
 
   def listOf[T : Arbitrary]: Gen[List[T]] =
     listOf(arbitrary[T])

--- a/swagger/src/test/scala/org/http4s/rho/swagger/Arbitraries.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/Arbitraries.scala
@@ -66,7 +66,7 @@ object Arbitraries {
       audio.midi,
       image.gif,
       text.html
-    ).map(_.toString)
+    ).map(_.show)
 
   def listOf[T : Arbitrary]: Gen[List[T]] =
     listOf(arbitrary[T])

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
@@ -46,8 +46,8 @@ class SwaggerModelsBuilderSpec extends Specification {
   import SwaggerModelsBuilderSpec._
   import models._
 
-  implicit def defaultCompiler: CompileService[IO, RhoRoute.Tpe[IO]] =
-    CompileService.identityCompiler
+  implicit def defaultCompiler: CompileRoutes[IO, RhoRoute.Tpe[IO]] =
+    CompileRoutes.identityCompiler
 
   sealed abstract class Renderable
   case class ModelA(name: String, color: Int) extends Renderable

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
@@ -13,7 +13,6 @@ import org.http4s.rho.bits._
 import org.http4s.rho.io._
 import org.http4s.rho.swagger.syntax.io._
 import org.specs2.mutable.Specification
-import scodec.bits.ByteVector
 
 import scala.language.existentials
 import scala.reflect._
@@ -559,14 +558,14 @@ class SwaggerModelsBuilderSpec extends Specification {
     }
 
     "collect response of an IO of a primitive" in {
-      val ra = GET / "test" |>> { () => Ok(IO.pure("")) }
+      val ra = GET / "test" |>> { () => Ok("") }
 
       sb.collectResponses[IO](ra) must havePair(
         "200" -> Response(description = "OK", schema = AbstractProperty(`type` = "string").some))
     }
 
     "collect response of an IO of a non-primitive" in {
-      val ra = GET / "test" |>> { () => Ok(IO.pure(List((0, ModelA("", 0))))) }
+      val ra = GET / "test" |>> { () => Ok(List((0, ModelA("", 0)))) }
 
       sb.collectResponses[IO](ra) must havePair(
         "200" -> Response(
@@ -593,17 +592,17 @@ class SwaggerModelsBuilderSpec extends Specification {
     }
   }
 
-  implicit def renderableEncoder[F[_], T <: Renderable](implicit F: Applicative[F]): EntityEncoder[F, T] =
+  implicit def renderableEncoder[F[_], T <: Renderable]: EntityEncoder[F, T] =
     EntityEncoder
-      .stringEncoder[F](F, Charset.`UTF-8`)
+      .stringEncoder[F](Charset.`UTF-8`)
       .contramap { r: T => "" }
-      .withContentType(`Content-Type`(MediaType.`application/json`, Charset.`UTF-8`))
+      .withContentType(`Content-Type`(MediaType.application.json, Charset.`UTF-8`))
 
-  implicit def tuple2Encoder[F[_], T <: Renderable](implicit F: Applicative[F]): EntityEncoder[F, (Int, T)] =
+  implicit def tuple2Encoder[F[_], T <: Renderable]: EntityEncoder[F, (Int, T)] =
     EntityEncoder
-      .stringEncoder[F](F, Charset.`UTF-8`)
+      .stringEncoder[F](Charset.`UTF-8`)
       .contramap { r: (Int, T) => "" }
-      .withContentType(`Content-Type`(MediaType.`application/json`, Charset.`UTF-8`))
+      .withContentType(`Content-Type`(MediaType.application.json, Charset.`UTF-8`))
 
   implicit def listEntityEncoder[F[_]: Applicative, A]: EntityEncoder[F, List[A]] =
     EntityEncoder.simple[F, List[A]]()(_ => Chunk.bytes("A".getBytes))
@@ -615,11 +614,9 @@ class SwaggerModelsBuilderSpec extends Specification {
 
   object CsvFile {
     implicit def entityEncoderCsvFile: EntityEncoder[IO, CsvFile] =
-      EntityEncoder.encodeBy[IO, CsvFile](`Content-Type`(MediaType.`text/csv`, Some(Charset.`UTF-8`))) { file: CsvFile =>
-        ByteVector.encodeUtf8("file content").fold(
-          IO.raiseError,
-          bv => IO.pure(org.http4s.Entity(Stream.emits(bv.toArray), Some(bv.length)))
-        )
+      EntityEncoder.encodeBy[IO, CsvFile](`Content-Type`(MediaType.text.csv, Some(Charset.`UTF-8`))) { file: CsvFile =>
+        val bv = "file content".getBytes(Charset.`UTF-8`.nioCharset)
+        org.http4s.Entity(Stream.emits(bv), Some(bv.length))
       }
   }
 }

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
@@ -15,27 +15,27 @@ class SwaggerSupportSpec extends Specification {
   import org.json4s.JsonAST._
   import org.json4s.jackson._
 
-  val baseService = new RhoService[IO] {
+  val baseService = new RhoRoutes[IO] {
     GET / "hello" |>> { () => Ok("hello world") }
     GET / "hello"/ pathVar[String] |>> { world: String => Ok("hello " + world) }
   }
 
-  val moarRoutes = new RhoService[IO] {
+  val moarRoutes = new RhoRoutes[IO] {
     GET / "goodbye" |>> { () => Ok("goodbye world") }
     GET / "goodbye"/ pathVar[String] |>> { world: String => Ok("goodbye " + world) }
   }
 
-  val trailingSlashService = new RhoService[IO] {
+  val trailingSlashService = new RhoRoutes[IO] {
     GET / "foo" / "" |>> { () => Ok("hello world") }
   }
 
-  val mixedTrailingSlashesService = new RhoService[IO] {
+  val mixedTrailingSlashesService = new RhoRoutes[IO] {
     GET / "foo" / "" |>> { () => Ok("hello world") }
     GET / "foo" |>> { () => Ok("hello world") }
     GET / "bar" |>> { () => Ok("hello world") }
   }
 
-  val metaDataService = new RhoService[IO] {
+  val metaDataService = new RhoRoutes[IO] {
     "Hello" ** GET / "hello" |>> { () => Ok("hello world") }
     Map("hello"->List("bye")) ^^ "Bye" ** GET / "bye" |>> { () => Ok("bye world") }
     Map("bye"->List("hello")) ^^ GET / "goodbye" |>> { () => Ok("goodbye world") }
@@ -69,7 +69,7 @@ class SwaggerSupportSpec extends Specification {
       swaggerSpec.paths must haveSize(2)
     }
 
-    "Provide a way to aggregate routes from multiple RhoServices" in {
+    "Provide a way to aggregate routes from multiple RhoRoutes" in {
       val aggregateSwagger = createSwagger()(baseService.getRoutes ++ moarRoutes.getRoutes)
       val swaggerRoutes = createSwaggerRoute(aggregateSwagger)
       val httpServices = NonEmptyList.of(baseService, moarRoutes, swaggerRoutes).map(_.toRoutes())
@@ -100,7 +100,7 @@ class SwaggerSupportSpec extends Specification {
       Set(a, b, c) should_== Set("/foo/", "/foo", "/bar")
     }
 
-    "Provide a way to agregate routes from multiple RhoServices, with mixed trailing slashes and non-trailing slashes" in {
+    "Provide a way to agregate routes from multiple RhoRoutes, with mixed trailing slashes and non-trailing slashes" in {
       val aggregateSwagger = createSwagger()(baseService.getRoutes ++ moarRoutes.getRoutes  ++ mixedTrailingSlashesService.getRoutes)
       val swaggerRoutes = createSwaggerRoute(aggregateSwagger)
       val httpServices = NonEmptyList.of(baseService, moarRoutes, swaggerRoutes).map(_.toRoutes())

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
@@ -43,7 +43,7 @@ class SwaggerSupportSpec extends Specification {
 
   "SwaggerSupport" should {
     "Expose an API listing" in {
-      val service = baseService.toService(createRhoMiddleware(swaggerRoutesInSwagger = true))
+      val service = baseService.toRoutes(createRhoMiddleware(swaggerRoutesInSwagger = true))
 
       val r = Request[IO](GET, Uri(path = "/swagger.json"))
 
@@ -54,7 +54,7 @@ class SwaggerSupportSpec extends Specification {
     }
 
     "Support prefixed routes" in {
-      val service = ("foo" /: baseService).toService(createRhoMiddleware(swaggerRoutesInSwagger = true))
+      val service = ("foo" /: baseService).toRoutes(createRhoMiddleware(swaggerRoutesInSwagger = true))
       val r = Request[IO](GET, Uri(path = "/swagger.json"))
 
       val JObject(List((a, JObject(_)), (b, JObject(_)), (c, JObject(_)))) =
@@ -72,7 +72,7 @@ class SwaggerSupportSpec extends Specification {
     "Provide a way to aggregate routes from multiple RhoServices" in {
       val aggregateSwagger = createSwagger()(baseService.getRoutes ++ moarRoutes.getRoutes)
       val swaggerRoutes = createSwaggerRoute(aggregateSwagger)
-      val httpServices = NonEmptyList.of(baseService, moarRoutes, swaggerRoutes).map(_.toService())
+      val httpServices = NonEmptyList.of(baseService, moarRoutes, swaggerRoutes).map(_.toRoutes())
 
       val allthogetherService = httpServices.reduceLeft(_ combineK _)
 
@@ -85,7 +85,7 @@ class SwaggerSupportSpec extends Specification {
     }
 
     "Support endpoints which end in a slash" in {
-      val service = trailingSlashService.toService(createRhoMiddleware())
+      val service = trailingSlashService.toRoutes(createRhoMiddleware())
       val r = Request[IO](GET, Uri(path = "/swagger.json"))
       val JObject(List((a, JObject(_)))) = parseJson(RRunner(service).checkOk(r)) \\ "paths"
 
@@ -93,7 +93,7 @@ class SwaggerSupportSpec extends Specification {
     }
 
     "Support endpoints which end in a slash being mixed with normal endpoints"  in {
-      val service = mixedTrailingSlashesService.toService(createRhoMiddleware())
+      val service = mixedTrailingSlashesService.toRoutes(createRhoMiddleware())
       val r = Request[IO](GET, Uri(path = "/swagger.json"))
       val JObject(List((a, JObject(_)), (b, JObject(_)), (c, JObject(_)))) = parseJson(RRunner(service).checkOk(r)) \\ "paths"
 
@@ -103,7 +103,7 @@ class SwaggerSupportSpec extends Specification {
     "Provide a way to agregate routes from multiple RhoServices, with mixed trailing slashes and non-trailing slashes" in {
       val aggregateSwagger = createSwagger()(baseService.getRoutes ++ moarRoutes.getRoutes  ++ mixedTrailingSlashesService.getRoutes)
       val swaggerRoutes = createSwaggerRoute(aggregateSwagger)
-      val httpServices = NonEmptyList.of(baseService, moarRoutes, swaggerRoutes).map(_.toService())
+      val httpServices = NonEmptyList.of(baseService, moarRoutes, swaggerRoutes).map(_.toRoutes())
 
       val allthogetherService = httpServices.reduceLeft(_ combineK  _)
 
@@ -116,7 +116,7 @@ class SwaggerSupportSpec extends Specification {
     }
 
     "Check metadata in API listing" in {
-      val service = metaDataService.toService(createRhoMiddleware(swaggerRoutesInSwagger = true))
+      val service = metaDataService.toRoutes(createRhoMiddleware(swaggerRoutesInSwagger = true))
 
       val r = Request[IO](GET, Uri(path = "/swagger.json"))
 
@@ -133,7 +133,7 @@ class SwaggerSupportSpec extends Specification {
     }
 
     "Swagger support for complex meta data" in {
-      val service = baseService.toService(createRhoMiddleware(
+      val service = baseService.toRoutes(createRhoMiddleware(
         apiPath = "swagger-test.json",
         apiInfo =  Info(
           title = "Complex Meta Data API",
@@ -188,7 +188,7 @@ class SwaggerSupportSpec extends Specification {
     }
 
     "Check metadata in API listing" in {
-      val service = metaDataService.toService(createRhoMiddleware(swaggerRoutesInSwagger = true))
+      val service = metaDataService.toRoutes(createRhoMiddleware(swaggerRoutesInSwagger = true))
 
       val r = Request[IO](GET, Uri(path = "/swagger.json"))
 

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSpec.scala
@@ -15,7 +15,7 @@ class SwaggerSupportSpec extends Specification {
   import org.json4s.JsonAST._
   import org.json4s.jackson._
 
-  val baseService = new RhoRoutes[IO] {
+  val baseRoutes = new RhoRoutes[IO] {
     GET / "hello" |>> { () => Ok("hello world") }
     GET / "hello"/ pathVar[String] |>> { world: String => Ok("hello " + world) }
   }
@@ -25,17 +25,17 @@ class SwaggerSupportSpec extends Specification {
     GET / "goodbye"/ pathVar[String] |>> { world: String => Ok("goodbye " + world) }
   }
 
-  val trailingSlashService = new RhoRoutes[IO] {
+  val trailingSlashRoutes = new RhoRoutes[IO] {
     GET / "foo" / "" |>> { () => Ok("hello world") }
   }
 
-  val mixedTrailingSlashesService = new RhoRoutes[IO] {
+  val mixedTrailingSlashesRoutes = new RhoRoutes[IO] {
     GET / "foo" / "" |>> { () => Ok("hello world") }
     GET / "foo" |>> { () => Ok("hello world") }
     GET / "bar" |>> { () => Ok("hello world") }
   }
 
-  val metaDataService = new RhoRoutes[IO] {
+  val metaDataRoutes = new RhoRoutes[IO] {
     "Hello" ** GET / "hello" |>> { () => Ok("hello world") }
     Map("hello"->List("bye")) ^^ "Bye" ** GET / "bye" |>> { () => Ok("bye world") }
     Map("bye"->List("hello")) ^^ GET / "goodbye" |>> { () => Ok("goodbye world") }
@@ -43,7 +43,7 @@ class SwaggerSupportSpec extends Specification {
 
   "SwaggerSupport" should {
     "Expose an API listing" in {
-      val service = baseService.toRoutes(createRhoMiddleware(swaggerRoutesInSwagger = true))
+      val service = baseRoutes.toRoutes(createRhoMiddleware(swaggerRoutesInSwagger = true))
 
       val r = Request[IO](GET, Uri(path = "/swagger.json"))
 
@@ -54,7 +54,7 @@ class SwaggerSupportSpec extends Specification {
     }
 
     "Support prefixed routes" in {
-      val service = ("foo" /: baseService).toRoutes(createRhoMiddleware(swaggerRoutesInSwagger = true))
+      val service = ("foo" /: baseRoutes).toRoutes(createRhoMiddleware(swaggerRoutesInSwagger = true))
       val r = Request[IO](GET, Uri(path = "/swagger.json"))
 
       val JObject(List((a, JObject(_)), (b, JObject(_)), (c, JObject(_)))) =
@@ -64,28 +64,28 @@ class SwaggerSupportSpec extends Specification {
     }
 
     "Provide a method to build the Swagger model for a list of routes" in {
-      val swaggerSpec = createSwagger()(baseService.getRoutes)
+      val swaggerSpec = createSwagger()(baseRoutes.getRoutes)
 
       swaggerSpec.paths must haveSize(2)
     }
 
     "Provide a way to aggregate routes from multiple RhoRoutes" in {
-      val aggregateSwagger = createSwagger()(baseService.getRoutes ++ moarRoutes.getRoutes)
+      val aggregateSwagger = createSwagger()(baseRoutes.getRoutes ++ moarRoutes.getRoutes)
       val swaggerRoutes = createSwaggerRoute(aggregateSwagger)
-      val httpServices = NonEmptyList.of(baseService, moarRoutes, swaggerRoutes).map(_.toRoutes())
+      val httpRoutess = NonEmptyList.of(baseRoutes, moarRoutes, swaggerRoutes).map(_.toRoutes())
 
-      val allthogetherService = httpServices.reduceLeft(_ combineK _)
+      val allthogetherRoutes = httpRoutess.reduceLeft(_ combineK _)
 
       val r = Request[IO](GET, Uri(path = "/swagger.json"))
 
       val JObject(List((a, JObject(_)), (b, JObject(_)), (c, JObject(_)), (d, JObject(_)))) =
-        parseJson(RRunner(allthogetherService).checkOk(r)) \\ "paths"
+        parseJson(RRunner(allthogetherRoutes).checkOk(r)) \\ "paths"
 
       Set(a, b, c, d) should_== Set("/hello", "/hello/{string}", "/goodbye", "/goodbye/{string}")
     }
 
     "Support endpoints which end in a slash" in {
-      val service = trailingSlashService.toRoutes(createRhoMiddleware())
+      val service = trailingSlashRoutes.toRoutes(createRhoMiddleware())
       val r = Request[IO](GET, Uri(path = "/swagger.json"))
       val JObject(List((a, JObject(_)))) = parseJson(RRunner(service).checkOk(r)) \\ "paths"
 
@@ -93,7 +93,7 @@ class SwaggerSupportSpec extends Specification {
     }
 
     "Support endpoints which end in a slash being mixed with normal endpoints"  in {
-      val service = mixedTrailingSlashesService.toRoutes(createRhoMiddleware())
+      val service = mixedTrailingSlashesRoutes.toRoutes(createRhoMiddleware())
       val r = Request[IO](GET, Uri(path = "/swagger.json"))
       val JObject(List((a, JObject(_)), (b, JObject(_)), (c, JObject(_)))) = parseJson(RRunner(service).checkOk(r)) \\ "paths"
 
@@ -101,22 +101,22 @@ class SwaggerSupportSpec extends Specification {
     }
 
     "Provide a way to agregate routes from multiple RhoRoutes, with mixed trailing slashes and non-trailing slashes" in {
-      val aggregateSwagger = createSwagger()(baseService.getRoutes ++ moarRoutes.getRoutes  ++ mixedTrailingSlashesService.getRoutes)
+      val aggregateSwagger = createSwagger()(baseRoutes.getRoutes ++ moarRoutes.getRoutes  ++ mixedTrailingSlashesRoutes.getRoutes)
       val swaggerRoutes = createSwaggerRoute(aggregateSwagger)
-      val httpServices = NonEmptyList.of(baseService, moarRoutes, swaggerRoutes).map(_.toRoutes())
+      val httpRoutess = NonEmptyList.of(baseRoutes, moarRoutes, swaggerRoutes).map(_.toRoutes())
 
-      val allthogetherService = httpServices.reduceLeft(_ combineK  _)
+      val allthogetherRoutes = httpRoutess.reduceLeft(_ combineK  _)
 
       val r = Request[IO](GET, Uri(path = "/swagger.json"))
 
       val JObject(List((a, JObject(_)), (b, JObject(_)), (c, JObject(_)), (d, JObject(_)), (e, JObject(_)), (f, JObject(_)), (g, JObject(_)))) =
-        parseJson(RRunner(allthogetherService).checkOk(r)) \\ "paths"
+        parseJson(RRunner(allthogetherRoutes).checkOk(r)) \\ "paths"
 
       Set(a, b, c, d, e, f, g) should_== Set("/hello", "/hello/{string}", "/goodbye", "/goodbye/{string}", "/foo/", "/foo", "/bar")
     }
 
     "Check metadata in API listing" in {
-      val service = metaDataService.toRoutes(createRhoMiddleware(swaggerRoutesInSwagger = true))
+      val service = metaDataRoutes.toRoutes(createRhoMiddleware(swaggerRoutesInSwagger = true))
 
       val r = Request[IO](GET, Uri(path = "/swagger.json"))
 
@@ -133,7 +133,7 @@ class SwaggerSupportSpec extends Specification {
     }
 
     "Swagger support for complex meta data" in {
-      val service = baseService.toRoutes(createRhoMiddleware(
+      val service = baseRoutes.toRoutes(createRhoMiddleware(
         apiPath = "swagger-test.json",
         apiInfo =  Info(
           title = "Complex Meta Data API",
@@ -188,7 +188,7 @@ class SwaggerSupportSpec extends Specification {
     }
 
     "Check metadata in API listing" in {
-      val service = metaDataService.toRoutes(createRhoMiddleware(swaggerRoutesInSwagger = true))
+      val service = metaDataRoutes.toRoutes(createRhoMiddleware(swaggerRoutesInSwagger = true))
 
       val r = Request[IO](GET, Uri(path = "/swagger.json"))
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,3 +1,2 @@
-
-version       in ThisBuild := "0.18.1-SNAPSHOT"
+version       in ThisBuild := "0.19.0-M1"
 apiVersion    in ThisBuild := RhoPlugin.extractApiVersion(version.value)


### PR DESCRIPTION
This is based on https://github.com/http4s/rho/pull/236 and leaves @Igosuki's work almost untouched, but:

* bumps http4s to 0.19.0 (which is [still not final](https://github.com/http4s/http4s/pull/2153), I guess?)
* rebased on top of current master
* makes all tests green
* Bumps SBT to latest version
* Makes json4s a test-only dependency for swagger

#### TODO

- [x] Fix `HListToFuncSpec`
- [x] Fix docstring in `AuthedContext`
- [x] Rename few more "service" to "routes"
- [x] Add a comment in `AuthedContext` that middleware is mandatory
- [x] Should we rename `RhoService` to `RhoRoutes`?
- [ ] Bump to final 0.20.0 when available