### PR TITLE
WIP: New Authentication for Rho v2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,7 +109,8 @@ lazy val buildSettings = publishing ++
       logbackClassic % "test"
     ),
     libraryDependencies ++= specs2,
-    libraryDependencies += `scala-reflect` % scalaVersion.value
+    libraryDependencies += `scala-reflect` % scalaVersion.value,
+    addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.8" cross CrossVersion.binary)
   )
 
 // to keep REPL usable

--- a/core/src/main/scala/org/http4s/rho/Action.scala
+++ b/core/src/main/scala/org/http4s/rho/Action.scala
@@ -1,16 +1,32 @@
 package org.http4s.rho
 
 import org.http4s.rho.bits.ResultInfo
-import org.http4s.{MediaType, Request, Response}
+import org.http4s.{AuthedRequest, MediaType, Request, Response}
 import shapeless.HList
 
 /** Encapsulation of metadata and a result generator
   *
   * @param resultInfo Information about the status and type the Action will produce.
   * @param responseEncodings Encodings that the response supports.
-  * @param act Function of `Request` and the `HList` to a `Task[Response]`
-  * @tparam T The type of `HList` required to execute the [[Action]].
+  * @param act Function of [[R]] and the [[HList]] to a `F[Response]`
+  * @tparam T The type of [[HList]] required to execute the [[AbstractAction]].
+  * @tparam F The effect type
+  * @tparam R The type of request
   */
-case class Action[F[_], T <: HList](resultInfo: Set[ResultInfo],
+case class AbstractAction[F[_], R[_[_]], T <: HList](resultInfo: Set[ResultInfo],
                                     responseEncodings: Set[MediaType],
-                                    act: (Request[F], T) => F[Response[F]])
+                                    act: (R[F], T) => F[Response[F]])
+
+object Action {
+  def apply[F[_], T <: HList](resultInfo: Set[ResultInfo],
+                              responseEncodings: Set[MediaType],
+                              act: (Request[F], T) => F[Response[F]]): Action[F, T] =
+    AbstractAction(resultInfo, responseEncodings, act)
+}
+
+object AuthedAction {
+  def apply[F[_], T <: HList, U](resultInfo: Set[ResultInfo],
+                              responseEncodings: Set[MediaType],
+                              act: (AuthedRequest[F, U], T) => F[Response[F]]): AuthedAction[F, T, U] =
+    AbstractAction[F, AuthedRequest[?[_], U], T](resultInfo, responseEncodings, act)
+}

--- a/core/src/main/scala/org/http4s/rho/CompileRoutes.scala
+++ b/core/src/main/scala/org/http4s/rho/CompileRoutes.scala
@@ -2,18 +2,19 @@ package org.http4s
 package rho
 
 import cats.Monad
-import cats.data.Kleisli
+import cats.data.{Kleisli, OptionT}
+import cats.implicits._
+import org.http4s.rho.bits.{PathTree, RequestLike}
 import shapeless.HList
-
-import org.http4s.rho.RhoRoute.Tpe
-import org.http4s.rho.bits.PathTree
+import org.http4s.server.AuthMiddleware
 
 /** Transforms a [[RhoRoute]] into an `RouteType`.
   *
   * This can be a stateful operation, storing the action for later execution
   * or any other type of compilation phase.
   */
-trait CompileRoutes[F[_], RouteType] {
+trait CompileRoutes[F[_], OutRouteType] {
+  type InRouteType[G[_], T <: HList]
 
   /** Transform the [[RhoRoute]] into a `RouteType` possibly mutating this compilers state.
     *
@@ -21,28 +22,108 @@ trait CompileRoutes[F[_], RouteType] {
     * @tparam T `HList` representation of the result of the route
     * @return The result of the compilation process.
     */
-  def compile[T <: HList](route: RhoRoute[F, T]): RouteType
+  def compile[T <: HList](route: InRouteType[F, T]): OutRouteType
 }
 
 object CompileRoutes {
 
+  type Aux[F[_], InRouteType0[_[_], _ <: HList], OutRouteType] = CompileRoutes[F, OutRouteType] { type InRouteType[G[_], T <: HList] = InRouteType0[G, T] }
+
   /** [[CompileRoutes]] that simply returns its argument */
-  def identityCompiler[F[_]]: CompileRoutes[F, Tpe[F]] = new CompileRoutes[F, RhoRoute.Tpe[F]] {
-    def compile[T <: HList](route: RhoRoute[F, T]): RhoRoute[F, T] = route
-  }
+  def identityCompiler[F[_]]: CompileRoutes.Aux[F, RhoRoute, RhoRoute.Tpe[F]] =
+    new CompileRoutes[F, RhoRoute.Tpe[F]] {
+      override type InRouteType[G[_], T <: HList] = RhoRoute[G, T]
+
+      def compile[T <: HList](route: RhoRoute[F, T]): RhoRoute[F, T] = route
+    }
 
   /** Importable implicit identity compiler */
   object Implicit {
-    implicit def compiler[F[_]]: CompileRoutes[F, RhoRoute.Tpe[F]] = identityCompiler[F]
+    implicit def compiler[F[_]]: CompileRoutes.Aux[F, RhoRoute, RhoRoute.Tpe[F]] = identityCompiler[F]
   }
+}
 
-  /** Convert the `Seq` of [[RhoRoute]]'s into a `HttpRoutes`
+trait CompileHttpRoutes[F[_], RR[_[_], _ <: HList]] {
+  type Rq[_[_]]
+  type Out = Kleisli[OptionT[F, ?], Rq[F], Response[F]]
+
+  /** Convert the `Seq` of [[RhoRoute]]'s like class into a [[HttpRoutes]] like class
     *
     * @param routes `Seq` of routes to bundle into a service.
     * @return An `HttpRoutes`
     */
-  def foldRoutes[F[_]: Monad](routes: Seq[RhoRoute.Tpe[F]]): HttpRoutes[F] = {
-    val tree = routes.foldLeft(PathTree[F]()){ (t, r) => t.appendRoute(r) }
-    Kleisli((req: Request[F]) => tree.getResult(req).toResponse)
-  }
+  def foldRoutes(routes: Seq[RR[F, _ <: HList]]): Out
+}
+
+object CompileHttpRoutes {
+  type Aux[F[_], RR[_[_], _ <: HList], Rq0[_[_]]] = CompileHttpRoutes[F, RR] { type Rq[G[_]] = Rq0[G] }
+
+  def action[F[_]: Monad]: CompileHttpRoutes.Aux[F, RhoRoute, Request] =
+    new CompileHttpRoutes[F, RhoRoute] {
+      type Rq[G[_]] = Request[G]
+      override def foldRoutes(routes: Seq[RhoRoute[F, _ <: HList]]): HttpRoutes[F] = {
+        /* Since we can merge AuthedRhoRoutes with UnAuthedRhoRoutes
+          we group the routes together by groups with the same middleware
+          maintaining the order in the seq.
+        */
+        val grouped: Seq[(Option[AuthMiddleware[F, _]], List[RhoRoute[F, _ <: HList]])] =
+          routes
+          .foldLeft(List.empty[(Option[AuthMiddleware[F, _]], List[RhoRoute[F, _<: HList]])]) {
+            (b, r) =>
+              (b, r) match {
+                case ((Some(am), rrs) :: t, rr@AuthedRhoRoute(am2, _, _)) if am == am2 =>
+                  (Option(am) -> (rr :: rrs)) :: t
+                case (t, rr@AuthedRhoRoute(am, _, _)) =>
+                  (Option(am) -> (rr :: Nil)) :: t
+                case ((None, rrs) :: t, rr@UnAuthedRhoRoute(_, _)) =>
+                  (Option.empty -> (rr :: rrs)) :: t
+                case (t, rr@UnAuthedRhoRoute(_, _)) =>
+                  (Option.empty -> (rr :: Nil)) :: t
+              }
+          }
+        /* Now we'll build each group into a HttpRoutes and compose those routes
+          together maintaining the order.  This way the AuthMiddlware get reused
+          at least for neighboring rho routes using the same middleware.
+          If a user does AuthedRhoRoutes and UnAuthedRhoRoutes and AuthedRhoRhoutes
+          using the same middleware, this will unfortunately call that middleware
+          multiple times, assuming they are not using the fallthrough version
+         */
+        grouped
+          .map {
+            case (None, routes) =>
+              routes.asInstanceOf[List[UnAuthedRhoRoute[F, _ <: HList]]]
+                .foldLeft(PathTree[F]()){ (t, r) => t.appendRoute(r) }
+                .toKleisli
+            case (Some(am), routes) =>
+              am.asInstanceOf[AuthMiddleware[F, Any]](
+                routes.asInstanceOf[List[AuthedRhoRoute[F, Any, _ <: HList]]]
+                  .foldLeft(PathTree.authed[F, Any]()(RequestLike.authedRequest[Any])){
+                    (t, r) => t.appendRoute(r)
+                  }
+                  .toKleisli
+              )
+          }
+          .reduce(_ <+> _)
+      }
+    }
+
+  implicit def unauthedAction[F[_]: Monad]: CompileHttpRoutes.Aux[F, UnAuthedRhoRoute, Request] =
+    new CompileHttpRoutes[F, UnAuthedRhoRoute] {
+      type Rq[G[_]] = Request[G]
+      override def foldRoutes(routes: Seq[UnAuthedRhoRoute[F, _ <: HList]]): HttpRoutes[F] = {
+        routes.foldLeft(PathTree[F]()) {
+            (t, r) => t.appendRoute(r)
+          }
+          .toKleisli
+      }
+    }
+
+  implicit def authedAction[F[_]: Monad, U]: CompileHttpRoutes.Aux[F, Lambda[(G[_], `T <: HList`) => PreAuthedRhoRoute[G, U, T]], AuthedRequest[?[_], U]] =
+    new CompileHttpRoutes[F, Lambda[(G[_], `T <: HList`) => PreAuthedRhoRoute[G, U, T]]] {
+      type Rq[G[_]] = AuthedRequest[G, U]
+      override def foldRoutes(routes: Seq[PreAuthedRhoRoute[F, U, _ <: HList]]): AuthedService[U, F] = /*{
+        val tree = routes.foldLeft(PathTree[F]()){ (t, r) => t.appendRoute(r) }
+        tree.toKleisli
+      }*/ ???
+    }
 }

