### PR TITLE
Partially fix #203

### DIFF
--- a/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
@@ -133,7 +133,7 @@ object TypeBuilder {
     }
 
   private[this] def isObjectEnum(sym: Symbol): Boolean =
-    sym.asClass.isSealed && sym.asClass.knownDirectSubclasses.forall { symbol =>
+    sym.isClass && sym.asClass.isSealed && sym.asClass.knownDirectSubclasses.forall { symbol =>
       symbol.isModuleClass && symbol.asClass.isCaseClass
     }
 

--- a/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
@@ -140,10 +140,14 @@ object TypeBuilder {
   private def modelToSwagger(tpe: Type, sfs: SwaggerFormats): Option[ModelImpl] =
     try {
       val TypeRef(_, sym: Symbol, tpeArgs: List[Type]) = tpe
+      val constructor = tpe.member(termNames.CONSTRUCTOR)
+      val typeSignature = if(constructor.owner == tpe.termSymbol) {
+        constructor.typeSignature
+      } else {
+        constructor.typeSignatureIn(tpe)
+      }
       val props: Map[String, Property] =
-        tpe
-          .member(termNames.CONSTRUCTOR)
-          .typeSignatureIn(tpe)
+        typeSignature
           .paramLists
           .flatten
           .map(paramSymToProp(sym, tpeArgs, sfs))

--- a/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
@@ -143,7 +143,7 @@ object TypeBuilder {
       val props: Map[String, Property] =
         tpe
           .member(termNames.CONSTRUCTOR)
-          .typeSignature
+          .typeSignatureIn(tpe)
           .paramLists
           .flatten
           .map(paramSymToProp(sym, tpeArgs, sfs))

--- a/swagger/src/test/scala/org/http4s/rho/swagger/TypeBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/TypeBuilderSpec.scala
@@ -57,7 +57,7 @@ package object model {
   trait Outer[T]{
     case class Inner(t: T)
   }
-  object OuterString extends Outer[String]
+  object OuterInt extends Outer[Int]
 
   type ShapelessIntOrString = Int :+: String :+: CNil
 }
@@ -413,9 +413,14 @@ class TypeBuilderSpec extends Specification {
     }
 
     "Build a model for a class using type parameters of an outer class" in {
-      val ms = modelOf[OuterString.Inner]
-      ms.size must_!== 0 // At least try to return some model.
-      // It won't be a fully correct model since TypeBuilder will fail to resolve the type param T to a concrete type.
+      val ms = modelOf[OuterInt.Inner]
+      ms.size must_== 1
+      val m = ms.head
+      val t = m.properties.get("t")
+      t should not be empty
+      // It won't be a fully correct model since TypeBuilder will fail to resolve the type param T to a concrete type an will fall back to a string.
+      // t.get.`type` must_== "integer"
+      // t.get.format must_== "int32"
     }
 
     "Build a model for shapless coproduct (:+:)" in {

--- a/swagger/src/test/scala/org/http4s/rho/swagger/TypeBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/TypeBuilderSpec.scala
@@ -418,9 +418,8 @@ class TypeBuilderSpec extends Specification {
       val m = ms.head
       val t = m.properties.get("t")
       t should not be empty
-      // It won't be a fully correct model since TypeBuilder will fail to resolve the type param T to a concrete type an will fall back to a string.
-      // t.get.`type` must_== "integer"
-      // t.get.format must_== "int32"
+      t.get.`type` must_== "integer"
+      t.get.format must beSome("int32")
     }
 
     "Build a model for shapless coproduct (:+:)" in {


### PR DESCRIPTION
Add missing sym.isClass check in isObjectEnum

Add tests for partially working shapeless coproducts and classes parametrised by type parameter of an outer type.