### PR TITLE
Issue 299 Maintain the order of inserted paths in swagger

### DIFF
--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
@@ -9,6 +9,7 @@ import org.http4s.rho.bits.RequestAST._
 import org.http4s.rho.bits._
 import org.log4s.getLogger
 
+import scala.collection.immutable.ListMap
 import scala.reflect.runtime.universe._
 import scala.util.control.NonFatal
 
@@ -23,7 +24,7 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
       paths       = collectPaths(rr)(s),
       definitions = collectDefinitions(rr)(s))
 
-  def collectPaths[F[_]](rr: RhoRoute[F, _])(s: Swagger)(implicit etag: WeakTypeTag[F[_]]): Map[String, Path] = {
+  def collectPaths[F[_]](rr: RhoRoute[F, _])(s: Swagger)(implicit etag: WeakTypeTag[F[_]]): ListMap[String, Path] = {
     val pairs = mkPathStrs(rr).map { ps =>
       val o = mkOperation(ps, rr)
       val p0 = s.paths.get(ps).getOrElse(Path())

--- a/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/models.scala
@@ -1,10 +1,12 @@
 package org.http4s.rho.swagger
 
+import java.util.ArrayList
+
 import io.swagger.{models => jm}
 import io.swagger.models.utils.PropertyModelConverter
 
 import scala.collection.JavaConverters._
-import java.util.ArrayList
+import scala.collection.immutable.ListMap
 
 object models {
   import JValue._
@@ -18,7 +20,7 @@ object models {
     , schemes             : List[Scheme]                          = Nil
     , consumes            : List[String]                          = Nil
     , produces            : List[String]                          = Nil
-    , paths               : Map[String, Path]                     = Map.empty
+    , paths               : ListMap[String, Path]                 = ListMap.empty
     , securityDefinitions : Map[String, SecuritySchemeDefinition] = Map.empty
     , definitions         : Map[String, Model]                    = Map.empty
     , parameters          : Map[String, Parameter]                = Map.empty

--- a/swagger/src/test/scala/org/http4s/rho/swagger/Arbitraries.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/Arbitraries.scala
@@ -8,6 +8,8 @@ import org.scalacheck.Arbitrary._
 import org.scalacheck.Gen._
 import org.scalacheck._
 
+import scala.collection.immutable.ListMap
+
 /**
  * Arbitraries for the creation of Swagger models
  *
@@ -40,7 +42,7 @@ object Arbitraries {
         schemes,
         consumes,
         produces,
-        paths,
+        ListMap(paths.toSeq:_*),
         securityDefinitions,
         definitions,
         parameters,


### PR DESCRIPTION
`ListMap` keeps the insertion order in take, where `Map` does not guarantee it.