### PR TITLE
RhoDSL extractor refactor

### DIFF
--- a/core/src/main/scala/org/http4s/rho/RhoDslHeaderExtractors.scala
+++ b/core/src/main/scala/org/http4s/rho/RhoDslHeaderExtractors.scala
@@ -1,0 +1,129 @@
+package org.http4s.rho
+
+import cats.syntax.functor._
+import cats.Monad
+import org.http4s._
+import org.http4s.rho.Result.BaseResult
+import org.http4s.rho.bits.RequestAST.CaptureRule
+import org.http4s.rho.bits._
+import org.log4s.{Logger, getLogger}
+import shapeless.{::, HNil}
+
+import scala.util.control.NonFatal
+
+trait RhoDslHeaderExtractors[F[_]]
+  extends FailureResponseOps[F] {
+
+  private[this] val logger: Logger = getLogger
+
+  /** Requires that the header exists
+    *
+    * @param header `HeaderKey` that identifies the header which is required
+    */
+  def exists(header: HeaderKey.Extractable)(implicit F: Monad[F]): TypedHeader[F, HNil] = existsAndR(header)(_ => None)
+
+  /** Requires that the header exists and satisfies the condition
+    *
+    * @param header  `HeaderKey` that identifies the header to capture and parse
+    * @param f predicate function where a return value of `false` signals an invalid
+    *          header and aborts evaluation with a _BadRequest_ response.
+    */
+  def existsAnd[H <: HeaderKey.Extractable](header: H)(f: H#HeaderT => Boolean)(implicit F: Monad[F]): TypedHeader[F, HNil] =
+    existsAndR[H](header){ h =>
+      if (f(h)) None
+      else Some(BadRequest(s"Invalid header: ${h.name} = ${h.value}").widen)
+    }
+
+  /** Check that the header exists and satisfies the condition
+    *
+    * @param header `HeaderKey` that identifies the header to capture and parse
+    * @param f function that evaluates the header and returns a Some(Response) to
+    *          immediately send back to the user or None to continue evaluation.
+    */
+  def existsAndR[H <: HeaderKey.Extractable](header: H)(f: H#HeaderT => Option[F[BaseResult[F]]])(implicit F: Monad[F]): TypedHeader[F, HNil] =
+    captureMapR(header, None){ h => f(h) match {
+      case Some(r) => Left(r)
+      case None    => Right(())
+    }
+  }.ignore
+
+
+  /** Capture the header and put it into the function args stack, if it exists
+    *
+    * @param key `HeaderKey` used to identify the header to capture
+    */
+  def captureOptionally[H <: HeaderKey.Extractable](key: H)(implicit F: Monad[F]): TypedHeader[F, Option[H#HeaderT] :: HNil] =
+    _captureMapR[H, Option[H#HeaderT]](key, isRequired = false)(Right(_))
+
+  /** requires the header and will pull this header from the pile and put it into the function args stack
+    *
+    * @param key `HeaderKey` used to identify the header to capture
+    */
+  def capture[H <: HeaderKey.Extractable](key: H)(implicit F: Monad[F]): TypedHeader[F, H#HeaderT :: HNil] =
+    captureMap(key)(identity)
+
+  /** Capture the header and put it into the function args stack, if it exists otherwise put the default in the args stack
+    *
+    * @param key `HeaderKey` used to identify the header to capture
+    * @param default The default to be used if the header was not present
+    */
+  def captureOrElse[H <: HeaderKey.Extractable](key: H)(default: H#HeaderT)(implicit F: Monad[F]): TypedHeader[F, H#HeaderT :: HNil] =
+    captureOptionally[H](key).map { header: Option[H#HeaderT] =>
+      header.getOrElse(default)
+    }
+
+  /** Capture a specific header and map its value
+    *
+    * @param key `HeaderKey` used to identify the header to capture
+    * @param f mapping function
+    */
+  def captureMap[H <: HeaderKey.Extractable, R](key: H)(f: H#HeaderT => R)(implicit F: Monad[F]): TypedHeader[F, R :: HNil] =
+    captureMapR(key, None, isRequired = true)(f andThen (Right(_)))
+
+  /** Capture a specific header and map its value with an optional override of the missing header response
+    *
+    * @param key `HeaderKey` used to identify the header to capture
+    * @param missingHeaderResult optional override result for the case of a missing header
+    * @param isRequired indicates for metadata purposes that the header is required, always true if `missingHeaderResult` is unset
+    * @param f mapping function
+    */
+  def captureMapR[H <: HeaderKey.Extractable, R](key: H, missingHeaderResult: Option[F[BaseResult[F]]] = None, isRequired: Boolean = false)(f: H#HeaderT => Either[F[BaseResult[F]], R])(implicit F: Monad[F]): TypedHeader[F, R :: HNil] =
+    _captureMapR(key, missingHeaderResult, missingHeaderResult.isEmpty || isRequired)(f)
+
+  /** Create a header capture rule using the `Request`'s `Headers`
+    *
+    * @param f function generating the result or failure
+    */
+  def genericHeaderCapture[R](f: Headers => ResultResponse[F, R]): TypedHeader[F, R :: HNil] =
+    genericRequestHeaderCapture[R](req => f(req.headers))
+
+  /** Create a header capture rule using the `Request`
+    *
+    * In general, this function should be avoided for most cases because it has access to the entire `Request`
+    * which allows it to modify the `Request` body which should be avoided.
+    *
+    * @param f function generating the result or failure
+    */
+  def genericRequestHeaderCapture[R](f: Request[F] => ResultResponse[F, R]): TypedHeader[F, R :: HNil] =
+    TypedHeader[F, R :: HNil](CaptureRule(f))
+
+  private def _captureMapR[H <: HeaderKey.Extractable, R](key: H, missingHeaderResult: Option[F[BaseResult[F]]], isRequired: Boolean)(f: H#HeaderT => Either[F[BaseResult[F]], R])(implicit F: Monad[F]): TypedHeader[F, R :: HNil] =
+    _captureMapR[H, R](key, isRequired) {
+      case Some(header) => f(header)
+      case None => Left(missingHeaderResult.getOrElse(BadRequest(s"Missing header: ${key.name}").widen[BaseResult[F]]))
+    }
+
+  private def _captureMapR[H <: HeaderKey.Extractable, R](key: H, isRequired: Boolean)(f: Option[H#HeaderT] => Either[F[BaseResult[F]], R])(implicit F: Monad[F]): TypedHeader[F, R :: HNil] =
+    genericHeaderCapture[R] { headers =>
+      val h = headers.get(key)
+      try f(h) match {
+        case Right(r) => SuccessResponse(r)
+        case Left(r) => FailureResponse.result(r)
+      } catch {
+        case NonFatal(e) =>
+          logger.error(e)(s"""Failure during header capture: "${key.name}" ${h.fold("Undefined")(v => s"""= "${v.value}"""")}""")
+          error("Error processing request.")
+      }
+    }.withMetadata(HeaderMetaData(key, isRequired = isRequired))
+}
+

--- a/core/src/main/scala/org/http4s/rho/RhoDslPathExtractors.scala
+++ b/core/src/main/scala/org/http4s/rho/RhoDslPathExtractors.scala
@@ -1,0 +1,36 @@
+package org.http4s.rho
+
+import org.http4s.rho.bits.PathAST._
+import org.http4s.rho.bits._
+import shapeless.{::, HNil}
+
+import scala.reflect.runtime.universe.TypeTag
+
+trait RhoDslPathExtractors[F[_]] {
+
+  private val stringTag = implicitly[TypeTag[String]]
+
+  implicit def pathMatch(s: String): TypedPath[F, HNil] = TypedPath(PathMatch(s))
+
+  implicit def pathMatch(s: Symbol): TypedPath[F, String :: HNil] =
+    TypedPath(PathCapture(s.name, None, StringParser.strParser, stringTag))
+
+  /**
+    * Defines a path variable of a URI that should be bound to a route definition
+    */
+  def pathVar[T](implicit parser: StringParser[F, T], m: TypeTag[T]): TypedPath[F, T :: HNil] =
+    pathVar(m.tpe.toString.toLowerCase)(parser)
+
+  /**
+    * Defines a path variable of a URI that should be bound to a route definition
+    */
+  def pathVar[T](id: String)(implicit parser: StringParser[F, T]): TypedPath[F, T :: HNil] =
+    TypedPath(PathCapture[F](id, None, parser, stringTag))
+
+  /**
+    * Defines a path variable of a URI with description that should be bound to a route definition
+    */
+  def pathVar[T](id: String, description: String)(implicit parser: StringParser[F, T]): TypedPath[F, T :: HNil] =
+    TypedPath(PathCapture[F](id, Some(description), parser, stringTag))
+
+}

--- a/core/src/main/scala/org/http4s/rho/RhoDslQueryParamExtractors.scala
+++ b/core/src/main/scala/org/http4s/rho/RhoDslQueryParamExtractors.scala
@@ -1,0 +1,124 @@
+package org.http4s.rho
+
+import cats.syntax.functor._
+import cats.{FlatMap, Functor, Monad}
+import org.http4s._
+import org.http4s.rho.Result.BaseResult
+import org.http4s.rho.bits.RequestAST.CaptureRule
+import org.http4s.rho.bits._
+import shapeless.{::, HNil}
+
+import scala.reflect.runtime.universe.TypeTag
+
+trait RhoDslQueryParamExtractors[F[_]]
+  extends FailureResponseOps[F] {
+
+  /** Defines a parameter in query string that should be bound to a route definition. */
+  private def _paramR[T](name: String, description: Option[String], default: Option[T], validate: T => Option[F[BaseResult[F]]])(implicit F: Functor[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
+    genericRequestQueryCapture[T] { req =>
+      val result = parser.collect(name, req.uri.multiParams, default)
+      result.flatMap { r => validate(r) match {
+        case None       => result
+        case Some(resp) => FailureResponse.pure(F.map(resp)(_.resp))
+      }
+    }
+  }.withMetadata(QueryMetaData(name, description, parser, default = default, m))
+
+  /**
+    * Defines a parameter in query string that should be bound to a route definition.
+    *
+    * @param name name of the parameter in query
+    */
+  def param[T](name: String)(implicit F: FlatMap[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
+    _paramR(name, None, None, _ => None)
+
+  /**
+    * Defines a parameter in query string that should be bound to a route definition.
+    *
+    * @param name        name of the parameter in query
+    * @param description description of the parameter
+    */
+  def paramD[T](name: String, description: String)(implicit F: FlatMap[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
+    _paramR(name, Some(description), None, _ => None)
+
+  /** Define a query parameter with a default value */
+  def param[T](name: String, default: T)(implicit F: FlatMap[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
+    _paramR(name, None, Some(default), _ => None)
+
+  /** Define a query parameter with description and a default value */
+  def paramD[T](name: String, default: T, description: String)(implicit F: FlatMap[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
+    _paramR(name, Some(description), Some(default), _ => None)
+
+  /** Define a query parameter that will be validated with the predicate
+    *
+    * Failure of the predicate results in a '403: BadRequest' response. */
+  def param[T](name: String, validate: T => Boolean)
+              (implicit F: Monad[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
+    paramR(name, { t =>
+      if (validate(t)) None
+      else Some(BadRequest(s"""Invalid query parameter: "$name" = "$t"""").widen)
+    })
+
+  /** Define a query parameter with description that will be validated with the predicate
+    *
+    * Failure of the predicate results in a '403: BadRequest' response. */
+  def paramD[T](name: String, description: String, validate: T => Boolean)
+               (implicit F: Monad[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
+    paramRDescr(name, description, { t: T =>
+      if (validate(t)) None
+      else Some(BadRequest(s"""Invalid query parameter: "$name" = "$t"""").widen)
+    })
+
+  /** Define a query parameter that will be validated with the predicate
+    *
+    * Failure of the predicate results in a '403: BadRequest' response. */
+  def param[T](name: String, default: T, validate: T => Boolean)
+              (implicit F: Monad[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
+    paramR(name, default, { t: T =>
+      if (validate(t)) None
+      else Some(BadRequest(s"""Invalid query parameter: "$name" = "$t"""").widen)
+    })
+
+  /** Define a query parameter with description that will be validated with the predicate
+    *
+    * Failure of the predicate results in a '403: BadRequest' response. */
+  def paramD[T](name: String, description: String, default: T, validate: T => Boolean)
+               (implicit F: Monad[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
+    paramR(name, description, default, { t =>
+      if (validate(t)) None
+      else Some(BadRequest(s"""Invalid query parameter: "$name" = "$t"""").widen)
+    })
+
+  /** Defines a parameter in query string that should be bound to a route definition. */
+  def paramR[T](name: String, validate: T => Option[F[BaseResult[F]]])(implicit F: FlatMap[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
+    _paramR(name, None, None, validate)
+
+  /** Defines a parameter in query string with description that should be bound to a route definition. */
+  def paramRDescr[T](name: String, description: String, validate: T => Option[F[BaseResult[F]]])(implicit F: FlatMap[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
+    _paramR(name, Some(description), None, validate)
+
+  /** Defines a parameter in query string that should be bound to a route definition. */
+  def paramR[T](name: String, default: T, validate: T => Option[F[BaseResult[F]]])(implicit F: FlatMap[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
+    _paramR(name, None, Some(default), validate)
+
+  /** Defines a parameter in query string with description that should be bound to a route definition. */
+  def paramR[T](name: String, description: String, default: T, validate: T => Option[F[BaseResult[F]]])(implicit F: FlatMap[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
+    _paramR(name, Some(description), Some(default), validate)
+
+  /** Create a query capture rule using the `Request`'s `Uri`
+    *
+    * @param f function generating the result or failure
+    */
+  def genericQueryCapture[R](f: Query => ResultResponse[F, R]): TypedQuery[F, R :: HNil] =
+    genericRequestQueryCapture[R](req => f(req.uri.query))
+
+  /** Create a query capture rule using the `Request`
+    *
+    * In general, this function should be avoided for most cases because it has access to the entire `Request`
+    * which allows it to modify the `Request` body which should be avoided.
+    *
+    * @param f function generating the result or failure
+    */
+  def genericRequestQueryCapture[R](f: Request[F] => ResultResponse[F, R]): TypedQuery[F, R :: HNil] =
+    TypedQuery(CaptureRule(f))
+}

--- a/core/src/main/scala/org/http4s/rho/package.scala
+++ b/core/src/main/scala/org/http4s/rho/package.scala
@@ -1,18 +1,11 @@
-package org.http4s
+  package org.http4s
 
-import cats.syntax.functor._
-import cats.{FlatMap, Functor, Monad}
-import org.http4s.rho.Result.BaseResult
-import org.http4s.rho.bits.PathAST._
-import org.http4s.rho.bits.RequestAST.CaptureRule
+import org.http4s.rho.{PathBuilder, PathEmpty, ResultSyntaxInstances, RhoDslHeaderExtractors, RhoDslPathExtractors, RhoDslQueryParamExtractors}
 import org.http4s.rho.bits._
-import org.http4s.rho.{PathBuilder, PathEmpty, ResultSyntaxInstances}
-import org.log4s.getLogger
-import shapeless.{::, HList, HNil}
+import org.http4s.rho.bits.PathAST._
+import shapeless.{HList, HNil}
 
 import scala.language.implicitConversions
-import scala.reflect.runtime.universe.TypeTag
-import scala.util.control.NonFatal
 
 package object rho extends org.http4s.syntax.AllSyntax {
   type RhoMiddleware[F[_]] = Seq[RhoRoute[F, _ <: HList]] => Seq[RhoRoute[F, _ <: HList]]
@@ -21,270 +14,26 @@ package object rho extends org.http4s.syntax.AllSyntax {
 }
 
 trait RhoDsl[F[_]]
-  extends ResultSyntaxInstances[F]
+  extends RhoDslQueryParamExtractors[F]
+    with RhoDslPathExtractors[F]
+    with RhoDslHeaderExtractors[F]
+    with ResultSyntaxInstances[F]
     with QueryParsers[F]
     with MatchersHListToFunc[F]
     with ResponseGeneratorInstances[F]
     with FailureResponseOps[F] {
 
-  private[this] val logger = getLogger
-
-  private val stringTag = implicitly[TypeTag[String]]
-
   implicit def method(m: Method): PathBuilder[F, HNil] = new PathBuilder(m, PathEmpty)
 
-  implicit def pathMatch(s: String): TypedPath[F, HNil] = TypedPath(PathMatch(s))
-
-  implicit def pathMatch(s: Symbol): TypedPath[F, String :: HNil] =
-    TypedPath(PathCapture(s.name, None, StringParser.strParser, stringTag))
-
   /**
-   * Defines a parameter in query string that should be bound to a route definition.
-   * @param name name of the parameter in query
-   */
-  def param[T](name: String)(implicit F: FlatMap[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
-    _paramR(name, None, None, _ => None)
-
-  /**
-    * Defines a parameter in query string that should be bound to a route definition.
-    * @param name name of the parameter in query
-    * @param description description of the parameter
+    * Helper to be able to define a path with one level only.
+    * {{{
+    * val hello = Root / "hello"
+    * }}}
     */
-  def paramD[T](name: String, description: String)(implicit F: FlatMap[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
-    _paramR(name, Some(description), None, _ => None)
-
-  /** Define a query parameter with a default value */
-  def param[T](name: String, default: T)(implicit F: FlatMap[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
-    _paramR(name, None, Some(default), _ => None)
-
-  /** Define a query parameter with description and a default value */
-  def paramD[T](name: String, default: T, description: String)(implicit F: FlatMap[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
-    _paramR(name, Some(description), Some(default), _ => None)
-
-  /** Define a query parameter that will be validated with the predicate
-    *
-    * Failure of the predicate results in a '403: BadRequest' response. */
-  def param[T](name: String, validate: T => Boolean)
-                    (implicit F: Monad[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
-    paramR(name, {t =>
-      if (validate(t)) None
-      else Some(BadRequest(s"""Invalid query parameter: "$name" = "$t"""").widen)
-    })
-
-  /** Define a query parameter with description that will be validated with the predicate
-    *
-    * Failure of the predicate results in a '403: BadRequest' response. */
-  def paramD[T](name: String, description: String, validate: T => Boolean)
-                     (implicit F: Monad[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
-    paramRDescr(name, description, { t: T =>
-      if (validate(t)) None
-      else Some(BadRequest(s"""Invalid query parameter: "$name" = "$t"""").widen)
-    })
-
-  /** Define a query parameter that will be validated with the predicate
-    *
-    * Failure of the predicate results in a '403: BadRequest' response. */
-  def param[T](name: String, default: T, validate: T => Boolean)
-                    (implicit F: Monad[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
-    paramR(name, default, { t: T =>
-      if (validate(t)) None
-      else Some(BadRequest(s"""Invalid query parameter: "$name" = "$t"""").widen)
-    })
-
-  /** Define a query parameter with description that will be validated with the predicate
-    *
-    * Failure of the predicate results in a '403: BadRequest' response. */
-  def paramD[T](name: String, description: String, default: T, validate: T => Boolean)
-                     (implicit F: Monad[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
-    paramR(name, description, default, { t =>
-      if (validate(t)) None
-      else Some(BadRequest(s"""Invalid query parameter: "$name" = "$t"""").widen)
-    })
-
-  /** Defines a parameter in query string that should be bound to a route definition. */
-  def paramR[T](name: String, validate: T => Option[F[BaseResult[F]]])(implicit F: FlatMap[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
-    _paramR(name, None, None, validate)
-
-  /** Defines a parameter in query string with description that should be bound to a route definition. */
-  def paramRDescr[T](name: String, description: String, validate: T => Option[F[BaseResult[F]]])(implicit F: FlatMap[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
-    _paramR(name, Some(description), None, validate)
-
-  /** Defines a parameter in query string that should be bound to a route definition. */
-  def paramR[T](name: String, default: T, validate: T => Option[F[BaseResult[F]]])(implicit F: FlatMap[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
-    _paramR(name, None, Some(default), validate)
-
-  /** Defines a parameter in query string with description that should be bound to a route definition. */
-  def paramR[T](name: String, description: String, default: T, validate: T => Option[F[BaseResult[F]]])(implicit F: FlatMap[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
-    _paramR(name, Some(description), Some(default), validate)
-
-  /** Create a query capture rule using the `Request`'s `Uri`
-    *
-    * @param f function generating the result or failure
-    */
-  def genericQueryCapture[R](f: Query => ResultResponse[F, R]): TypedQuery[F, R :: HNil] =
-    genericRequestQueryCapture[R](req => f(req.uri.query))
-
-  /** Create a query capture rule using the `Request`
-    *
-    * In general, this function should be avoided for most cases because it has access to the entire `Request`
-    * which allows it to modify the `Request` body which should be avoided.
-    *
-    * @param f function generating the result or failure
-    */
-  def genericRequestQueryCapture[R](f: Request[F] => ResultResponse[F, R]): TypedQuery[F, R :: HNil] =
-    TypedQuery(CaptureRule(f))
-
-  /////////////////////////////// Path helpers //////////////////////////////////////
-  /**
-   * Defines a path variable of a URI that should be bound to a route definition
-   */
-  def pathVar[T](implicit parser: StringParser[F, T], m: TypeTag[T]): TypedPath[F, T :: HNil] =
-    pathVar(m.tpe.toString.toLowerCase)(parser)
-
-  /**
-   * Defines a path variable of a URI that should be bound to a route definition
-   */
-  def pathVar[T](id: String)(implicit parser: StringParser[F, T]): TypedPath[F, T :: HNil] =
-    TypedPath(PathCapture[F](id, None, parser, stringTag))
-
-  /**
-    * Defines a path variable of a URI with description that should be bound to a route definition
-    */
-  def pathVar[T](id: String, description: String)(implicit parser: StringParser[F, T]): TypedPath[F, T :: HNil] =
-    TypedPath(PathCapture[F](id, Some(description), parser, stringTag))
-
-  /**
-   * Helper to be able to define a path with one level only.
-   * {{{
-   * val hello = Root / "hello"
-   * }}}
-   */
   def root(): TypedPath[F, HNil] = TypedPath(PathEmpty)
 
   def * : CaptureTail.type = CaptureTail
-
-  /////////////////////////////// Header helpers //////////////////////////////////////
-
-  /** Requires that the header exists
-    *
-    * @param header `HeaderKey` that identifies the header which is required
-    */
-  def exists(header: HeaderKey.Extractable)(implicit F: Monad[F]): TypedHeader[F, HNil] = existsAndR(header)(_ => None)
-
-  /** Requires that the header exists and satisfies the condition
-    *
-    * @param header  `HeaderKey` that identifies the header to capture and parse
-    * @param f predicate function where a return value of `false` signals an invalid
-    *          header and aborts evaluation with a _BadRequest_ response.
-    */
-  def existsAnd[H <: HeaderKey.Extractable](header: H)(f: H#HeaderT => Boolean)(implicit F: Monad[F]): TypedHeader[F, HNil] =
-    existsAndR[H](header){ h =>
-      if (f(h)) None
-      else Some(BadRequest(s"Invalid header: ${h.name} = ${h.value}").widen)
-    }
-
-  /** Check that the header exists and satisfies the condition
-    *
-    * @param header `HeaderKey` that identifies the header to capture and parse
-    * @param f function that evaluates the header and returns a Some(Response) to
-    *          immediately send back to the user or None to continue evaluation.
-    */
-  def existsAndR[H <: HeaderKey.Extractable](header: H)(f: H#HeaderT => Option[F[BaseResult[F]]])(implicit F: Monad[F]): TypedHeader[F, HNil] =
-    captureMapR(header, None){ h => f(h) match {
-        case Some(r) => Left(r)
-        case None    => Right(())
-      }
-    }.ignore
-
-
-  /** Capture the header and put it into the function args stack, if it exists
-    *
-    * @param key `HeaderKey` used to identify the header to capture
-    */
-  def captureOptionally[H <: HeaderKey.Extractable](key: H)(implicit F: Monad[F]): TypedHeader[F, Option[H#HeaderT] :: HNil] =
-    _captureMapR[H, Option[H#HeaderT]](key, isRequired = false)(Right(_))
-
-  /** requires the header and will pull this header from the pile and put it into the function args stack
-    *
-    * @param key `HeaderKey` used to identify the header to capture
-    */
-  def capture[H <: HeaderKey.Extractable](key: H)(implicit F: Monad[F]): TypedHeader[F, H#HeaderT :: HNil] =
-    captureMap(key)(identity)
-
-  /** Capture the header and put it into the function args stack, if it exists otherwise put the default in the args stack
-    *
-    * @param key `HeaderKey` used to identify the header to capture
-    * @param default The default to be used if the header was not present
-    */
-  def captureOrElse[H <: HeaderKey.Extractable](key: H)(default: H#HeaderT)(implicit F: Monad[F]): TypedHeader[F, H#HeaderT :: HNil] =
-    captureOptionally[H](key).map { header: Option[H#HeaderT] =>
-      header.getOrElse(default)
-    }
-
-  /** Capture a specific header and map its value
-    *
-    * @param key `HeaderKey` used to identify the header to capture
-    * @param f mapping function
-    */
-  def captureMap[H <: HeaderKey.Extractable, R](key: H)(f: H#HeaderT => R)(implicit F: Monad[F]): TypedHeader[F, R :: HNil] =
-    captureMapR(key, None, isRequired = true)(f andThen (Right(_)))
-
-  /** Capture a specific header and map its value with an optional override of the missing header response
-    *
-    * @param key `HeaderKey` used to identify the header to capture
-    * @param missingHeaderResult optional override result for the case of a missing header
-    * @param isRequired indicates for metadata purposes that the header is required, always true if `missingHeaderResult` is unset
-    * @param f mapping function
-    */
-  def captureMapR[H <: HeaderKey.Extractable, R](key: H, missingHeaderResult: Option[F[BaseResult[F]]] = None, isRequired: Boolean = false)(f: H#HeaderT => Either[F[BaseResult[F]], R])(implicit F: Monad[F]): TypedHeader[F, R :: HNil] =
-    _captureMapR(key, missingHeaderResult, missingHeaderResult.isEmpty || isRequired)(f)
-
-  /** Create a header capture rule using the `Request`'s `Headers`
-    *
-    * @param f function generating the result or failure
-    */
-  def genericHeaderCapture[R](f: Headers => ResultResponse[F, R]): TypedHeader[F, R :: HNil] =
-    genericRequestHeaderCapture[R](req => f(req.headers))
-
-  /** Create a header capture rule using the `Request`
-    *
-    * In general, this function should be avoided for most cases because it has access to the entire `Request`
-    * which allows it to modify the `Request` body which should be avoided.
-    *
-    * @param f function generating the result or failure
-    */
-  def genericRequestHeaderCapture[R](f: Request[F] => ResultResponse[F, R]): TypedHeader[F, R :: HNil] =
-    TypedHeader[F, R :: HNil](CaptureRule(f))
-
-  /** Defines a parameter in query string that should be bound to a route definition. */
-  private def _paramR[T](name: String, description: Option[String], default: Option[T], validate: T => Option[F[BaseResult[F]]])(implicit F: Functor[F], parser: QueryParser[F, T], m: TypeTag[T]): TypedQuery[F, T :: HNil] =
-    genericRequestQueryCapture[T] { req =>
-        val result = parser.collect(name, req.uri.multiParams, default)
-        result.flatMap { r => validate(r) match {
-          case None       => result
-          case Some(resp) => FailureResponse.pure(F.map(resp)(_.resp))
-        }
-      }
-    }.withMetadata(QueryMetaData(name, description, parser, default = default, m))
-
-  private def _captureMapR[H <: HeaderKey.Extractable, R](key: H, missingHeaderResult: Option[F[BaseResult[F]]], isRequired: Boolean)(f: H#HeaderT => Either[F[BaseResult[F]], R])(implicit F: Monad[F]): TypedHeader[F, R :: HNil] =
-    _captureMapR[H, R](key, isRequired) {
-      case Some(header) => f(header)
-      case None => Left(missingHeaderResult.getOrElse(BadRequest(s"Missing header: ${key.name}").widen[BaseResult[F]]))
-    }
-
-  private def _captureMapR[H <: HeaderKey.Extractable, R](key: H, isRequired: Boolean)(f: Option[H#HeaderT] => Either[F[BaseResult[F]], R])(implicit F: Monad[F]): TypedHeader[F, R :: HNil] =
-    genericHeaderCapture[R] { headers =>
-      val h = headers.get(key)
-      try f(h) match {
-        case Right(r) => SuccessResponse(r)
-        case Left(r) => FailureResponse.result(r)
-      } catch {
-        case NonFatal(e) =>
-          logger.error(e)(s"""Failure during header capture: "${key.name}" ${h.fold("Undefined")(v => s"""= "${v.value}"""")}""")
-          error("Error processing request.")
-      }
-    }.withMetadata(HeaderMetaData(key, isRequired = isRequired))
 }
 
 object RhoDsl {


### PR DESCRIPTION
moving path, query and header extractors to their own files so future refactoring will be easier.

Nothing has changed, just been moved around.

(Working on custom error messages) 