### PR TITLE
#339 Allow mixing case classes and case objects in selaed traits. 

### DIFF
--- a/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
@@ -132,7 +132,7 @@ object TypeBuilder {
 
   private[this] def isSumType(sym: Symbol): Boolean =
     sym.isClass && sym.asClass.isSealed && sym.asClass.knownDirectSubclasses.forall { symbol =>
-      (!symbol.isModuleClass && symbol.asClass.isCaseClass) || isSumType(symbol)
+      symbol.asClass.isCaseClass || isSumType(symbol)
     }
 
   private[this] def isObjectEnum(sym: Symbol): Boolean =


### PR DESCRIPTION
Treat `case object`s the same as `case class`es with 0 fields.

Fixes #339 