### PR TITLE
Fix issue 301, POST with body and query string, with no header extractor

### DIFF
--- a/core/src/test/scala/ApiExamples.scala
+++ b/core/src/test/scala/ApiExamples.scala
@@ -176,6 +176,11 @@ class ApiExamples extends Specification {
         POST / "postSomething" ^ UrlForm.entityDecoder[IO] |>> { m: UrlForm =>
           Ok(s"You posted these things: $m")
         }
+
+        // Using decoders after query string
+        POST / "postSomething" +? param[String]("foo") ^ UrlForm.entityDecoder[IO] |>> { (foo: String, m: UrlForm) =>
+          Ok(s"You posted these things ($foo): $m")
+        }
       }
       /// end_src_inlined
 

--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/MyRoutes.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/MyRoutes.scala
@@ -93,6 +93,11 @@ abstract class MyRoutes[F[+_] : Effect](swaggerSyntax: SwaggerSyntax[F])(implici
       "You posted: " + body
     }
 
+  "This route allows your to post stuff with query parameters" **
+    POST / "post-query" +? param[String]("query") ^ EntityDecoder.text[F] |>> { (query: String, body: String) =>
+    s"You queried '$query' and posted: $body"
+  }
+
   "This demonstrates using a process of entities" **
     GET / "stream" |>> {
       val s = 0 until 100 map (i => s"Hello $i\n")


### PR DESCRIPTION
There was a missing link in the chain
PathBuilder -> QueryBuilder -> CodecRouter

What was available
PathBuilder -> QueryBuilder -> Router -> CodecRouter
PathBuilder -> Router -> CodecRouter
PathBuilder -> CodecRouter