### PR TITLE
Reworked handling of sum types. Solution for #268

### DIFF
--- a/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
@@ -26,6 +26,12 @@ object TypeBuilder {
     def go(t: Type, alreadyKnown: Set[Model], known: Set[Type]): Set[Model] =
       t.dealias match {
 
+        case tpe if alreadyKnown.exists(_.id == tpe.fullName) =>
+          Set.empty
+
+        case tpe if known.exists(_ =:= tpe) =>
+          Set.empty
+
         case tpe if sfs.customSerializers.isDefinedAt(tpe) =>
           sfs.customSerializers(tpe)
 
@@ -33,28 +39,19 @@ object TypeBuilder {
           alreadyKnown ++ modelToSwagger(tpe, sfs)
 
         case tpe if tpe.isEither || tpe.isMap =>
-          go(tpe.typeArgs.head, alreadyKnown, tpe.typeArgs.toSet) ++
-            go(tpe.typeArgs.last, alreadyKnown, tpe.typeArgs.toSet)
+          go(tpe.typeArgs.head, alreadyKnown, known + tpe) ++
+            go(tpe.typeArgs.last, alreadyKnown, known + tpe)
 
-        case tpe if (tpe.isCollection || tpe.isOption) && tpe.typeArgs.nonEmpty =>
-          val ntpe = tpe.typeArgs.head
-          if (!known.exists(_ =:= ntpe)) go(ntpe, alreadyKnown, known + ntpe)
-          else Set.empty
+        case tpe if (tpe.isCollection || tpe.isOption || tpe.isEffect(et)) && tpe.typeArgs.nonEmpty =>
+          go(tpe.typeArgs.head, alreadyKnown, known + tpe)
 
         case tpe if tpe.isStream =>
-          val ntpe = tpe.typeArgs.apply(1)
-          if (!known.exists(_ =:= ntpe)) go(ntpe, alreadyKnown, known + ntpe)
-          else Set.empty
-
-        case tpe if tpe.isEffect(et) =>
-          val ntpe = tpe.typeArgs.head
-          if (!known.exists(_ =:= ntpe)) go(ntpe, alreadyKnown, known + ntpe)
-          else Set.empty
+          go(tpe.typeArgs.apply(1), alreadyKnown, known + tpe)
 
         case tpe if tpe.isSwaggerFile =>
           Set.empty
 
-        case tpe if alreadyKnown.map(_.id).contains(tpe.fullName) || tpe.isPrimitive =>
+        case tpe if tpe.isPrimitive =>
           Set.empty
 
         case tpe if tpe <:< typeOf[AnyVal] =>
@@ -67,7 +64,7 @@ object TypeBuilder {
           val ctor = sym.asClass.primaryConstructor.asMethod
           val models = alreadyKnown ++ modelToSwagger(tpe, sfs)
           val generics = tpe.typeArgs.foldLeft(List[Model]()) { (acc, t) =>
-            acc ++ go(t, alreadyKnown, tpe.typeArgs.toSet)
+            acc ++ go(t, alreadyKnown, known + tpe)
           }
           val children = ctor.paramLists.flatten.flatMap { paramsym =>
             val paramType =

--- a/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
@@ -308,12 +308,12 @@ object TypeBuilder {
       t <:< typeOf[collection.Traversable[_]] || t <:< typeOf[java.util.Collection[_]]
   }
 
-  implicit class WrappedType(val t: Type){
+  private implicit class WrappedType(val t: Type){
     override def equals(obj: Any): Boolean = obj match{
       case wt2: WrappedType => t =:= wt2.t
       case _ => false
     }
   }
 
-  type TypeSet = ListSet[WrappedType]
+  private type TypeSet = ListSet[WrappedType]
 }

--- a/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
@@ -129,7 +129,7 @@ object TypeBuilder {
 
   private[this] def isSumType(sym: Symbol): Boolean =
     sym.isClass && sym.asClass.isSealed && sym.asClass.knownDirectSubclasses.forall { symbol =>
-      !symbol.isModuleClass && symbol.asClass.isCaseClass
+      (!symbol.isModuleClass && symbol.asClass.isCaseClass) || isSumType(symbol)
     }
 
   private[this] def isObjectEnum(sym: Symbol): Boolean =

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
@@ -49,7 +49,7 @@ class SwaggerModelsBuilderSpec extends Specification {
   implicit def defaultCompiler: CompileRoutes[IO, RhoRoute.Tpe[IO]] =
     CompileRoutes.identityCompiler
 
-  sealed abstract class Renderable
+  trait Renderable
   case class ModelA(name: String, color: Int) extends Renderable
   case class ModelB(name: String, id: Long) extends Renderable
   case class ModelC(name: String, shape: String) extends Renderable

--- a/swagger/src/test/scala/org/http4s/rho/swagger/TypeBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/TypeBuilderSpec.scala
@@ -326,7 +326,7 @@ class TypeBuilderSpec extends Specification {
     // fails because the implementation for AnyVals is just Seg.empty
     "Treat AnyVals transparently" in {
       modelOf[FooVal] must_== modelOf[Foo]
-    }.pendingUntilFixed("AnyVals")
+    }.pendingUntilFixed("https://github.com/http4s/rho/issues/272")
 
     // fails because the implementation for AnyVals is just Seg.empty
     "Build a model with the underlying type for AnyVals" in {
@@ -341,13 +341,13 @@ class TypeBuilderSpec extends Specification {
           name must_== "fooVal"
           prop.`$ref` must_== Some("Foo")
       }
-    }.pendingUntilFixed("AnyVals")
+    }.pendingUntilFixed("https://github.com/http4s/rho/issues/272")
 
     "Build a model for sealed traits" in {
       val ms = modelOf[Sealed]
       ms.foreach(_.toJModel) // Testing that there are no exceptions
       ms.size must_== 4
-      val Some(_: models.ModelImpl) = ms.find(_.id2 == "Foo") // Foo should not become a ComposedModel
+      ms.find(_.id2 == "Foo").get must haveClass[models.ModelImpl]  // Foo should not become a ComposedModel
       val Some(seald: models.ModelImpl) = ms.find(_.id2 == "Sealed")
       seald.discriminator must_== Some("foobar")
       val Some(sealedFoo: models.ComposedModel) = ms.find(_.id2 == "FooSealed")

--- a/swagger/src/test/scala/org/http4s/rho/swagger/TypeBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/TypeBuilderSpec.scala
@@ -319,7 +319,7 @@ class TypeBuilderSpec extends Specification {
 
     // fails because the implementation for AnyVals is just Seg.empty
     "Treat AnyVals transparently" in {
-      modelOf[FooVal] == modelOf[Foo]
+      modelOf[FooVal] must_== modelOf[Foo]
     }
 
     // fails because the implementation for AnyVals is just Seg.empty
@@ -353,9 +353,8 @@ class TypeBuilderSpec extends Specification {
     // Fails because FooDefault model appears twice in the results. Once as a ModelImpl and once as ComposedModel.
     "Not modify unrelated types when building model for sealed trait" in {
       val unrelatedModel = modelOf[FooDefault]
-      val jointModel = TypeBuilder.collectModels(typeOf[Sealed], unrelatedModel, DefaultSwaggerFormats, typeOf[IO[_]])
-
-      jointModel must_== (unrelatedModel ++ modelOf[Sealed])
+      val model = TypeBuilder.collectModels(typeOf[Sealed], unrelatedModel, DefaultSwaggerFormats, typeOf[IO[_]])
+      model must_== modelOf[Sealed]
     }
 
     "Build a model for a case class containing a sealed enum" in {

--- a/swagger/src/test/scala/org/http4s/rho/swagger/TypeBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/TypeBuilderSpec.scala
@@ -33,8 +33,6 @@ package object model {
   case class FooSealed(a: Int, foo: String, foo2: Foo) extends Sealed
   case class BarSealed(str: String, foo: String) extends Sealed
 
-  case class ContainsSealed(seal: Sealed)
-
   sealed trait SealedEnum
   case object FooEnum extends SealedEnum
   case object BarEnum extends SealedEnum
@@ -337,6 +335,13 @@ class TypeBuilderSpec extends Specification {
       val Some(foo: models.ComposedModel) = ms.find(_.id2 == "FooSealed")
       val Some(fooRef) = foo.allOf.collectFirst {case ref: models.RefModel => ref}
       fooRef.ref must_== "Sealed"
+    }
+
+    "Not modify unrelated types when building model for sealed trait" in {
+      val unrelatedModel = modelOf[FooDefault]
+      val jointModel = TypeBuilder.collectModels(typeOf[Sealed], unrelatedModel, DefaultSwaggerFormats, typeOf[IO[_]])
+
+      jointModel must_== (unrelatedModel ++ modelOf[Sealed])
     }
   }
 


### PR DESCRIPTION
This pull request:
* Fixes #268. Unrelated models are no longer accidentally modified.
* Changes behaviour in case only some subtypes of a sum type are in use. Now the whole sum type (the type and all it's children) are added to the model.
* Adds support for multi-level sum types. See the "Build a model for two-level sealed trait hierarchy" test case.
* Adds some tests, including some not directly related to sub types handling.
* Fixes some issues discovered in the process, namely: infinite recursion for `FooEither` and `BTree` types (see the test cases)
* cleans up/unifies the way `alreadyKnown` and `known` are used (mainly in order to fix the infinite recursion issues)