--- a/core/src/main/scala/org/http4s/rho/PathBuilder.scala
+++ b/core/src/main/scala/org/http4s/rho/PathBuilder.scala
@@ -17,13 +17,13 @@ import scala.reflect.runtime.universe.TypeTag
 
 /** Fully functional path building */
 final class PathBuilder[F[_], T <: HList](val method: Method, val path: PathRule)
-  extends RouteExecutable[F, T]
+  extends TypedBuilder[F, T]
   with Decodable[F, T, Nothing]
   with HeaderAppendable[F, T]
   with RoutePrependable[F, PathBuilder[F, T]]
   with UriConvertible[F]
 {
-  type HeaderAppendResult[T <: HList] = Router[F, T]
+  type HeaderAppendResult[T0 <: HList] = Router[F, T0]
 
   override val rules: RequestRule[F] = EmptyRule[F]()
 
@@ -87,6 +87,9 @@ final class PathBuilder[F[_], T <: HList](val method: Method, val path: PathRule
 
   override def decoding[R](decoder: EntityDecoder[F, R])(implicit F: Functor[F], t: TypeTag[R]): CodecRouter[F, T, R] =
     CodecRouter(>>>(TypedHeader[F, HNil](EmptyRule[F]())), decoder)
+}
 
-  override def makeRoute(action: Action[F, T]): RhoRoute[F, T] = RhoRoute(Router(method, path, EmptyRule[F]()), action)
+object PathBuilder {
+  implicit def routeExecutable[F[_], T <: HList]: RouteExecutable[F, T, PathBuilder[F, T]] =
+    (pathBuilder: PathBuilder[F, T]) => Router(pathBuilder.method, pathBuilder.path, EmptyRule[F]())
 }

--- a/core/src/main/scala/org/http4s/rho/RhoRoute.scala
+++ b/core/src/main/scala/org/http4s/rho/RhoRoute.scala
@@ -1,16 +1,59 @@
 package org.http4s
 package rho
 
-import org.http4s.rho.bits.PathAST.{TypedPath, PathRule}
+import cats._
+import cats.data.{Kleisli, OptionT}
+import org.http4s.rho.bits.PathAST.{PathRule, TypedPath}
 import org.http4s.rho.bits.RequestAST.RequestRule
 import org.http4s.rho.bits.ResultInfo
+import org.http4s.server.AuthMiddleware
+import shapeless.{HList, HNil}
 
-import shapeless.{HNil, HList}
+object AbstractRhoRoute {
+  /** Existentially typed [[RhoRoute]] useful when the parameters are not needed */
+  type Tpe[F[_]] = AbstractRhoRoute[F, _ <: HList]
+
+  //def unapply[F[_], T <: HList](arg: AbstractRhoRoute[F,T]): Option[(RoutingEntity[F, T], AbstractAction[F, R, T] forSome {type R[_]})] = Some(arg.router, arg.action)
+
+  type Aux[F[_], Rq[_[_]], T <: HList] = AbstractRhoRoute[F, T] { type RequestType[G[_]] = Rq[G] }
+}
+sealed trait AbstractRhoRoute[F[_], T <: HList] {
+  type RequestType[_[_]]
+
+  def router: RoutingEntity[F, T]
+  def action: AbstractAction[F, RequestType, T]
+
+  def responseEncodings: Set[MediaType]
+  def resultInfo: Set[ResultInfo]
+  def method: Method = router.method
+  def path: PathRule = router.path
+  def rules: RequestRule[F] = router.rules
+  def validMedia: Set[MediaRange] = router match {
+    case r: CodecRouter[F,_,_] => r.decoder.consumes
+    case _ => Set.empty
+  }
+}
+
+object RhoRoute {
+  /** Existentially typed [[RhoRoute]] useful when the parameters are not needed */
+  type Tpe[F[_]] = RhoRoute[F, _ <: HList]
+
+  //def unapply[F[_], T <: HList](arg: RhoRoute[F,T]): Option[(RoutingEntity[F, T], AbstractAction[F, R, T] forSome {type R[_]})] = Some(arg.router, arg.action)
+}
+
+sealed trait RhoRoute[F[_], T <: HList]
+  extends AbstractRhoRoute[F, T]
+  with RoutePrependable[F, RhoRoute[F, T]]
 
 /** A type to bundle everything needed to define a route */
-final case class RhoRoute[F[_], T <: HList](router: RoutingEntity[F, T], action: Action[F, T])
-      extends RoutePrependable[F, RhoRoute[F, T]]
+final case class UnAuthedRhoRoute[F[_], T <: HList](override val router: RoutingEntity[F, T],
+                                                                 action: Action[F, T])
+  extends RhoRoute[F, T]
 {
+  override type RequestType[G[_]] = Request[G]
+
+  override def responseEncodings: Set[MediaType] = action.responseEncodings
+  override def resultInfo: Set[ResultInfo] = action.resultInfo
 
   /** Execute the [[RhoRoute]]
     *
@@ -25,22 +68,83 @@ final case class RhoRoute[F[_], T <: HList](router: RoutingEntity[F, T], action:
     * @param prefix non-capturing prefix to prepend
     * @return builder with the prefix prepended to the path rules
     */
+  override def /:(prefix: TypedPath[F, HNil]): UnAuthedRhoRoute[F, T] = {
+    copy(router = prefix /: router)
+  }
+}
+object UnAuthedRhoRoute {
+  /** Existentially typed [[UnAuthedRhoRoute]] useful when the parameters are not needed */
+  type Tpe[F[_]] = UnAuthedRhoRoute[F, _ <: HList]
+}
+
+final case class AuthedRhoRoute[F[_], U, T <: HList](authMiddleware: AuthMiddleware[F, U],
+                                                     override val router: RoutingEntity[F, T],
+                                                                  action: AuthedAction[F, T, U])
+  extends RhoRoute[F, T]
+{
+  override type RequestType[G[_]] = AuthedRequest[G, U]
+
+  override def responseEncodings: Set[MediaType] = action.responseEncodings
+  override def resultInfo: Set[ResultInfo] = action.resultInfo
+
+  /** Execute the [[AuthedRhoRoute]]
+    *
+    * @param req The `AuthedRequest` to be served.
+    * @param hlist Parameters obtained by executing the rules.
+    * @return A `Response` to the `AuthedRequest`.
+    */
+  def apply(req: AuthedRequest[F, U], hlist: T): F[Response[F]] = action.act(req, hlist)
+  /** Execute the [[AuthedRhoRoute]] using the attached authMiddleware
+    *
+    * @param req The `Request` to be served.
+    * @param hlist Parameters obtained by executing the rules.
+    * @return A `Response` to the `AuthedRequest`.
+    */
+  def apply(req: Request[F], hlist: T)(implicit F: Functor[F]): OptionT[F, Response[F]] =
+    authMiddleware(Kleisli((ar: AuthedRequest[F, U]) => action.act(ar, hlist)).mapF(OptionT.liftF[F, Response[F]](_)))(req)
+
+  /** Prefix the [[RhoRoute]] with non-capturing path rules
+    *
+    * @param prefix non-capturing prefix to prepend
+    * @return builder with the prefix prepended to the path rules
+    */
   override def /:(prefix: TypedPath[F, HNil]): RhoRoute[F, T] = {
     copy(router = prefix /: router)
   }
-
-  def method: Method = router.method
-  def path: PathRule = router.path
-  def rules: RequestRule[F] = router.rules
-  def responseEncodings: Set[MediaType] = action.responseEncodings
-  def resultInfo: Set[ResultInfo] = action.resultInfo
-  def validMedia: Set[MediaRange] = router match {
-    case r: CodecRouter[F,_,_] => r.decoder.consumes
-    case _ => Set.empty
-  }
 }
 
-object RhoRoute {
-  /** Existentially typed [[RhoRoute]] useful when the parameters are not needed */
-  type Tpe[F[_]] = RhoRoute[F, _ <: HList]
+object PreAuthedRhoRoute {
+  /** Existentially typed [[PreAuthedRhoRoute]] useful when the parameters are not needed */
+  type Tpe[F[_], U] = PreAuthedRhoRoute[F, U, _ <: HList]
+}
+
+final case class PreAuthedRhoRoute[F[_], U, T <: HList](router: RoutingEntity[F, T], action: AuthedAction[F, T, U])
+  extends AbstractRhoRoute[F, T]
+  with RoutePrependable[F, PreAuthedRhoRoute[F, U, T]] {
+
+  override type RequestType[G[_]] = AuthedRequest[G, U]
+
+  override def responseEncodings: Set[MediaType] = action.responseEncodings
+  override def resultInfo: Set[ResultInfo] = action.resultInfo
+
+  /** Execute the [[PreAuthedRhoRoute]]
+    *
+    * @param req The `AuthedRequest` to be served.
+    * @param hlist Parameters obtained by executing the rules.
+    * @return A `Response` to the `AuthedRequest`.
+    */
+  def apply(req: AuthedRequest[F, U], hlist: T): F[Response[F]] = action.act(req, hlist)
+
+
+  def attachAuthMiddleware(authMiddleware: AuthMiddleware[F, U]): AuthedRhoRoute[F, U, T] =
+    AuthedRhoRoute(authMiddleware, router, action)
+
+  /** Prefix the [[RhoRoute]] with non-capturing path rules
+    *
+    * @param prefix non-capturing prefix to prepend
+    * @return builder with the prefix prepended to the path rules
+    */
+  override def /:(prefix: TypedPath[F, HNil]): PreAuthedRhoRoute[F, U, T] = {
+    copy(router = prefix /: router)
+  }
 }

--- a/core/src/main/scala/org/http4s/rho/RhoRoutes.scala
+++ b/core/src/main/scala/org/http4s/rho/RhoRoutes.scala
@@ -2,9 +2,11 @@ package org.http4s
 package rho
 
 import cats.Monad
+import org.http4s.rho.bits.{AuthedMatchersHListToFunc, MatchersHListToFunc}
 import org.http4s.rho.bits.PathAST.TypedPath
-import org.log4s.getLogger
+import org.http4s.server.AuthMiddleware
 import shapeless.{HList, HNil}
+import scala.collection.immutable.Seq
 
 /** Constructor class for defining routes
   *
@@ -22,17 +24,16 @@ import shapeless.{HList, HNil}
   *
   * @param routes Routes to prepend before elements in the constructor.
   */
-class RhoRoutes[F[_]: Monad](routes: Seq[RhoRoute[F, _ <: HList]] = Vector.empty)
+class RhoRoutes[F[_]: Monad](routes: Seq[UnAuthedRhoRoute[F, _ <: HList]] = Vector.empty)
     extends bits.MethodAliases
     with bits.ResponseGeneratorInstances[F]
     with RoutePrependable[F, RhoRoutes[F]]
     with RhoDsl[F]
+    with MatchersHListToFunc[F]
 {
-  final private val routesBuilder = RoutesBuilder[F](routes)
+  final private val routesBuilder: RoutesBuilder[F, UnAuthedRhoRoute] = RoutesBuilder[F, UnAuthedRhoRoute](routes)
 
-  final protected val logger = getLogger
-
-  final implicit protected def compileRoutes: CompileRoutes[F, RhoRoute.Tpe[F]] = routesBuilder
+  final implicit protected def compileRoutes: CompileRoutes.Aux[F, UnAuthedRhoRoute, UnAuthedRhoRoute.Tpe[F]] = routesBuilder
 
   /** Create a new [[RhoRoutes]] by appending the routes of the passed [[RhoRoutes]]
     *
@@ -42,16 +43,94 @@ class RhoRoutes[F[_]: Monad](routes: Seq[RhoRoute[F, _ <: HList]] = Vector.empty
     */
   final def and(other: RhoRoutes[F]): RhoRoutes[F] = new RhoRoutes(this.getRoutes ++ other.getRoutes)
 
+  final def and(other: CompositeRhoRoutes[F]): CompositeRhoRoutes[F] =
+    new CompositeRhoRoutes(this.getRoutes ++ other.routes)
+
+
   /** Get a snapshot of the collection of [[RhoRoute]]'s accumulated so far */
-  final def getRoutes: Seq[RhoRoute[F, _ <: HList]] = routesBuilder.routes()
+  final def getRoutes: Seq[UnAuthedRhoRoute[F, _ <: HList]] = routesBuilder.routes()
 
   /** Convert the [[RhoRoute]]'s accumulated into a `HttpRoutes` */
-  final def toRoutes(middleware: RhoMiddleware[F] = identity): HttpRoutes[F] =
-    routesBuilder.toRoutes(middleware)
+  final def toHttpRoutes(middleware: ARhoMiddleware[F, UnAuthedRhoRoute] = identity): HttpRoutes[F] =
+    routesBuilder.toHttpRoutes(middleware)
+
+  /** Convert the [[RhoRoute]]'s accumulated into a `HttpRoutes` */
+  final def toHttpRoutes(middleware: RhoMiddleware[F])(implicit dummyImplicit: DummyImplicit): HttpRoutes[F] =
+    new CompositeRhoRoutes(getRoutes).toHttpRoutes(middleware)
 
   final override def toString: String = s"RhoRoutes(${routesBuilder.routes().toString()})"
 
   final override def /:(prefix: TypedPath[F, HNil]): RhoRoutes[F] = {
     new RhoRoutes(routesBuilder.routes().map { prefix /: _ })
   }
+}
+
+class AuthedRhoRoutes[F[_]: Monad, U](routes: Seq[PreAuthedRhoRoute[F, U, _ <: HList]] = Vector.empty)
+  extends bits.MethodAliases
+    with bits.ResponseGeneratorInstances[F]
+    with RoutePrependable[F, AuthedRhoRoutes[F, U]]
+    with RhoDsl[F]
+    with AuthedMatchersHListToFunc[F, U]
+{
+  type Tpe[G[_], T <: HList] = PreAuthedRhoRoute[G, U, T]
+
+  final private val routesBuilder: RoutesBuilder[F, Tpe] = RoutesBuilder[F, Tpe](routes)
+
+  final implicit protected def compileRoutes: CompileRoutes.Aux[F, Tpe, PreAuthedRhoRoute.Tpe[F, U]] =
+    routesBuilder
+
+  /** Create a new [[RhoRoutes]] by appending the routes of the passed [[RhoRoutes]]
+    *
+    * @param other [[RhoRoutes]] whos routes are to be appended.
+    * @return A new [[RhoRoutes]] that contains the routes of the other service appended
+    *         the the routes contained in this service.
+    */
+  final def and(other: AuthedRhoRoutes[F, U]): AuthedRhoRoutes[F, U] = new AuthedRhoRoutes(this.getRoutes ++ other.getRoutes)
+
+  /** Get a snapshot of the collection of [[RhoRoute]]'s accumulated so far */
+  final def getRoutes: Seq[PreAuthedRhoRoute[F, U, _ <: HList]] = routesBuilder.routes()
+
+  /** Convert the [[RhoRoute]]'s accumulated into a `HttpRoutes` */
+  final def toHttpRoutes(middleware: ARhoMiddleware[F, Tpe] = identity): AuthedService[U, F] =
+    routesBuilder.toHttpRoutes(middleware)(CompileHttpRoutes.authedAction[F, U])
+
+  final def toRhoRoutes(authMiddleware: AuthMiddleware[F, U]): CompositeRhoRoutes[F] = {
+    new CompositeRhoRoutes[F](getRoutes.map(_.attachAuthMiddleware(authMiddleware)))
+  }
+
+  final override def toString: String = s"AuthedRhoRoutes(${getRoutes.toString()})"
+
+  /** Prepend the prefix to the path rules
+    *
+    * @param prefix non-capturing prefix to prepend
+    * @return builder with the prefix prepended to the path rules
+    */
+  final override def /:(prefix: TypedPath[F, HNil]): AuthedRhoRoutes[F, U] = {
+    new AuthedRhoRoutes(getRoutes.map { prefix /: _ })
+  }
+}
+
+final class CompositeRhoRoutes[F[_]: Monad](val routes: Seq[RhoRoute[F, _ <:HList]])
+  extends RoutePrependable[F, CompositeRhoRoutes[F]] {
+
+  private val routesBuilder: RoutesBuilder[F, RhoRoute] = RoutesBuilder[F, RhoRoute](routes)
+
+  /** Prepend the prefix to the path rules
+    *
+    * @param prefix non-capturing prefix to prepend
+    * @return builder with the prefix prepended to the path rules
+    */
+  override def /:(prefix: TypedPath[F, HNil]): CompositeRhoRoutes[F] = {
+    new CompositeRhoRoutes(routes.map { prefix /: _ })
+  }
+
+  def and(other: CompositeRhoRoutes[F]): CompositeRhoRoutes[F] =
+    new CompositeRhoRoutes(this.routes ++ other.routes)
+
+  def and(other: RhoRoutes[F]): CompositeRhoRoutes[F] =
+    new CompositeRhoRoutes(this.routes ++ other.getRoutes)
+
+  /** Convert the [[RhoRoute]]'s accumulated into a `HttpRoutes` */
+  def toHttpRoutes(middleware: RhoMiddleware[F] = identity): HttpRoutes[F] =
+    routesBuilder.toHttpRoutes(middleware)(CompileHttpRoutes.action[F])
 }

--- a/core/src/main/scala/org/http4s/rho/RouteExecutable.scala
+++ b/core/src/main/scala/org/http4s/rho/RouteExecutable.scala
@@ -10,15 +10,50 @@ import shapeless.HList
   * @tparam T The `HList` representation of the types the route expects to extract
   *           from a `Request`.
   */
-trait RouteExecutable[F[_], T <: HList] extends TypedBuilder[F, T] { exec =>
-
-  /** `Method` of the incoming HTTP `Request` */
-  def method: Method
-
-  /** Create a [[RhoRoute]] from a given [[Action]] */
-  def makeRoute(action: Action[F, T]): RhoRoute[F, T]
+case class RouteExecutableSyntax[F[_], T <: HList, RE](builder: RE)
+                                                      (implicit re: RouteExecutable[F, T, RE]) {
 
   /** Compiles a HTTP request definition into an action */
-  final def |>>[U, R](f: U)(implicit hltf: HListToFunc[F, T, U], srvc: CompileRoutes[F, R]): R =
-    srvc.compile(makeRoute(hltf.toAction(f)))
+  final def |>>[U, R, RR[G[_], T0 <: HList] <: AbstractRhoRoute[G, T0]](f: U)(implicit
+                            srvc: CompileRoutes.Aux[F, RR, R],
+                            routeBuilder: RouteBuilder.Aux[F, RR],
+                            hltf: HListToFunc[F, RR[F, T]#RequestType, T, U]
+                            ): R = {
+    val action: AbstractAction[F, RR[F, T]#RequestType, T] = hltf.toAction(f)
+    val entity: RoutingEntity[F, T] = re.routingEntity(builder)
+    val route: RR[F, T] = routeBuilder.makeRoute[T](entity, action)
+    srvc.compile(route)
+  }
+}
+
+trait RouteExecutable[F[_], T <: HList, RE] {
+  def routingEntity(re: RE): RoutingEntity[F, T]
+}
+
+
+sealed trait RouteBuilder[F[_]] {
+  type RouteType[G[_], T0 <: HList] <: AbstractRhoRoute[G, T0]
+
+  /** Create a [[RhoRoute]] from a given [[Action]] */
+  def makeRoute[T <: HList](router: RoutingEntity[F, T], action: AbstractAction[F, RouteType[F, T]#RequestType, T]): RouteType[F, T]
+}
+object RouteBuilder {
+  type Aux[F[_], RR[G[_], T <: HList] <: AbstractRhoRoute[G, T]] =
+    RouteBuilder[F] { type RouteType[G[_], T0 <: HList] = RR[G, T0] }
+
+  implicit def unauthedRhoRoute[F[_]]: RouteBuilder.Aux[F, UnAuthedRhoRoute] =
+    new RouteBuilder[F] {
+      override type RouteType[G[_], T0 <: HList] = UnAuthedRhoRoute[G, T0]
+      override def makeRoute[T <: HList](router: RoutingEntity[F, T],
+                                         action: Action[F, T]): UnAuthedRhoRoute[F, T] =
+        UnAuthedRhoRoute(router, action)
+    }
+
+  implicit def preAuthedRhoRoute[F[_], U]: RouteBuilder.Aux[F, λ[(G[_], `T <: HList`) => PreAuthedRhoRoute[G, U, T]]] =
+    new RouteBuilder[F] {
+      override type RouteType[G[_], T0 <: HList] = PreAuthedRhoRoute[G, U, T0]
+      override def makeRoute[T <: HList](router: RoutingEntity[F, T],
+                                         action: AuthedAction[F, T, U]): PreAuthedRhoRoute[F, U, T] =
+        PreAuthedRhoRoute(router, action)
+    }
 }

--- a/core/src/main/scala/org/http4s/rho/Router.scala
+++ b/core/src/main/scala/org/http4s/rho/Router.scala
@@ -31,7 +31,7 @@ sealed trait RoutingEntity[F[_], T <: HList] {
 case class Router[F[_], T <: HList](method: Method,
                                     path: PathRule,
                                     rules: RequestRule[F])
-  extends RouteExecutable[F, T]
+  extends TypedBuilder[F, T]
     with HeaderAppendable[F, T]
     with RoutingEntity[F, T]
     with Decodable[F, T, Nothing]
@@ -39,7 +39,7 @@ case class Router[F[_], T <: HList](method: Method,
 {
   type Self = Router[F, T]
 
-  override type HeaderAppendResult[T <: HList] = Router[F, T]
+  override type HeaderAppendResult[T0 <: HList] = Router[F, T0]
 
   override def /:(prefix: TypedPath[F, HNil]): Self = {
     copy(path = PathAnd(prefix.rule, path))
@@ -48,18 +48,19 @@ case class Router[F[_], T <: HList](method: Method,
   override def >>>[T1 <: HList](v: TypedHeader[F, T1])(implicit prep1: Prepend[T1, T]): Router[F, prep1.Out] =
     Router(method, path, AndRule(rules, v.rule))
 
-  override def makeRoute(action: Action[F, T]): RhoRoute[F, T] = RhoRoute(this, action)
-
   override def decoding[R](decoder: EntityDecoder[F, R])(implicit F: Functor[F], t: TypeTag[R]): CodecRouter[F, T, R] =
     CodecRouter(this, decoder)
 
   def withMethod(other: Method): Self =
     copy(method = other)
 }
+object Router {
+  implicit def routeExecutable[F[_], T <: HList]: RouteExecutable[F, T, Router[F, T]] =
+    (re: Router[F, T]) => re
+}
 
 case class CodecRouter[F[_], T <: HList, R](router: Router[F, T], decoder: EntityDecoder[F, R])(implicit t: TypeTag[R])
   extends HeaderAppendable[F, T]
-    with RouteExecutable[F, R::T]
     with RoutingEntity[F, R::T]
     with Decodable[F, T, R]
 {
@@ -73,10 +74,7 @@ case class CodecRouter[F[_], T <: HList, R](router: Router[F, T], decoder: Entit
   override def /:(prefix: TypedPath[F, HNil]): Self =
     copy(router = prefix /: router)
 
-  /** Append the header to the builder, generating a new typed representation of the route */
-  //  override def >>>[T2 <: HList](header: TypedHeader[T2])(implicit prep: Prepend[T2, T]): CodecRouter[prep.Out, R] = ???
-
-  override def makeRoute(action: Action[F, R::T]): RhoRoute[F, R::T] = RhoRoute(this, action)
+  //override def makeRoute(action: Action[F, R::T]): RhoRoute[F, R::T] = RhoRoute(this, action)
 
   override val path: PathRule = router.path
 
@@ -92,4 +90,7 @@ case class CodecRouter[F[_], T <: HList, R](router: Router[F, T], decoder: Entit
   def withMethod(other: Method): Self =
     copy(router = router.withMethod(other))
 }
-
+object CodecRouter {
+  implicit def routeExecutable[F[_], T <: HList, R]: RouteExecutable[F, R :: T, CodecRouter[F, T, R]] =
+    (re: CodecRouter[F, T, R]) => re
+}

--- a/core/src/main/scala/org/http4s/rho/RoutesBuilder.scala
+++ b/core/src/main/scala/org/http4s/rho/RoutesBuilder.scala
@@ -1,30 +1,32 @@
 package org.http4s.rho
 
-import scala.collection.immutable.VectorBuilder
+import scala.collection.immutable.{VectorBuilder, Seq}
 import cats.Monad
 import shapeless.HList
-import org.http4s._
 
 /** CompileRoutes which accumulates routes and can build a `HttpRoutes` */
-final class RoutesBuilder[F[_]: Monad] private(internalRoutes: VectorBuilder[RhoRoute.Tpe[F]]) extends CompileRoutes[F, RhoRoute.Tpe[F]] {
+final class RoutesBuilder[F[_]: Monad, RouteType[_[_], _ <: HList]] private (internalRoutes: VectorBuilder[RouteType[F, _ <: HList]])
+extends CompileRoutes[F, RouteType[F, _ <: HList]] {
+
+  override type InRouteType[G[_], T <: HList] = RouteType[G, T]
 
   /** Turn the accumulated routes into an `HttpRoutes`
     *
     * @param middleware [[RhoMiddleware]] to apply to the collection of routes.
     * @return An `HttpRoutes` which can be mounted by http4s servers.
     */
-  def toRoutes(middleware: RhoMiddleware[F] = identity): HttpRoutes[F] =
-    CompileRoutes.foldRoutes(middleware.apply(internalRoutes.result()))
+  def toHttpRoutes(middleware: ARhoMiddleware[F, RouteType] = identity)(implicit compileHttpRoutes: CompileHttpRoutes[F, RouteType]): compileHttpRoutes.Out =
+    compileHttpRoutes.foldRoutes(middleware.apply(internalRoutes.result()))
 
   /** Get a snapshot of the currently acquired routes */
-  def routes(): Seq[RhoRoute.Tpe[F]] = internalRoutes.result()
+  def routes(): Seq[RouteType[F, _ <: HList]] = internalRoutes.result()
 
   /** Append the routes into this [[RoutesBuilder]]
     *
     * @param routes Routes to accumulate.
     * @return `this` instance with its internal state mutated.
     */
-  def append(routes: TraversableOnce[RhoRoute.Tpe[F]]): this.type = {
+  def append(routes: TraversableOnce[RouteType[F, _ <: HList]]): this.type = {
     internalRoutes ++= routes
     this
   }
@@ -37,7 +39,7 @@ final class RoutesBuilder[F[_]: Monad] private(internalRoutes: VectorBuilder[Rho
     * @tparam T `HList` representation of the result of the route
     * @return The [[RhoRoute]] passed to the method.
     */
-  override def compile[T <: HList](route: RhoRoute[F, T]): RhoRoute[F, T] = {
+  override def compile[T <: HList](route: RouteType[F, T]): RouteType[F, T] = {
     internalRoutes += route
     route
   }
@@ -45,13 +47,13 @@ final class RoutesBuilder[F[_]: Monad] private(internalRoutes: VectorBuilder[Rho
 
 object RoutesBuilder {
   /** Constructor method for new `RoutesBuilder` instances */
-  def apply[F[_]: Monad](): RoutesBuilder[F] = apply(Seq.empty)
+  def apply[F[_]: Monad, R[_[_], _ <: HList]](): RoutesBuilder[F, R] = apply(Seq.empty)
 
   /** Constructor method for new `RoutesBuilder` instances with existing routes */
-  def apply[F[_]: Monad](routes: Seq[RhoRoute.Tpe[F]]): RoutesBuilder[F] = {
-    val builder = new VectorBuilder[RhoRoute.Tpe[F]]
+  def apply[F[_]: Monad, R[_[_], _ <: HList]](routes: Seq[R[F, _ <: HList]]): RoutesBuilder[F, R] = {
+    val builder = new VectorBuilder[R[F, _ <: HList]]
     builder ++= routes
 
-    new RoutesBuilder(builder)
+    new RoutesBuilder[F, R](builder)
   }
 }

--- a/core/src/main/scala/org/http4s/rho/RuleExecutor.scala
+++ b/core/src/main/scala/org/http4s/rho/RuleExecutor.scala
@@ -1,23 +1,22 @@
 package org.http4s
 package rho
 
-import org.http4s.rho.bits.RequestAST, RequestAST._
-import org.http4s.rho.bits.{ ResultResponse, SuccessResponse }
-
-import shapeless.{ HNil, HList }
+import org.http4s.rho.bits.{RequestAST, RequestLike, ResultResponse, SuccessResponse, requestLikeOps}
+import RequestAST._
+import shapeless.{HList, HNil}
 
 private[rho] trait RuleExecutor[F[_]] {
   //////////////////////// Stuff for executing the route //////////////////////////////////////
 
   /** Execute the rule tree */
-  def runRequestRules(v: RequestRule[F], req: Request[F]): ResultResponse[F, HList] =
+  def runRequestRules[R[_[_]]: RequestLike](v: RequestRule[F], req: R[F]): ResultResponse[F, HList] =
     runRequestRules(req, v, HNil)
 
   /** Executes the [[RequestRule]] tree pushing the results to `stack` */
-  def runRequestRules(req: Request[F], v: RequestRule[F], stack: HList): ResultResponse[F, HList] = v match {
+  def runRequestRules[R[_[_]]: RequestLike](req: R[F], v: RequestRule[F], stack: HList): ResultResponse[F, HList] = v match {
     case AndRule(a, b) => runRequestRules(req, a, stack).flatMap(runRequestRules(req, b, _))
     case OrRule(a, b) => runRequestRules(req, a, stack).orElse(runRequestRules(req, b, stack))
-    case CaptureRule(reader) => reader(req).map(_::stack)
+    case CaptureRule(reader) => reader(req.toRequest).map(_::stack)
     case MetaRule(r, _) => runRequestRules(req, r, stack)
     case EmptyRule() => SuccessResponse(stack)
     case IgnoreRule(r) => runRequestRules(req, r, stack).map(_ => stack)

--- a/core/src/main/scala/org/http4s/rho/bits/HListToFunc.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/HListToFunc.scala
@@ -2,49 +2,77 @@ package org.http4s
 package rho.bits
 
 import cats.Monad
-import org.http4s.rho.Action
-import shapeless.HList
+import org.http4s.rho.AbstractAction
+import shapeless._
+import shapeless.ops.function._
+import shapeless.ops.hlist._
+import shapeless.syntax.std.function._
 
 /** Converter of an value of type F to the HList of type T
   *
  * @tparam T HList type of the incoming values
  * @tparam U type of element onto which T will be mapped
  */
-trait HListToFunc[F[_], T <: HList, -U] {
-  def toAction(f: U): Action[F, T]
+trait HListToFunc[F[_], R[_[_]], T <: HList, -U] {
+  def toAction(f: U): AbstractAction[F, R, T]
 }
 
-trait MatchersHListToFunc[F[_]] {
-  import shapeless._
-  import shapeless.ops.function._
-  import shapeless.ops.hlist._
-  import shapeless.syntax.std.function._
+trait AbstractMatchersHListToFunc[F[_], RQ[_[_]]] {
+  type ActionType[G[_], T0 <: HList] = AbstractAction[G, RQ, T0]
 
   /** Converter of any type with a result matcher when there are no values on the stack
     *
     * @tparam R type of result
     */
-  implicit def const0[R](implicit F: Monad[F], m: ResultMatcher[F, R]): HListToFunc[F, HNil, R] = new MatcherHListToFunc[HNil, R] {
+  implicit def const0[R](implicit F: Monad[F], rq: RequestLike[RQ],m: ResultMatcher[F, R]): HListToFunc[F, RQ, HNil, R] = new MatcherHListToFunc[HNil, R] {
     override def matcher: ResultMatcher[F, R] = m
-    override def conv(r: R): (Request[F], HNil) => F[Response[F]] = (req, _) => m.conv(req, r)
+    override def conv(r: R): (RQ[F], HNil) => F[Response[F]] = (req, _) => m.conv(req, r)
   }
 
   /** Converter for types `FunctionN` to an `HList` */
-  implicit def instance[T <: HList, TR <: HList, FU, R](implicit F: Monad[F], fp: FnToProduct.Aux[FU, TR => R], rev: Reverse.Aux[T, TR], m: Lazy[ResultMatcher[F, R]]): HListToFunc[F, T, FU] = new MatcherHListToFunc[T, FU] {
+  implicit def instance[T <: HList, TR <: HList, FU, R](implicit F: Monad[F], rq: RequestLike[RQ], fp: FnToProduct.Aux[FU, TR => R], rev: Reverse.Aux[T, TR], m: Lazy[ResultMatcher[F, R]]): HListToFunc[F, RQ, T, FU] = new MatcherHListToFunc[T, FU] {
     override def matcher: ResultMatcher[F, R] = m.value
-    override def conv(f: FU): (Request[F], T) => F[Response[F]] = (req: Request[F], h: T) => { matcher.conv(req, f.toProduct(rev(h))) }
+    override def conv(f: FU): (RQ[F], T) => F[Response[F]] = (req: RQ[F], h: T) => { matcher.conv(req, f.toProduct(rev(h))) }
   }
 
-  /** Converter for types `FunctionN` where the first element is a `Request` to an `HList` */
-  implicit def instance1[T <: HList, TR <: HList, FU, R](implicit F: Monad[F], fp: FnToProduct.Aux[FU, Request[F] :: TR => R], rev: Reverse.Aux[T, TR], m: Lazy[ResultMatcher[F, R]]): HListToFunc[F, T, FU] = new MatcherHListToFunc[T, FU] {
+  /** Converter for types `FunctionN` where the first element is a `RQ` to an `HList` */
+  implicit def instanceRQ[T <: HList, TR <: HList, FU, R](implicit F: Monad[F], rq: RequestLike[RQ], fp: FnToProduct.Aux[FU, RQ[F] :: TR => R], rev: Reverse.Aux[T, TR], m: Lazy[ResultMatcher[F, R]]): HListToFunc[F, RQ, T, FU] = new MatcherHListToFunc[T, FU] {
     override def matcher: ResultMatcher[F, R] = m.value
-    override def conv(f: FU): (Request[F], T) => F[Response[F]] = (req: Request[F], h: T) => { matcher.conv(req, f.toProduct(req :: rev(h))) }
+    override def conv(f: FU): (RQ[F], T) => F[Response[F]] = (req: RQ[F], h: T) => { matcher.conv(req, f.toProduct(req :: rev(h))) }
   }
 
   // for convenience
-  private trait MatcherHListToFunc[T <: HList, -FU] extends HListToFunc[F, T, FU] {
+  private[bits] trait MatcherHListToFunc[T <: HList, -FU] extends HListToFunc[F, RQ, T, FU] {
     protected def matcher: ResultMatcher[F, _]
-    protected def conv(f: FU): (Request[F], T) => F[Response[F]]
-    final override def toAction(f: FU) = Action(matcher.resultInfo, matcher.encodings, conv(f))
+    protected def conv(f: FU): (RQ[F], T) => F[Response[F]]
+    final override def toAction(f: FU): AbstractAction[F, RQ, T] = AbstractAction(matcher.resultInfo, matcher.encodings, conv(f))
+  }
+}
+
+trait MatchersHListToFunc[F[_]] extends AbstractMatchersHListToFunc[F, Request]
+
+trait AuthedMatchersHListToFunc[F[_], U] extends AbstractMatchersHListToFunc[F, AuthedRequest[?[_], U]] {
+  type RQ[G[_]] = AuthedRequest[G, U]
+
+  /** Converter for types `FunctionN` where the first element is a `Request` to an `HList` */
+  implicit def instanceRequest[T <: HList, TR <: HList, FU, R](implicit F: Monad[F],
+                                                               rq: RequestLike[RQ],
+                                                               fp: FnToProduct.Aux[FU, Request[F] :: TR => R],
+                                                               rev: Reverse.Aux[T, TR],
+                                                               m: Lazy[ResultMatcher[F, R]]): HListToFunc[F, RQ, T, FU] = new MatcherHListToFunc[T, FU] {
+    override def matcher: ResultMatcher[F, R] = m.value
+    override def conv(f: FU): (RQ[F], T) => F[Response[F]] =
+      (req: RQ[F], h: T) => { matcher.conv(req, f.toProduct(req.req :: rev(h))) }
+  }
+
+  /** Converter for types `FunctionN` where the first element is a `U` to an `HList` */
+  implicit def instanceUser[T <: HList, TR <: HList, FU, R](implicit F: Monad[F],
+                                                            rq: RequestLike[RQ],
+                                                            fp: FnToProduct.Aux[FU, U :: TR => R],
+                                                            rev: Reverse.Aux[T, TR],
+                                                            m: Lazy[ResultMatcher[F, R]]): HListToFunc[F, RQ, T, FU] = new MatcherHListToFunc[T, FU] {
+    override def matcher: ResultMatcher[F, R] = m.value
+    override def conv(f: FU): (RQ[F], T) => F[Response[F]] =
+      (req: RQ[F], h: T) => { matcher.conv(req, f.toProduct(req.authInfo :: rev(h))) }
   }
 }

--- a/core/src/main/scala/org/http4s/rho/bits/RequestLike.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/RequestLike.scala
@@ -1,0 +1,62 @@
+package org.http4s.rho.bits
+
+import org.http4s.{AttributeMap, AuthedRequest, EntityBody, Headers, HttpVersion, Method, Request, Uri}
+
+case class RequestLikeOps[R[_[_]], F[_]](r: R[F]) extends AnyVal {
+  def toRequest(implicit rl: RequestLike[R]): Request[F] = rl.toRequest(r)
+  def method(implicit rl: RequestLike[R]): Method = rl.method(r)
+  def uri(implicit rl: RequestLike[R]): Uri = rl.uri(r)
+  def httpVersion(implicit rl: RequestLike[R]): HttpVersion = rl.httpVersion(r)
+  def headers(implicit rl: RequestLike[R]): Headers = rl.headers(r)
+  def body(implicit rl: RequestLike[R]): EntityBody[F] = rl.body(r)
+  def attributes(implicit rl: RequestLike[R]): AttributeMap = rl.attributes(r)
+  def pathInfo(implicit rl: RequestLike[R]): String = rl.pathInfo(r)
+}
+
+trait RequestLike[R[_[_]]] {
+  def toRequest[F[_]](r: R[F]): Request[F]
+
+  def method[F[_]](r: R[F]): Method
+  def uri[F[_]](r: R[F]): Uri
+  def httpVersion[F[_]](r: R[F]): HttpVersion
+  def headers[F[_]](r: R[F]): Headers
+  def body[F[_]](r: R[F]): EntityBody[F]
+  def attributes[F[_]](r: R[F]): AttributeMap
+
+  def pathInfo[F[_]](r: R[F]): String
+}
+
+object RequestLike {
+  def apply[R[_[_]]](implicit r: RequestLike[R]): RequestLike[R] = r
+
+  implicit val request: RequestLike[Request] =
+    new RequestLike[Request] {
+      override def toRequest[F[_]](r: Request[F]): Request[F] = r
+
+      override def method[F[_]](r: Request[F]): Method = r.method
+      override def uri[F[_]](r: Request[F]): Uri = r.uri
+      override def httpVersion[F[_]](r: Request[F]): HttpVersion = r.httpVersion
+      override def headers[F[_]](r: Request[F]): Headers = r.headers
+      override def body[F[_]](r: Request[F]): EntityBody[F] = r.body
+      override def attributes[F[_]](r: Request[F]): AttributeMap = r.attributes
+
+      override def pathInfo[F[_]](r: Request[F]): String = r.pathInfo
+    }
+
+  implicit def authedRequest[U]: RequestLike[AuthedRequest[?[_], U]] =
+    new RequestLike[AuthedRequest[?[_], U]] {
+      override def toRequest[F[_]](r: AuthedRequest[F, U]): Request[F] = r.req
+
+      override def method[F[_]](r: AuthedRequest[F, U]): Method = r.req.method
+      override def uri[F[_]](r: AuthedRequest[F, U]): Uri = r.req.uri
+      override def httpVersion[F[_]](r: AuthedRequest[F, U]): HttpVersion = r.req.httpVersion
+      override def headers[F[_]](r: AuthedRequest[F, U]): Headers = r.req.headers
+      override def body[F[_]](r: AuthedRequest[F, U]): EntityBody[F] = r.req.body
+      override def attributes[F[_]](r: AuthedRequest[F, U]): AttributeMap = r.req.attributes
+
+      override def pathInfo[F[_]](r: AuthedRequest[F, U]): String = r.req.pathInfo
+    }
+
+  implicit def ops[R[_[_]]: RequestLike, F[_]](r: R[F]): RequestLikeOps[R, F] =
+    RequestLikeOps[R, F](r)
+}

--- a/core/src/main/scala/org/http4s/rho/bits/package.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/package.scala
@@ -1,0 +1,5 @@
+package org.http4s.rho
+
+package object bits {
+  implicit def requestLikeOps[R[_[_]], F[_]](r: R[F])(implicit rl: RequestLike[R]): RequestLikeOps[R, F] = RequestLike.ops[R, F](r)
+}

--- a/core/src/test/scala/org/http4s/rho/ApiTest.scala
+++ b/core/src/test/scala/org/http4s/rho/ApiTest.scala
@@ -18,7 +18,7 @@ class ApiTest extends Specification {
 
   object ruleExecutor extends RuleExecutor[IO]
 
-  def runWith[F[_]: Monad, T <: HList, FU](exec: RouteExecutable[F, T])(f: FU)(implicit hltf: HListToFunc[F, T, FU]): Request[F] => OptionT[F, Response[F]] = {
+  def runWith[F[_]: Monad, T <: HList, FU](exec: RouteExecutable[F, T])(f: FU)(implicit hltf: HListToFunc[F, Request, T, FU]): Request[F] => OptionT[F, Response[F]] = {
     val srvc = new RhoRoutes[F] { exec |>> f }.toRoutes()
     srvc.apply(_: Request[F])
   }

--- a/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/Routes.scala
+++ b/examples/src/main/scala/com/http4s/rho/hal/plus/swagger/demo/Routes.scala
@@ -11,7 +11,7 @@ class Routes(businessLayer: BusinessLayer)(implicit T: Timer[IO], cs: ContextShi
     createRhoMiddleware()
 
   val dynamicContent: HttpRoutes[IO] =
-    new RestRoutes[IO](businessLayer).toRoutes(middleware)
+    new RestRoutes[IO](businessLayer).toHttpRoutes(middleware)
 
   /**
    * Routes for getting static resources. These might be served more efficiently by apache2 or nginx,

--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/Main.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/Main.scala
@@ -21,8 +21,16 @@ object Main extends IOApp {
   def run(args: List[String]): IO[ExitCode] = {
     val middleware = createRhoMiddleware()
 
-    val myService: HttpRoutes[IO] =
-      new MyRoutes[IO](ioSwagger) {}.toRoutes(middleware)
+    val myAuthedRoute: MyAuthedRoutes[IO] = new MyAuthedRoutes[IO]()
+
+    val myRoutes = new MyRoutes[IO](ioSwagger) {}
+
+    val myRhoServices = (
+      (myAuthedRoute.toRhoRoutes(ExampleAuth.simpleAuthMiddlware)) and
+        myRoutes
+      )
+
+    val myService: HttpRoutes[IO] = myRhoServices.toHttpRoutes(middleware)
 
     BlazeServerBuilder[IO]
       .withHttpApp((StaticContentService.routes <+> myService).orNotFound)

--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/MyAuthedRoutes.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/MyAuthedRoutes.scala
@@ -1,0 +1,36 @@
+package com.http4s.rho.swagger.demo
+
+import cats.Monad
+import cats.data.{Kleisli, OptionT}
+import cats.effect.IO
+import org.http4s.rho.AuthedRhoRoutes
+import org.http4s.Request
+import org.http4s.rho.swagger.SwaggerSyntax
+import org.http4s.server.AuthMiddleware
+import org.http4s.util.CaseInsensitiveString
+
+object ExampleAuth {
+  val simpleAuthService: Kleisli[OptionT[IO, ?], Request[IO], SimpleUser] =
+    Kleisli { request =>
+
+      OptionT.fromOption[IO] {
+        request.params.get("api_key").orElse(request.headers.get(CaseInsensitiveString("user")).map(_.value)).map(h => SimpleUser(h))
+      }
+    }
+  val simpleAuthMiddlware: AuthMiddleware[IO, SimpleUser] = AuthMiddleware.apply(simpleAuthService)
+
+}
+case class SimpleUser(name: String)
+
+class MyAuthedRoutes[F[_]: Monad]
+  extends AuthedRhoRoutes[F, SimpleUser]
+  with SwaggerSyntax[F] {
+
+  "Simple route" **
+    GET / "authed" / "ping" |>> Ok("pong!")
+
+  "Simple hello world route" **
+    GET / "authed" / "hello" |>> { (user: SimpleUser) =>
+      Ok(s"Hello ${user.name}!")
+    }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.3
+sbt.version=1.2.8


### PR DESCRIPTION
This still needs lots of tests, and improvements with usages.

- [X] Ability to merge authed and unauthed services swagger docs.
- [ ] Lots more Test.
- [ ] Ability to add some auth information to swagger.
- [ ] Syntactic sugar for rejecting a request for some users on a per route basis.
- [ ] Syntactic sugar for `AuthedRhoRoutes[Kleisli[F, User, ?], User]` to `AuthedRhoRoutes[F, User]` 

This is different than #265 because of with this method a user doesn't have to deal with different [F] contexts forcing the generation of different swagger docs, or having to combine the swagger docs manually.