### PR TITLE
Add support for user-provided route tags.

### DIFF
--- a/examples/src/main/scala/com/http4s/rho/swagger/demo/MyRoutes.scala
+++ b/examples/src/main/scala/com/http4s/rho/swagger/demo/MyRoutes.scala
@@ -39,7 +39,7 @@ abstract class MyRoutes[F[+_] : Effect](swaggerSyntax: SwaggerSyntax[F])(implici
     GET |>> TemporaryRedirect(Uri(path = "/swagger-ui"))
 
   // We want to define this chunk of the service as abstract for reuse below
-  val hello = GET / "hello"
+  val hello = "hello" @@ GET / "hello"
 
   "Simple hello world route" **
     hello |>> Ok("Hello world!")
@@ -66,19 +66,23 @@ abstract class MyRoutes[F[+_] : Effect](swaggerSyntax: SwaggerSyntax[F])(implici
     }
 
   "Adds the cookie Foo=bar to the client" **
+  "cookies" @@
     GET / "addcookie" |>> {
       Ok("You now have a good cookie!").map(_.addCookie("Foo", "bar"))
     }
 
   "Sets the cookie Foo=barr to the client" **
+  "cookies" @@
     GET / "addbadcookie" |>> {
       Ok("You now have an evil cookie!").map(_.addCookie("Foo", "barr"))
     }
 
   "Checks the Foo cookie to make sure its 'bar'" **
+  "cookies" @@
     GET / "checkcookie" >>> requireCookie |>> Ok("Good job, you have the cookie!")
 
   "Clears the cookies" **
+  "cookies" @@
     GET / "clearcookies" |>> { req: Request[F] =>
       val hs = req.headers.get(headers.Cookie) match {
         case None => Headers.empty
@@ -89,12 +93,14 @@ abstract class MyRoutes[F[+_] : Effect](swaggerSyntax: SwaggerSyntax[F])(implici
       Ok("Deleted cookies!").map(_.withHeaders(hs))
     }
 
-  "This route allows your to post stuff" **
-    POST / "post" ^ EntityDecoder.text[F] |>> { body: String =>
+    "This route allows your to post stuff" **
+    List("post", "stuff") @@
+      POST / "post" ^ EntityDecoder.text[F] |>> { body: String =>
       "You posted: " + body
     }
 
   "This route allows your to post stuff with query parameters" **
+  List("post", "stuff", "query") @@
     POST / "post-query" +? param[String]("query") ^ EntityDecoder.text[F] |>> { (query: String, body: String) =>
     s"You queried '$query' and posted: $body"
   }

--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSyntax.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSyntax.scala
@@ -7,13 +7,19 @@ import shapeless.HNil
 
 trait SwaggerSyntax[F[_]] {
 
-  /** Add support for adding documentation before a route using the ** operator */
-  implicit class StrOps(description: String) {
+  /** Add support for adding documentation to routes using symbolic operators. */
+  implicit class StrOps(doc: String) {
     def **(method: Method): PathBuilder[F, HNil] =
       **(new PathBuilder[F, HNil](method, PathEmpty))
 
     def **[T <: HNil](builder: PathBuilder[F, T]): PathBuilder[F, T] =
-      new PathBuilder(builder.method, PathAST.MetaCons(builder.path, RouteDesc(description)))
+      new PathBuilder(builder.method, PathAST.MetaCons(builder.path, RouteDesc(doc)))
+
+    def @@(method: Method): PathBuilder[F, HNil] =
+      @@(new PathBuilder[F, HNil](method, PathEmpty))
+
+    def @@[T <: HNil](builder: PathBuilder[F, T]): PathBuilder[F, T] =
+      new PathBuilder(builder.method, PathAST.MetaCons(builder.path, RouteTags(List(doc))))
   }
 
   /** Add support for adding tags before a route using the @@ operator */

--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSyntax.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSyntax.scala
@@ -15,4 +15,13 @@ trait SwaggerSyntax[F[_]] {
     def **[T <: HNil](builder: PathBuilder[F, T]): PathBuilder[F, T] =
       new PathBuilder(builder.method, PathAST.MetaCons(builder.path, RouteDesc(description)))
   }
+
+  /** Add support for adding tags before a route using the @@ operator */
+  implicit class ListOps(tags: List[String]) {
+    def @@(method: Method): PathBuilder[F, HNil] =
+      @@(new PathBuilder[F, HNil](method, PathEmpty))
+
+    def @@[T <: HNil](builder: PathBuilder[F, T]): PathBuilder[F, T] =
+      new PathBuilder(builder.method, PathAST.MetaCons(builder.path, RouteTags(tags)))
+  }
 }

--- a/swagger/src/main/scala/org/http4s/rho/swagger/package.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/package.scala
@@ -2,7 +2,7 @@ package org.http4s.rho
 
 import fs2.Stream
 import org.http4s.Method
-import org.http4s.rho.bits.{PathAST, SecurityScopesMetaData, TextMetaData}
+import org.http4s.rho.bits.{Metadata, PathAST, SecurityScopesMetaData, TextMetaData}
 import org.http4s.rho.swagger.models.Model
 import shapeless.{HList, HNil}
 
@@ -12,6 +12,8 @@ package object swagger {
 
   /** Metadata carrier for specific routes */
   case class RouteDesc(msg: String) extends TextMetaData
+
+  case class RouteTags(tags: List[String]) extends Metadata
 
   /** Scopes carrier for specific routes */
   case class RouteSecurityScope(definitions: Map[String, List[String]]) extends SecurityScopesMetaData

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
@@ -260,6 +260,11 @@ class SwaggerModelsBuilderSpec extends Specification {
       sb.mkOperation("/foo", ra).summary must_== "foo".some
     }
 
+    "Get explicit route tag" in {
+      val ra = "tag" @@ GET / "bar" |>> { () => "" }
+      sb.mkOperation("/bar", ra).tags must_== List("tag")
+    }
+
     "Get explicit route tags" in {
       val ra = List("tag1", "tag2") @@ GET / "bar" |>> { () => "" }
 
@@ -280,8 +285,11 @@ class SwaggerModelsBuilderSpec extends Specification {
     "Mix and match route descriptions and tags" in {
       val ra1 = "foo" ** List("tag1", "tag2") @@ GET / "bar" |>> { () => "" }
       val ra2 = List("tag1", "tag2") @@ ("foo" ** GET / "bar") |>> { () => "" }
+      val ra3 = "foo" ** "tag" @@ GET / "bar" |>> { () => "" }
+      val ra4 = "tag" @@ ("foo" ** GET / "bar") |>> { () => "" }
 
       sb.mkOperation("/bar", ra1) must_== sb.mkOperation("/bar", ra2)
+      sb.mkOperation("/bar", ra3) must_== sb.mkOperation("/bar", ra4)
     }
 
     "Preserve explicit tags after prepending segments" in {

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
@@ -260,6 +260,37 @@ class SwaggerModelsBuilderSpec extends Specification {
       sb.mkOperation("/foo", ra).summary must_== "foo".some
     }
 
+    "Get explicit route tags" in {
+      val ra = List("tag1", "tag2") @@ GET / "bar" |>> { () => "" }
+
+      sb.mkOperation("/bar", ra).tags must_== List("tag1", "tag2")
+    }
+
+    "Default to first segment for tags" in {
+      val ra = GET / "foo" / "bar" |>> { () => "" }
+
+      sb.mkOperation("/foo/bar", ra).tags must_== List("foo")
+    }
+
+    "Default to / as a tag for routes without segments" in {
+      val ra = GET |>> { () => "" }
+      sb.mkOperation("/", ra).tags must_== List("/")
+    }
+
+    "Mix and match route descriptions and tags" in {
+      val ra1 = "foo" ** List("tag1", "tag2") @@ GET / "bar" |>> { () => "" }
+      val ra2 = List("tag1", "tag2") @@ ("foo" ** GET / "bar") |>> { () => "" }
+
+      sb.mkOperation("/bar", ra1) must_== sb.mkOperation("/bar", ra2)
+    }
+
+    "Preserve explicit tags after prepending segments" in {
+      val inner = List("tag1", "tag2") @@ GET / "bar" |>> { () => "" }
+      val ra = "foo" /: inner
+
+      sb.mkOperation("/foo/bar", ra).tags must_== List("tag1", "tag2")
+    }
+
     "Produce unique operation ids" in {
       val routes = Seq(
         "foo1" ** GET / "bar" |>> { () => "" },


### PR DESCRIPTION
Fixes #314.

I went with `@@` for the syntax to get things rolling, but I'm not tied to it. I plan to have a follow-up PR that adds alphanumeric aliases for it and the other existing methods as part of #315.