### PR TITLE
Fix validation failures caused by Unit/Void/Nothing/Null

### DIFF
--- a/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/TypeBuilder.scala
@@ -180,20 +180,21 @@ object TypeBuilder {
   private def typeToProperty(tpe: Type, sfs: SwaggerFormats): Property = {
     sfs.customFieldSerializers.applyOrElse(tpe, { _: Type =>
       val TypeRef(_, ptSym: Symbol, _) = tpe
-
-      if (tpe.isMap && !tpe.isNothingOrNull) {
+      if (tpe.isNothingOrNull || tpe.isUnitOrVoid) {
+        RefProperty(tpe.simpleName)
+      } else if (tpe.isMap) {
         val pType = tpe.dealias.typeArgs.last
         val itemProperty = typeToProperty(pType, sfs).withRequired(false)
         MapProperty(additionalProperties = itemProperty)
       }
-      else if (tpe.isCollection && !tpe.isNothingOrNull) {
+      else if (tpe.isCollection) {
         val pType = tpe.dealias.typeArgs.head
         val itemProperty = typeToProperty(pType, sfs).withRequired(false)
         ArrayProperty(items = itemProperty)
       }
-      else if (tpe.isOption && !tpe.isNothingOrNull)
+      else if (tpe.isOption)
         typeToProperty(tpe.typeArgs.head, sfs).withRequired(false)
-      else if (tpe.isAnyVal && !tpe.isPrimitive && !tpe.isUnitOrVoid && !tpe.isNothingOrNull)
+      else if (tpe.isAnyVal && !tpe.isPrimitive)
         typeToProperty(ptSym.asClass.primaryConstructor.asMethod.paramLists.flatten.head.typeSignature, sfs)
       else if (isCaseClass(ptSym) || isSumType(ptSym))
         RefProperty(tpe.simpleName)
@@ -261,7 +262,7 @@ object TypeBuilder {
     private[swagger] def fromType(t: Type): DataType = {
       val klass = if (t.isOption && t.typeArgs.nonEmpty) t.typeArgs.head else t
 
-      if (klass.isNothingOrNull || klass.isUnitOrVoid) ComplexDataType(klass.simpleName, qualifiedName = Option(klass.fullName))
+      if (klass.isNothingOrNull || klass.isUnitOrVoid) ComplexDataType("string", qualifiedName = Option(klass.fullName))
       else if (isString(klass)) this.String
       else if (klass <:< typeOf[Byte] || klass <:< typeOf[java.lang.Byte]) this.Byte
       else if (klass <:< typeOf[Long] || klass <:< typeOf[java.lang.Long]) this.Long

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
@@ -175,6 +175,16 @@ class SwaggerModelsBuilderSpec extends Specification {
         QueryParameter(`type` = None, name = "bar".some, items = Some(AbstractProperty(`type` = "string")), defaultValue = "".some, isArray = true)
       )
     }
+
+    "handle and action with query parameters of empty data types" in {
+      val ra = fooPath +? param[Unit]("unit") & param[Void]("void") |>> { (_: Unit, _: Void) => "" }
+
+      sb.collectQueryParams[IO](ra) must_==
+        List(
+          QueryParameter(`type` = "string".some, name = "unit".some, required = true),
+          QueryParameter(`type` = "string".some, name = "void".some, required = true),
+        )
+    }
   }
 
   "SwaggerModelsBuilder.collectHeaderParams" should {

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
@@ -176,7 +176,7 @@ class SwaggerModelsBuilderSpec extends Specification {
       )
     }
 
-    "handle and action with query parameters of empty data types" in {
+    "handle an action with query parameters of empty data types" in {
       val ra = fooPath +? param[Unit]("unit") & param[Void]("void") |>> { (_: Unit, _: Void) => "" }
 
       sb.collectQueryParams[IO](ra) must_==

--- a/swagger/src/test/scala/org/http4s/rho/swagger/TypeBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/TypeBuilderSpec.scala
@@ -173,9 +173,9 @@ class TypeBuilderSpec extends Specification {
     "Build a model with a generic of type Nothing" in {
       val ms = modelOf[FooGeneric[Nothing]]
       ms.size must_== 2
-      ms.find(_.id2 == "FooGeneric«Nothing»") must beSome.which { m =>
+      ms.find(_.id2 == "FooGeneric«Nothing»") must beSome[Model].which { m =>
         m.properties.size must_== 1
-        m.properties("a").`type` must_== "Nothing"
+        m.properties("a").asInstanceOf[RefProperty].ref must_== "Nothing"
       }
 
       ms.find(_.id2 == "Nothing") must beSome
@@ -184,9 +184,9 @@ class TypeBuilderSpec extends Specification {
     "Build a model with a generic of type Null" in {
       val ms = modelOf[FooGeneric[Null]]
       ms.size must_== 2
-      ms.find(_.id2 == "FooGeneric«Null»") must beSome.which { m =>
+      ms.find(_.id2 == "FooGeneric«Null»") must beSome[Model].which { m =>
         m.properties.size must_== 1
-        m.properties("a").`type` must_== "Null"
+        m.properties("a").asInstanceOf[RefProperty].ref must_== "Null"
       }
 
       ms.find(_.id2 == "Null") must beSome
@@ -195,9 +195,9 @@ class TypeBuilderSpec extends Specification {
     "Build a model with a generic of type Unit" in {
       val ms = modelOf[FooGeneric[Unit]]
       ms.size must_== 2
-      ms.find(_.id2 == "FooGeneric«Unit»") must beSome.which { m =>
+      ms.find(_.id2 == "FooGeneric«Unit»") must beSome[Model].which { m =>
         m.properties.size must_== 1
-        m.properties("a").`type` must_== "Unit"
+        m.properties("a").asInstanceOf[RefProperty].ref must_== "Unit"
       }
 
       ms.find(_.id2 == "Unit") must beSome
@@ -206,9 +206,9 @@ class TypeBuilderSpec extends Specification {
     "Build a model with a generic of type Void" in {
       val ms = modelOf[FooGeneric[Void]]
       ms.size must_== 2
-      ms.find(_.id2 == "FooGeneric«Void»") must beSome.which { m =>
+      ms.find(_.id2 == "FooGeneric«Void»") must beSome[Model].which { m =>
         m.properties.size must_== 1
-        m.properties("a").`type` must_== "Void"
+        m.properties("a").asInstanceOf[RefProperty].ref must_== "Void"
       }
 
       ms.find(_.id2 == "Void") must beSome


### PR DESCRIPTION
I've noticed that my swagger files fail validation when I have `case class Result[T](t: T msg: String)` and then use `Result[Unit]`. The problem is that rho emits a swagger schema with a property with `"type": "Unit"`. It isn't directly stated in swagger specification that `type` can't be an arbitrary string, but it turns out this requirement is inherited from JSON Schema.

This PR changes rho's behaviour when handling Unit/Void/Nothing/Null to:
- When building a model, emit a `RefProperty` referring to the definition of "Unit/Void/Nothing/Null" 
- Fall back to "string" where refs aren't allowed (query params, pathVars etc.)