### PR TITLE
Fix scaladoc example for AuthedContext

### DIFF
--- a/core/src/main/scala/org/http4s/rho/AuthedContext.scala
+++ b/core/src/main/scala/org/http4s/rho/AuthedContext.scala
@@ -16,9 +16,13 @@ import cats.effect._
   * {{{
   *     case class User(name: String, id: UUID)
   *
-  *     val middleware = AuthMiddleware { req =>
-  *       OptionT(IO(User("Bob", UUID.randomUUID())))
+  *     val authUser: Kleisli[IO, Request[IO], Either[String, User]] = Kleisli{ req =>
+  *       IO(Right(User("Bob", UUID.randomUUID())))
   *     }
+  *
+  *     val onFailure: AuthedRoutes[String, IO] = Kleisli(req => OptionT.liftF(Forbidden(req.authInfo)))
+  *
+  *     val middleware = AuthMiddleware(authUser, onFailure)
   *
   *     object Auth extends AuthedContext[IO, User]
   *


### PR DESCRIPTION
Code given as an example inside of scaladoc for `AuthedContext` didn't compile.

Here is a small fix.