### PR TITLE
Make names of generic types customisable

### DIFF
--- a/swagger-ui/src/main/scala/com/http4s/rho/swagger/ui/SwaggerUi.scala
+++ b/swagger-ui/src/main/scala/com/http4s/rho/swagger/ui/SwaggerUi.scala
@@ -3,7 +3,7 @@ package com.http4s.rho.swagger.ui
 import cats.effect.{Blocker, ContextShift, Sync}
 import org.http4s.rho.bits.PathAST.{PathMatch, TypedPath}
 import org.http4s.rho.swagger.models._
-import org.http4s.rho.swagger.{SwaggerFormats, SwaggerMetadata, SwaggerSupport, SwaggerSyntax}
+import org.http4s.rho.swagger.{DefaultShowType, ShowType, SwaggerFormats, SwaggerMetadata, SwaggerSupport, SwaggerSyntax}
 import org.http4s.rho.{RhoMiddleware, RhoRoute, swagger}
 import shapeless.HList
 
@@ -22,10 +22,11 @@ class SwaggerUi[F[+ _] : Sync : ContextShift](implicit etag: WeakTypeTag[F[_]]) 
                            swaggerSpecPath: String = "swagger.json",
                            swaggerUiPath: String = "swagger-ui",
                            swaggerRoutesInSwagger: Boolean = false,
-                           swaggerMetadata: SwaggerMetadata = SwaggerMetadata()): RhoMiddleware[F] = { routes: Seq[RhoRoute[F, _ <: HList]] =>
+                           swaggerMetadata: SwaggerMetadata = SwaggerMetadata(),
+                           showType: ShowType = DefaultShowType): RhoMiddleware[F] = { routes: Seq[RhoRoute[F, _ <: HList]] =>
 
     lazy val swaggerSpec: Swagger =
-      SwaggerSupport[F].createSwagger(swaggerFormats, swaggerMetadata)(
+      SwaggerSupport[F].createSwagger(swaggerFormats, swaggerMetadata, showType)(
         routes ++ (if (swaggerRoutesInSwagger) swaggerSpecRoute else Seq.empty)
       )
 

--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
@@ -14,7 +14,7 @@ import scala.collection.immutable.Seq
 import scala.reflect.runtime.universe._
 import scala.util.control.NonFatal
 
-private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
+private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats)(implicit st: ShowType) {
   import models._
 
   private[this] val logger = getLogger

--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
@@ -26,10 +26,11 @@ abstract class SwaggerSupport[F[_]](implicit F: Sync[F], etag: WeakTypeTag[F[_]]
       swaggerFormats: SwaggerFormats = DefaultSwaggerFormats,
       apiPath: TypedPath[F, HNil] = TypedPath(PathMatch("swagger.json")),
       swaggerRoutesInSwagger: Boolean = false,
-      swaggerMetadata: SwaggerMetadata = SwaggerMetadata()): RhoMiddleware[F] = { routes =>
+      swaggerMetadata: SwaggerMetadata = SwaggerMetadata(),
+      showType: ShowType = DefaultShowType): RhoMiddleware[F] = { routes =>
 
     lazy val swaggerSpec: Swagger =
-      createSwagger(swaggerFormats, swaggerMetadata)(
+      createSwagger(swaggerFormats, swaggerMetadata, showType)(
         routes ++ (if(swaggerRoutesInSwagger) swaggerRoute else Seq.empty )
       )
 
@@ -44,9 +45,10 @@ abstract class SwaggerSupport[F[_]](implicit F: Sync[F], etag: WeakTypeTag[F[_]]
     */
   def createSwagger(
       swaggerFormats: SwaggerFormats = DefaultSwaggerFormats,
-      swaggerMetadata: SwaggerMetadata = SwaggerMetadata())(routes: Seq[RhoRoute[F, _]]): Swagger = {
+      swaggerMetadata: SwaggerMetadata = SwaggerMetadata(),
+      showType: ShowType = DefaultShowType)(routes: Seq[RhoRoute[F, _]]): Swagger = {
 
-    val sb = new SwaggerModelsBuilder(swaggerFormats)
+    val sb = new SwaggerModelsBuilder(swaggerFormats)(showType)
     routes.foldLeft(swaggerMetadata.toSwagger())((s, r) => sb.mkSwagger(r)(s))
   }
 

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerFormatsSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerFormatsSpec.scala
@@ -20,6 +20,8 @@ class SwaggerFormatsSpec extends Specification {
   import model._
   import models._
 
+  implicit val showType: ShowType = DefaultShowType
+
   "SwaggerFormats" should {
 
     "withSerializers" in {

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerModelsBuilderSpec.scala
@@ -56,7 +56,7 @@ class SwaggerModelsBuilderSpec extends Specification {
   case class ModelC(name: String, shape: String) extends Renderable
   case class ModelMap(bar: String, baz: Map[String, Int]) extends Renderable
 
-  val sb = new SwaggerModelsBuilder(DefaultSwaggerFormats)
+  val sb = new SwaggerModelsBuilder(DefaultSwaggerFormats)(DefaultShowType)
   val fooPath = GET / "foo"
   val barPath = GET / "bar"
   type OpSeq = Option[Seq[String]]


### PR DESCRIPTION
The default behaviour remains unchanged. The way names are generated can be customised by providing a custom `ShowType` instance. This customisability is not limited to generic types, so if someone wishes to let's say, convert CamelCase class names into kebab-case type names in swagger that's also possible.  

Internally the `ShowType` is propagated as an implicit. On the API surface it's handled analogically to `SwaggerFormats` (non-implicit param with a default value).

Fixes #416