### PR TITLE
Fix Header capture 'default' semantics

### DIFF
--- a/core/src/main/scala/org/http4s/rho/bits/Metadata.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/Metadata.scala
@@ -25,4 +25,4 @@ trait SecurityScopesMetaData extends Metadata {
 case class QueryMetaData[F[_], T](name: String, description: Option[String], p: QueryParser[F, T], default: Option[T], m: TypeTag[T]) extends Metadata
 
 /** Metadata about a header rule */
-case class HeaderMetaData[T <: HeaderKey.Extractable](key: T, default: Boolean) extends Metadata
+case class HeaderMetaData[T <: HeaderKey.Extractable](key: T, isRequired: Boolean) extends Metadata

--- a/core/src/main/scala/org/http4s/rho/package.scala
+++ b/core/src/main/scala/org/http4s/rho/package.scala
@@ -197,9 +197,29 @@ trait RhoDsl[F[_]]
     }.ignore
 
 
-  /** requires the header and will pull this header from the pile and put it into the function args stack */
+  /** Capture the header and put it into the function args stack, if it exists
+    *
+    * @param key `HeaderKey` used to identify the header to capture
+    */
+  def captureOptionally[H <: HeaderKey.Extractable](key: H)(implicit F: Monad[F]): TypedHeader[F, Option[H#HeaderT] :: HNil] =
+    _captureMapR[H, Option[H#HeaderT]](key, isRequired = false)(Right(_))
+
+  /** requires the header and will pull this header from the pile and put it into the function args stack
+    *
+    * @param key `HeaderKey` used to identify the header to capture
+    */
   def capture[H <: HeaderKey.Extractable](key: H)(implicit F: Monad[F]): TypedHeader[F, H#HeaderT :: HNil] =
     captureMap(key)(identity)
+
+  /** Capture the header and put it into the function args stack, if it exists otherwise put the default in the args stack
+    *
+    * @param key `HeaderKey` used to identify the header to capture
+    * @param default The default to be used if the header was not present
+    */
+  def captureOrElse[H <: HeaderKey.Extractable](key: H)(default: H#HeaderT)(implicit F: Monad[F]): TypedHeader[F, H#HeaderT :: HNil] =
+    captureOptionally[H](key).map { header: Option[H#HeaderT] =>
+      header.getOrElse(default)
+    }
 
   /** Capture a specific header and map its value
     *
@@ -207,16 +227,17 @@ trait RhoDsl[F[_]]
     * @param f mapping function
     */
   def captureMap[H <: HeaderKey.Extractable, R](key: H)(f: H#HeaderT => R)(implicit F: Monad[F]): TypedHeader[F, R :: HNil] =
-    captureMapR(key, None)(f andThen (Right(_)))
+    captureMapR(key, None, isRequired = true)(f andThen (Right(_)))
 
   /** Capture a specific header and map its value with an optional override of the missing header response
     *
     * @param key `HeaderKey` used to identify the header to capture
     * @param missingHeaderResult optional override result for the case of a missing header
+    * @param isRequired indicates for metadata purposes that the header is required, always true if `missingHeaderResult` is unset
     * @param f mapping function
     */
-  def captureMapR[H <: HeaderKey.Extractable, R](key: H, missingHeaderResult: Option[F[BaseResult[F]]] = None)(f: H#HeaderT => Either[F[BaseResult[F]], R])(implicit F: Monad[F]): TypedHeader[F, R :: HNil] =
-    _captureMapR(key, missingHeaderResult)(f)
+  def captureMapR[H <: HeaderKey.Extractable, R](key: H, missingHeaderResult: Option[F[BaseResult[F]]] = None, isRequired: Boolean = false)(f: H#HeaderT => Either[F[BaseResult[F]], R])(implicit F: Monad[F]): TypedHeader[F, R :: HNil] =
+    _captureMapR(key, missingHeaderResult, missingHeaderResult.isEmpty || isRequired)(f)
 
   /** Create a header capture rule using the `Request`'s `Headers`
     *
@@ -246,25 +267,24 @@ trait RhoDsl[F[_]]
       }
     }.withMetadata(QueryMetaData(name, description, parser, default = default, m))
 
-  private def _captureMapR[H <: HeaderKey.Extractable, R](key: H, missingHeaderResult: Option[F[BaseResult[F]]])(f: H#HeaderT => Either[F[BaseResult[F]], R])(implicit F: Monad[F]): TypedHeader[F, R :: HNil] =
-    genericHeaderCapture[R] { headers =>
-      headers.get(key) match {
-        case Some(h) =>
-          try f(h) match {
-            case Right(r) => SuccessResponse(r)
-            case Left(r) => FailureResponse.result(r)
-          } catch {
-            case NonFatal(e) =>
-              logger.error(e)(s"""Failure during header capture: "${key.name}" = "${h.value}"""")
-              error("Error processing request.")
-          }
+  private def _captureMapR[H <: HeaderKey.Extractable, R](key: H, missingHeaderResult: Option[F[BaseResult[F]]], isRequired: Boolean)(f: H#HeaderT => Either[F[BaseResult[F]], R])(implicit F: Monad[F]): TypedHeader[F, R :: HNil] =
+    _captureMapR[H, R](key, isRequired) {
+      case Some(header) => f(header)
+      case None => Left(missingHeaderResult.getOrElse(BadRequest(s"Missing header: ${key.name}").widen[BaseResult[F]]))
+    }
 
-        case None => missingHeaderResult match {
-          case Some(r) => FailureResponse.result(r)
-          case None    => badRequest(s"Missing header: ${key.name}")
-        }
+  private def _captureMapR[H <: HeaderKey.Extractable, R](key: H, isRequired: Boolean)(f: Option[H#HeaderT] => Either[F[BaseResult[F]], R])(implicit F: Monad[F]): TypedHeader[F, R :: HNil] =
+    genericHeaderCapture[R] { headers =>
+      val h = headers.get(key)
+      try f(h) match {
+        case Right(r) => SuccessResponse(r)
+        case Left(r) => FailureResponse.result(r)
+      } catch {
+        case NonFatal(e) =>
+          logger.error(e)(s"""Failure during header capture: "${key.name}" ${h.fold("Undefined")(v => s"""= "${v.value}"""")}""")
+          error("Error processing request.")
       }
-    }.withMetadata(HeaderMetaData(key, missingHeaderResult.isDefined))
+    }.withMetadata(HeaderMetaData(key, isRequired = isRequired))
 }
 
 object RhoDsl {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.3
+sbt.version=1.2.8

--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
@@ -206,7 +206,7 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
       stack match {
         case Nil                                   => Nil
         case AndRule(a,b)::xs                      => go(a::b::xs)
-        case MetaRule(a,HeaderMetaData(key,d))::xs => mkHeaderParam(key, d)::go(a::xs)
+        case MetaRule(a,HeaderMetaData(key,r))::xs => mkHeaderParam(key, r)::go(a::xs)
         case MetaRule(a,_)::xs                     => go(a::xs)
         case (EmptyRule() | CaptureRule(_))::xs    => go(xs)
         case MapRule(r,_)::xs                      => go(r::xs)
@@ -402,11 +402,11 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
     }
   }
 
-  def mkHeaderParam(key: HeaderKey.Extractable, hasDefault: Boolean): HeaderParameter =
+  def mkHeaderParam(key: HeaderKey.Extractable, isRequired: Boolean): HeaderParameter =
     HeaderParameter(
       `type`   = "string",
       name     = key.name.toString.some,
-      required = !hasDefault)
+      required = isRequired)
 
   def linearizeStack(stack: List[PathRule]): List[List[PathOperation]] = {
 

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
@@ -206,6 +206,20 @@ class SwaggerModelsBuilderSpec extends Specification {
     }
 
     "set required = false if there is a default value for the header" in {
+      val ra = fooPath >>> captureOrElse(`Content-Length`)(`Content-Length`.unsafeFromLong(20)) |>> { (_: `Content-Length`) => "" }
+
+      sb.collectHeaderParams[IO](ra) must_==
+        List(HeaderParameter(`type` = "string", name = "Content-Length".some, required = false))
+    }
+
+    "set required = false if the header is optional" in {
+      val ra = fooPath >>> captureOptionally(`Content-Length`) |>> { (_: Option[`Content-Length`]) => "" }
+
+      sb.collectHeaderParams[IO](ra) must_==
+        List(HeaderParameter(`type` = "string", name = "Content-Length".some, required = false))
+    }
+
+    "set required = false by default if there is a missingHeaderResult for the header" in {
       val ra = fooPath >>> captureMapR(`Content-Length`, Option(Ok("5")))(Right(_)) |>> { (_: `Content-Length`) => "" }
 
       sb.collectHeaderParams[IO](ra) must_==


### PR DESCRIPTION
The `capture*` family of functions had a `default` parameter that allowed a default response to be sent when a header was not present, but did not have a way to set a default value for a header that was not present, or to optionally capture a header (that is, use an `Option`).  

This PR renames the old `default` parameter to make more sense, fixes the broken swagger values that was being set for it, and adds ways to default, or optionally capture headers.