### PR TITLE
Speed up ResultMatcher implict lookups

### DIFF
--- a/core/src/main/scala/org/http4s/rho/bits/ResultMatcher.scala
+++ b/core/src/main/scala/org/http4s/rho/bits/ResultMatcher.scala
@@ -15,17 +15,15 @@ trait ResultMatcher[F[_], -R] {
 
 object ResultMatcher extends ResultMatcherMidPrioInstances {
 
-  sealed trait MaybeWritable[T] {
+  sealed trait MaybeWritable[F[_], T] {
     def contentType: Set[MediaType]
     def resultInfo: Option[Type]
     def encodings: Set[MediaType]
   }
 
   object MaybeWritable extends MaybeWritableOps {
-    type Aux[F[_], T] = MaybeWritable[T]
-
     // This will represent a "missing" result meaning this status wasn't used
-    implicit val maybeWritableAny: MaybeWritable[Any] = new MaybeWritable[Any] {
+    implicit def maybeWritableAny[F[_]]: MaybeWritable[F, Any] = new MaybeWritable[F, Any] {
       override def contentType: Set[MediaType] = Set.empty
       override def encodings: Set[MediaType] = Set.empty
       override def resultInfo: Option[Type] = None
@@ -35,7 +33,7 @@ object ResultMatcher extends ResultMatcherMidPrioInstances {
   trait MaybeWritableOps {
     /* Allowing the `Writable` to be `null` only matches real results but allows for
        situations where you return the same status with two types */
-    implicit def maybeIsWritable[F[_], T](implicit t: WeakTypeTag[T], w: EntityEncoder[F, T] = null): MaybeWritable.Aux[F, T] = new MaybeWritable[T] {
+    implicit def maybeIsWritable[F[_], T](implicit t: WeakTypeTag[T], w: EntityEncoder[F, T] = null): MaybeWritable[F, T] = new MaybeWritable[F, T] {
       private val ww = Option(w)
       override def contentType: Set[MediaType] = ww.flatMap(_.contentType.map(_.mediaType)).toSet
       override def encodings: Set[MediaType] = ww.flatMap(_.contentType.map(_.mediaType)).toSet
@@ -110,66 +108,66 @@ object ResultMatcher extends ResultMatcherMidPrioInstances {
   /* 510 */ NOTEXTENDED,
   /* 511 */ NETWORKAUTHENTICATIONREQUIRED
   ](implicit
-    /* 100 */ mCONTINUE: MaybeWritable.Aux[F, CONTINUE],
-    /* 101 */ mSWITCHINGPROTOCOLS: MaybeWritable.Aux[F, SWITCHINGPROTOCOLS],
-    /* 102 */ mPROCESSING: MaybeWritable.Aux[F, PROCESSING],
-    /* 103 */ mEARLYHINTS: MaybeWritable.Aux[F, EARLYHINTS],
-    /* 200 */ mOK: MaybeWritable.Aux[F, OK],
-    /* 201 */ mCREATED: MaybeWritable.Aux[F, CREATED],
-    /* 202 */ mACCEPTED: MaybeWritable.Aux[F, ACCEPTED],
-    /* 203 */ mNONAUTHORITATIVEINFORMATION: MaybeWritable.Aux[F, NONAUTHORITATIVEINFORMATION],
-    /* 204 */ mNOCONTENT: MaybeWritable.Aux[F, NOCONTENT],
-    /* 205 */ mRESETCONTENT: MaybeWritable.Aux[F, RESETCONTENT],
-    /* 206 */ mPARTIALCONTENT: MaybeWritable.Aux[F, PARTIALCONTENT],
-    /* 207 */ mMULTISTATUS: MaybeWritable.Aux[F, MULTISTATUS],
-    /* 208 */ mALREADYREPORTED: MaybeWritable.Aux[F, ALREADYREPORTED],
-    /* 226 */ mIMUSED: MaybeWritable.Aux[F, IMUSED],
-    /* 300 */ mMULTIPLECHOICES: MaybeWritable.Aux[F, MULTIPLECHOICES],
-    /* 301 */ mMOVEDPERMANENTLY: MaybeWritable.Aux[F, MOVEDPERMANENTLY],
-    /* 302 */ mFOUND: MaybeWritable.Aux[F, FOUND],
-    /* 303 */ mSEEOTHER: MaybeWritable.Aux[F, SEEOTHER],
-    /* 304 */ mNOTMODIFIED: MaybeWritable.Aux[F, NOTMODIFIED],
-    /* 307 */ mTEMPORARYREDIRECT: MaybeWritable.Aux[F, TEMPORARYREDIRECT],
-    /* 308 */ mPERMANENTREDIRECT: MaybeWritable.Aux[F, PERMANENTREDIRECT],
-    /* 400 */ mBADREQUEST: MaybeWritable.Aux[F, BADREQUEST],
-    /* 401 */ mUNAUTHORIZED: MaybeWritable.Aux[F, UNAUTHORIZED],
-    /* 402 */ mPAYMENTREQUIRED: MaybeWritable.Aux[F, PAYMENTREQUIRED],
-    /* 403 */ mFORBIDDEN: MaybeWritable.Aux[F, FORBIDDEN],
-    /* 404 */ mNOTFOUND: MaybeWritable.Aux[F, NOTFOUND],
-    /* 405 */ mMETHODNOTALLOWED: MaybeWritable.Aux[F, METHODNOTALLOWED],
-    /* 406 */ mNOTACCEPTABLE: MaybeWritable.Aux[F, NOTACCEPTABLE],
-    /* 407 */ mPROXYAUTHENTICATIONREQUIRED: MaybeWritable.Aux[F, PROXYAUTHENTICATIONREQUIRED],
-    /* 408 */ mREQUESTTIMEOUT: MaybeWritable.Aux[F, REQUESTTIMEOUT],
-    /* 409 */ mCONFLICT: MaybeWritable.Aux[F, CONFLICT],
-    /* 410 */ mGONE: MaybeWritable.Aux[F, GONE],
-    /* 411 */ mLENGTHREQUIRED: MaybeWritable.Aux[F, LENGTHREQUIRED],
-    /* 412 */ mPRECONDITIONFAILED: MaybeWritable.Aux[F, PRECONDITIONFAILED],
-    /* 413 */ mPAYLOADTOOLARGE: MaybeWritable.Aux[F, PAYLOADTOOLARGE],
-    /* 414 */ mURITOOLONG: MaybeWritable.Aux[F, URITOOLONG],
-    /* 415 */ mUNSUPPORTEDMEDIATYPE: MaybeWritable.Aux[F, UNSUPPORTEDMEDIATYPE],
-    /* 416 */ mRANGENOTSATISFIABLE: MaybeWritable.Aux[F, RANGENOTSATISFIABLE],
-    /* 417 */ mEXPECTATIONFAILED: MaybeWritable.Aux[F, EXPECTATIONFAILED],
-    /* 421 */ mMISDIRECTEDREQUEST: MaybeWritable.Aux[F, MISDIRECTEDREQUEST],
-    /* 422 */ mUNPROCESSABLEENTITY: MaybeWritable.Aux[F, UNPROCESSABLEENTITY],
-    /* 423 */ mLOCKED: MaybeWritable.Aux[F, LOCKED],
-    /* 424 */ mFAILEDDEPENDENCY: MaybeWritable.Aux[F, FAILEDDEPENDENCY],
-    /* 424 */ mTOOEARLY: MaybeWritable.Aux[F, TOOEARLY],
-    /* 426 */ mUPGRADEREQUIRED: MaybeWritable.Aux[F, UPGRADEREQUIRED],
-    /* 428 */ mPRECONDITIONREQUIRED: MaybeWritable.Aux[F, PRECONDITIONREQUIRED],
-    /* 429 */ mTOOMANYREQUESTS: MaybeWritable.Aux[F, TOOMANYREQUESTS],
-    /* 431 */ mREQUESTHEADERFIELDSTOOLARGE: MaybeWritable.Aux[F, REQUESTHEADERFIELDSTOOLARGE],
-    /* 451 */ mUNAVAILABLEFORLEGALREASONS: MaybeWritable.Aux[F, UNAVAILABLEFORLEGALREASONS],
-    /* 500 */ mINTERNALSERVERERROR: MaybeWritable.Aux[F, INTERNALSERVERERROR],
-    /* 501 */ mNOTIMPLEMENTED: MaybeWritable.Aux[F, NOTIMPLEMENTED],
-    /* 502 */ mBADGATEWAY: MaybeWritable.Aux[F, BADGATEWAY],
-    /* 503 */ mSERVICEUNAVAILABLE: MaybeWritable.Aux[F, SERVICEUNAVAILABLE],
-    /* 504 */ mGATEWAYTIMEOUT: MaybeWritable.Aux[F, GATEWAYTIMEOUT],
-    /* 505 */ mHTTPVERSIONNOTSUPPORTED: MaybeWritable.Aux[F, HTTPVERSIONNOTSUPPORTED],
-    /* 506 */ mVARIANTALSONEGOTIATES: MaybeWritable.Aux[F, VARIANTALSONEGOTIATES],
-    /* 507 */ mINSUFFICIENTSTORAGE: MaybeWritable.Aux[F, INSUFFICIENTSTORAGE],
-    /* 508 */ mLOOPDETECTED: MaybeWritable.Aux[F, LOOPDETECTED],
-    /* 510 */ mNOTEXTENDED: MaybeWritable.Aux[F, NOTEXTENDED],
-    /* 511 */ mNETWORKAUTHENTICATIONREQUIRED: MaybeWritable.Aux[F, NETWORKAUTHENTICATIONREQUIRED]
+    /* 100 */ mCONTINUE: MaybeWritable[F, CONTINUE],
+    /* 101 */ mSWITCHINGPROTOCOLS: MaybeWritable[F, SWITCHINGPROTOCOLS],
+    /* 102 */ mPROCESSING: MaybeWritable[F, PROCESSING],
+    /* 103 */ mEARLYHINTS: MaybeWritable[F, EARLYHINTS],
+    /* 200 */ mOK: MaybeWritable[F, OK],
+    /* 201 */ mCREATED: MaybeWritable[F, CREATED],
+    /* 202 */ mACCEPTED: MaybeWritable[F, ACCEPTED],
+    /* 203 */ mNONAUTHORITATIVEINFORMATION: MaybeWritable[F, NONAUTHORITATIVEINFORMATION],
+    /* 204 */ mNOCONTENT: MaybeWritable[F, NOCONTENT],
+    /* 205 */ mRESETCONTENT: MaybeWritable[F, RESETCONTENT],
+    /* 206 */ mPARTIALCONTENT: MaybeWritable[F, PARTIALCONTENT],
+    /* 207 */ mMULTISTATUS: MaybeWritable[F, MULTISTATUS],
+    /* 208 */ mALREADYREPORTED: MaybeWritable[F, ALREADYREPORTED],
+    /* 226 */ mIMUSED: MaybeWritable[F, IMUSED],
+    /* 300 */ mMULTIPLECHOICES: MaybeWritable[F, MULTIPLECHOICES],
+    /* 301 */ mMOVEDPERMANENTLY: MaybeWritable[F, MOVEDPERMANENTLY],
+    /* 302 */ mFOUND: MaybeWritable[F, FOUND],
+    /* 303 */ mSEEOTHER: MaybeWritable[F, SEEOTHER],
+    /* 304 */ mNOTMODIFIED: MaybeWritable[F, NOTMODIFIED],
+    /* 307 */ mTEMPORARYREDIRECT: MaybeWritable[F, TEMPORARYREDIRECT],
+    /* 308 */ mPERMANENTREDIRECT: MaybeWritable[F, PERMANENTREDIRECT],
+    /* 400 */ mBADREQUEST: MaybeWritable[F, BADREQUEST],
+    /* 401 */ mUNAUTHORIZED: MaybeWritable[F, UNAUTHORIZED],
+    /* 402 */ mPAYMENTREQUIRED: MaybeWritable[F, PAYMENTREQUIRED],
+    /* 403 */ mFORBIDDEN: MaybeWritable[F, FORBIDDEN],
+    /* 404 */ mNOTFOUND: MaybeWritable[F, NOTFOUND],
+    /* 405 */ mMETHODNOTALLOWED: MaybeWritable[F, METHODNOTALLOWED],
+    /* 406 */ mNOTACCEPTABLE: MaybeWritable[F, NOTACCEPTABLE],
+    /* 407 */ mPROXYAUTHENTICATIONREQUIRED: MaybeWritable[F, PROXYAUTHENTICATIONREQUIRED],
+    /* 408 */ mREQUESTTIMEOUT: MaybeWritable[F, REQUESTTIMEOUT],
+    /* 409 */ mCONFLICT: MaybeWritable[F, CONFLICT],
+    /* 410 */ mGONE: MaybeWritable[F, GONE],
+    /* 411 */ mLENGTHREQUIRED: MaybeWritable[F, LENGTHREQUIRED],
+    /* 412 */ mPRECONDITIONFAILED: MaybeWritable[F, PRECONDITIONFAILED],
+    /* 413 */ mPAYLOADTOOLARGE: MaybeWritable[F, PAYLOADTOOLARGE],
+    /* 414 */ mURITOOLONG: MaybeWritable[F, URITOOLONG],
+    /* 415 */ mUNSUPPORTEDMEDIATYPE: MaybeWritable[F, UNSUPPORTEDMEDIATYPE],
+    /* 416 */ mRANGENOTSATISFIABLE: MaybeWritable[F, RANGENOTSATISFIABLE],
+    /* 417 */ mEXPECTATIONFAILED: MaybeWritable[F, EXPECTATIONFAILED],
+    /* 421 */ mMISDIRECTEDREQUEST: MaybeWritable[F, MISDIRECTEDREQUEST],
+    /* 422 */ mUNPROCESSABLEENTITY: MaybeWritable[F, UNPROCESSABLEENTITY],
+    /* 423 */ mLOCKED: MaybeWritable[F, LOCKED],
+    /* 424 */ mFAILEDDEPENDENCY: MaybeWritable[F, FAILEDDEPENDENCY],
+    /* 424 */ mTOOEARLY: MaybeWritable[F, TOOEARLY],
+    /* 426 */ mUPGRADEREQUIRED: MaybeWritable[F, UPGRADEREQUIRED],
+    /* 428 */ mPRECONDITIONREQUIRED: MaybeWritable[F, PRECONDITIONREQUIRED],
+    /* 429 */ mTOOMANYREQUESTS: MaybeWritable[F, TOOMANYREQUESTS],
+    /* 431 */ mREQUESTHEADERFIELDSTOOLARGE: MaybeWritable[F, REQUESTHEADERFIELDSTOOLARGE],
+    /* 451 */ mUNAVAILABLEFORLEGALREASONS: MaybeWritable[F, UNAVAILABLEFORLEGALREASONS],
+    /* 500 */ mINTERNALSERVERERROR: MaybeWritable[F, INTERNALSERVERERROR],
+    /* 501 */ mNOTIMPLEMENTED: MaybeWritable[F, NOTIMPLEMENTED],
+    /* 502 */ mBADGATEWAY: MaybeWritable[F, BADGATEWAY],
+    /* 503 */ mSERVICEUNAVAILABLE: MaybeWritable[F, SERVICEUNAVAILABLE],
+    /* 504 */ mGATEWAYTIMEOUT: MaybeWritable[F, GATEWAYTIMEOUT],
+    /* 505 */ mHTTPVERSIONNOTSUPPORTED: MaybeWritable[F, HTTPVERSIONNOTSUPPORTED],
+    /* 506 */ mVARIANTALSONEGOTIATES: MaybeWritable[F, VARIANTALSONEGOTIATES],
+    /* 507 */ mINSUFFICIENTSTORAGE: MaybeWritable[F, INSUFFICIENTSTORAGE],
+    /* 508 */ mLOOPDETECTED: MaybeWritable[F, LOOPDETECTED],
+    /* 510 */ mNOTEXTENDED: MaybeWritable[F, NOTEXTENDED],
+    /* 511 */ mNETWORKAUTHENTICATIONREQUIRED: MaybeWritable[F, NETWORKAUTHENTICATIONREQUIRED]
    ): ResultMatcher[F, Result[
     F,
     /* 100 */ CONTINUE,
@@ -378,7 +376,7 @@ object ResultMatcher extends ResultMatcherMidPrioInstances {
       }.toSet
     }
 
-    private lazy val allTpes: List[(org.http4s.Status, MaybeWritable[_])] = {
+    private lazy val allTpes: List[(org.http4s.Status, MaybeWritable[F, _])] = {
       List(
         (org.http4s.Status.Continue, mCONTINUE),
         (org.http4s.Status.SwitchingProtocols, mSWITCHINGPROTOCOLS),

--- a/core/src/main/scala/org/http4s/rho/package.scala
+++ b/core/src/main/scala/org/http4s/rho/package.scala
@@ -20,7 +20,8 @@ trait RhoDsl[F[_]]
     with QueryParsers[F]
     with MatchersHListToFunc[F]
     with ResponseGeneratorInstances[F]
-    with FailureResponseOps[F] {
+    with FailureResponseOps[F]
+    with ResultMatchers[F] {
 
   implicit def method(m: Method): PathBuilder[F, HNil] = new PathBuilder(m, PathEmpty)
 


### PR DESCRIPTION
This is a follow up to the profiling of compilation times of rho routes started in #417.

Let's start with an analysis of the current performance profile of the [Benchmark5_TypedPathAndComplexResult](https://github.com/RafalSumislawski/rho/blob/compilation-benchmarks/benchmark/src/main/scala/com/http4s/rho/swagger/demo/Benchmark5_TypedPathAndComplexResult.scala). 

![before-with-annotations](https://user-images.githubusercontent.com/9465998/82737964-ba703f00-9d34-11ea-8637-29a54f541b2e.png)

The whole width of the flame chart is 12640ms. The lookup for ResultMatcher[F, F[Result[...]]] that I'm trying to optimize in this PR is 9450ms (75%).

- A - failed attempts to use the `writableMatcher` - problem solved by 
d5de0a6 
- B - `FnToProduct` and a `Reverse` this part will be doubled by #417
- C - building HList of the inputs (path vars in this case)
- D - lots of searches for `maybeWritableAny` (on for each `Nothing` in `Result`) - these are made faster by 0024904

d5de0a6 is a general improvement of implicit lookups by fixing the `F`

After these changes the `Benchmark5_TypedPathAndComplexResult` looks like this:

![after](https://user-images.githubusercontent.com/9465998/82737813-e50dc800-9d33-11ea-8337-babd5bcb37dc.PNG)
The whole chart is 8006ms and the `ResultMatcher` lookup is 4478m (56%). So the changes **reduced compilation time by ~37%.**



### Commit by commit measurements
The three commits are to some extent independent, so this PR isn't all-or-nothing, we can decide to merge some of them while leaving out others.

These are measurement of the `Benchmark7_ResultMatcherFOk` - the benchmark that measures just the ResultMatcher lookup:
- 9341.225ms // master
- 8076.063ms // d5de0a6  writable as low prio
- 6033.998ms // 0024904  remove MaybeWritable.Aux
- 4826.143ms // bce27dd  object -> trait typed with F
