### PR TITLE
Fix issue #216

### DIFF
--- a/core/src/main/scala/org/http4s/rho/bits/HListToFunc.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/HListToFunc.scala
@@ -30,14 +30,14 @@ trait MatchersHListToFunc[F[_]] {
   }
 
   /** Converter for types `FunctionN` to an `HList` */
-  implicit def instance[T <: HList, TR <: HList, FU, R](implicit F: Monad[F], fp: FnToProduct.Aux[FU, TR => R], rev: Reverse.Aux[T, TR], m: Lazy[ResultMatcher[F, R]]): HListToFunc[F, T, FU] = new MatcherHListToFunc[T, FU] {
-    override def matcher: ResultMatcher[F, R] = m.value
+  implicit def instance[T <: HList, TR <: HList, FU, R](implicit F: Monad[F], fp: FnToProduct.Aux[FU, TR => R], rev: Reverse.Aux[T, TR], m: ResultMatcher[F, R]): HListToFunc[F, T, FU] = new MatcherHListToFunc[T, FU] {
+    override def matcher: ResultMatcher[F, R] = m
     override def conv(f: FU): (Request[F], T) => F[Response[F]] = (req: Request[F], h: T) => { matcher.conv(req, f.toProduct(rev(h))) }
   }
 
   /** Converter for types `FunctionN` where the first element is a `Request` to an `HList` */
-  implicit def instance1[T <: HList, TR <: HList, FU, R](implicit F: Monad[F], fp: FnToProduct.Aux[FU, Request[F] :: TR => R], rev: Reverse.Aux[T, TR], m: Lazy[ResultMatcher[F, R]]): HListToFunc[F, T, FU] = new MatcherHListToFunc[T, FU] {
-    override def matcher: ResultMatcher[F, R] = m.value
+  implicit def instance1[T <: HList, TR <: HList, FU, R](implicit F: Monad[F], fp: FnToProduct.Aux[FU, Request[F] :: TR => R], rev: Reverse.Aux[T, TR], m: ResultMatcher[F, R]): HListToFunc[F, T, FU] = new MatcherHListToFunc[T, FU] {
+    override def matcher: ResultMatcher[F, R] = m
     override def conv(f: FU): (Request[F], T) => F[Response[F]] = (req: Request[F], h: T) => { matcher.conv(req, f.toProduct(req :: rev(h))) }
   }
 


### PR DESCRIPTION
Removing the `Lazy` on the `ResultMatcher` (which is only barely recursive on situations of `F[ResultMatcher]` seems to fix the issue in #216 with circe `Encoder` causing a compilation issue.

Reproduction requires this dependency: 
`"io.circe" %% "circe-core" % "0.10.0"`

Minimum reproduction.
```
import cats.effect.Effect
import io.circe.Encoder
import org.http4s._
import org.http4s.rho.RhoRoutes

trait Auto

class Test[F[+_]: Effect] extends RhoRoutes[F] {
  implicit def autoEncoder[A <: Auto : Encoder]: EntityEncoder[F, A] = ???

  GET / "get" |>> ({ () => // Didn't work.  Used Lazy[ResultMatcher]
    Ok(())
  })

  GET / "get2" |>> ({ // Worked.  Does not use Lazy[ResultMatcher]
    Ok(())
  })
}
```

I'm still wondering how I can make a test, I haven't isolated what it is about the circe `Encoder` that causes the root issue.