### PR TITLE
Relaxing Sync constrainton RhoRoutes

### DIFF
--- a/core/src/main/scala/org/http4s/rho/CompileRoutes.scala
+++ b/core/src/main/scala/org/http4s/rho/CompileRoutes.scala
@@ -2,7 +2,7 @@ package org.http4s
 package rho
 
 import scala.collection.immutable.Seq
-import cats.effect.Sync
+import cats._
 import shapeless.HList
 import org.http4s.rho.RhoRoute.Tpe
 import org.http4s.rho.bits.PathTree
@@ -40,7 +40,7 @@ object CompileRoutes {
     * @param routes `Seq` of routes to bundle into a service.
     * @return An `HttpRoutes`
     */
-  def foldRoutes[F[_]: Sync](routes: Seq[RhoRoute.Tpe[F]]): HttpRoutes[F] = {
+  def foldRoutes[F[_]: Defer: Monad](routes: Seq[RhoRoute.Tpe[F]]): HttpRoutes[F] = {
     val tree = routes.foldLeft(PathTree[F]()){ (t, r) => t.appendRoute(r) }
     HttpRoutes((req: Request[F]) => tree.getResult(req).toResponse)
   }

--- a/core/src/main/scala/org/http4s/rho/RhoRoutes.scala
+++ b/core/src/main/scala/org/http4s/rho/RhoRoutes.scala
@@ -2,7 +2,7 @@ package org.http4s
 package rho
 
 import scala.collection.immutable.Seq
-import cats.effect.Sync
+import cats._
 import org.http4s.rho.bits.PathAST.TypedPath
 import org.log4s.getLogger
 import shapeless.{HList, HNil}
@@ -23,7 +23,7 @@ import shapeless.{HList, HNil}
   *
   * @param routes Routes to prepend before elements in the constructor.
   */
-class RhoRoutes[F[_]: Sync](routes: Seq[RhoRoute[F, _ <: HList]] = Vector.empty)
+class RhoRoutes[F[_]: Defer: Monad](routes: Seq[RhoRoute[F, _ <: HList]] = Vector.empty)
     extends bits.MethodAliases
     with bits.ResponseGeneratorInstances[F]
     with RoutePrependable[F, RhoRoutes[F]]

--- a/core/src/main/scala/org/http4s/rho/RoutesBuilder.scala
+++ b/core/src/main/scala/org/http4s/rho/RoutesBuilder.scala
@@ -2,14 +2,14 @@ package org.http4s.rho
 
 import scala.collection.immutable.VectorBuilder
 import scala.collection.immutable.Seq
-import cats.effect.Sync
+import cats._
 import shapeless.HList
 import org.http4s._
 
 import scala.collection.compat._
 
 /** CompileRoutes which accumulates routes and can build a `HttpRoutes` */
-final class RoutesBuilder[F[_]: Sync] private(internalRoutes: VectorBuilder[RhoRoute.Tpe[F]]) extends CompileRoutes[F, RhoRoute.Tpe[F]] {
+final class RoutesBuilder[F[_]: Defer: Monad] private(internalRoutes: VectorBuilder[RhoRoute.Tpe[F]]) extends CompileRoutes[F, RhoRoute.Tpe[F]] {
 
   /** Turn the accumulated routes into an `HttpRoutes`
     *
@@ -48,10 +48,10 @@ final class RoutesBuilder[F[_]: Sync] private(internalRoutes: VectorBuilder[RhoR
 
 object RoutesBuilder {
   /** Constructor method for new `RoutesBuilder` instances */
-  def apply[F[_]: Sync](): RoutesBuilder[F] = apply(Seq.empty)
+  def apply[F[_]: Defer: Monad](): RoutesBuilder[F] = apply(Seq.empty)
 
   /** Constructor method for new `RoutesBuilder` instances with existing routes */
-  def apply[F[_]: Sync](routes: Seq[RhoRoute.Tpe[F]]): RoutesBuilder[F] = {
+  def apply[F[_]: Defer: Monad](routes: Seq[RhoRoute.Tpe[F]]): RoutesBuilder[F] = {
     val builder = new VectorBuilder[RhoRoute.Tpe[F]]
     builder ++= routes
 


### PR DESCRIPTION
Relax the `Sync` constraint to `Defer` and `Monad` which should allow the use of `Eval` and not `SyncIO` for some purposes (such as testing)


@rossabaker Do you have some thoughts on this?  