### PR TITLE
Fix generation of swagger for alternative routes (routes with || )

### DIFF
--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerModelsBuilder.scala
@@ -14,22 +14,21 @@ import scala.collection.immutable.Seq
 import scala.reflect.runtime.universe._
 import scala.util.control.NonFatal
 
-private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
+private[swagger] class SwaggerModelsBuilder[F[_]](formats: SwaggerFormats)(implicit etag: WeakTypeTag[F[_]]) {
   import models._
 
   private[this] val logger = getLogger
 
-  def mkSwagger[F[_]](rr: RhoRoute[F, _])(s: Swagger)(implicit etag: WeakTypeTag[F[_]]): Swagger =
+  def mkSwagger(rr: RhoRoute[F, _])(s: Swagger): Swagger =
     s.copy(
       paths       = collectPaths(rr)(s),
       definitions = collectDefinitions(rr)(s))
 
-  def collectPaths[F[_]](rr: RhoRoute[F, _])(s: Swagger)(implicit etag: WeakTypeTag[F[_]]): ListMap[String, Path] = {
-    val pairs = linearizeStack(rr.path::Nil).map { linearRoute: List[PathOperation] =>
-      val ps = mkPathStr(linearRoute)
-      val o = mkOperation(ps, linearRoute, rr)
-      val p0 = s.paths.getOrElse(ps, Path())
-      val p1 = rr.method.name.toLowerCase match {
+  def collectPaths(rr: RhoRoute[F, _])(s: Swagger): ListMap[String, Path] = {
+    val pairs = linearizeRoute(rr).map { lr =>
+      val o = mkOperation(lr)
+      val p0 = s.paths.getOrElse(lr.pathString, Path())
+      val p1 = lr.method.name.toLowerCase match {
         case "get"     => p0.copy(get = o.some)
         case "put"     => p0.copy(put = o.some)
         case "post"    => p0.copy(post = o.some)
@@ -41,12 +40,12 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
           logger.warn("unrecognized method: " + unknown)
           p0
       }
-      ps -> p1
+      lr.pathString -> p1
     }
     pairs.foldLeft(s.paths) { case (paths, (s, p)) => paths.updated(s, p) }
   }
 
-  def collectDefinitions[F[_]](rr: RhoRoute[F, _])(s: Swagger)(implicit etag: WeakTypeTag[F[_]]): Map[String, Model] = {
+  def collectDefinitions(rr: RhoRoute[F, _])(s: Swagger): Map[String, Model] = {
     val initial: Set[Model] = s.definitions.values.toSet
     (collectResultTypes(rr) ++ collectCodecTypes(rr) ++ collectQueryTypes(rr))
       .foldLeft(initial)((s, tpe) => s ++ TypeBuilder.collectModels(tpe, s, formats, etag.tpe))
@@ -54,19 +53,19 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
       .toMap
   }
 
-  def collectResultTypes[F[_]](rr: RhoRoute[F, _]): Set[Type] =
+  def collectResultTypes(rr: RhoRoute[F, _]): Set[Type] =
     rr.resultInfo.collect {
       case TypeOnly(tpe)         => tpe
       case StatusAndType(_, tpe) => tpe
     }
 
-  def collectCodecTypes[F[_]](rr: RhoRoute[F, _]): Set[Type] =
+  def collectCodecTypes(rr: RhoRoute[F, _]): Set[Type] =
     rr.router match {
       case r: CodecRouter[F, _, _] => Set(r.entityType)
       case _                    => Set.empty
     }
 
-  def collectQueryTypes[F[_]](rr: RhoRoute[F, _]): Seq[Type] = {
+  def collectQueryTypes(rr: RhoRoute[F, _]): Seq[Type] = {
     def go(stack: List[RequestRule[F]]): List[Type] =
       stack match {
         case Nil                                         => Nil
@@ -91,23 +90,7 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
     go(rr.rules::Nil)
   }
 
-  def mkPathStr[F[_]](linearRoute: List[PathOperation]): String = {
-
-    def go(stack: List[PathOperation], pathStr: String): String =
-      stack match {
-        case Nil                          => if(pathStr.isEmpty) "/" else pathStr
-        case PathMatch("") :: Nil         => pathStr + "/"
-        case PathMatch("") :: xs          => go(xs, pathStr)
-        case PathMatch(s) :: xs           => go(xs, pathStr + "/" + s)
-        case MetaCons(_, _) :: xs         => go(xs, pathStr)
-        case PathCapture(id, _, _, _)::xs => go(xs, s"$pathStr/{$id}")
-        case CaptureTail :: _             => pathStr + "/{tail...}"
-      }
-
-    go(linearRoute, "")
-  }
-
-  def collectPathParams[F[_]](rr: RhoRoute[F, _]): List[PathParameter] = {
+  def collectPathParams(lr: LinearRoute): List[PathParameter] = {
 
     def go(stack: List[PathOperation], pps: List[PathParameter]): List[PathParameter] =
       stack match {
@@ -115,27 +98,24 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
         case PathMatch("") :: xs               => go(xs, pps)
         case PathMatch(_) :: xs                => go(xs, pps)
         case MetaCons(_, _) :: xs              => go(xs, pps)
-        case PathCapture(id, desc, p, _) :: xs => go(xs, mkPathParam[F](id, desc, p.asInstanceOf[StringParser[F, String]])::pps)
+        case PathCapture(id, desc, p, _) :: xs => go(xs, mkPathParam(id, desc, p.asInstanceOf[StringParser[F, String]])::pps)
         case CaptureTail :: _                  => PathParameter(`type` = "string", name = "tail...".some) :: Nil
       }
 
-    linearizeStack(rr.path::Nil).flatMap(go(_, Nil)).reverse
+    go(lr.path, Nil).reverse
   }
 
-  def collectBodyParams[F[_]](rr: RhoRoute[F, _]): Option[BodyParameter] =
-    rr.router match {
-      case r: CodecRouter[_, _, _] => mkBodyParam(r).some
-      case _                       => none
-    }
+  def collectBodyParams(lr: LinearRoute): Option[BodyParameter] =
+    lr.entityType.map(mkBodyParam)
 
-  def collectResponses[F[_]](rr: RhoRoute[F, _])(implicit etag: WeakTypeTag[F[_]]): Map[String, Response] =
-    rr.resultInfo.collect {
+  def collectResponses(lr: LinearRoute): Map[String, Response] =
+    lr.resultInfo.collect {
       case TypeOnly(tpe)         => mkResponse("200", "OK", tpe.some, etag.tpe)
       case StatusAndType(s, tpe) => mkResponse(s.code.toString, s.reason, tpe.some, etag.tpe)
       case StatusOnly(s)         => mkResponse(s.code.toString, s.reason, none, etag.tpe)
     }.toMap
 
-  def collectSummary[F[_]](linearRoute: List[PathOperation]): Option[String] = {
+  def collectSummary(lr: LinearRoute): Option[String] = {
 
     def go(stack: List[PathOperation], summary: Option[String]): Option[String] =
       stack match {
@@ -153,10 +133,10 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
         case Nil => summary
       }
 
-    go(linearRoute, None)
+    go(lr.path, None)
   }
 
-  def collectTags[F[_]](linearPath: List[PathOperation]): List[String] = {
+  def collectTags(lr: LinearRoute): List[String] = {
 
     def go(stack: List[PathOperation], tags: List[String]): List[String] =
       stack match {
@@ -183,10 +163,10 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
           }
       }
 
-    go(linearPath, Nil)
+    go(lr.path, Nil)
   }
 
-  def collectSecurityScopes[F[_]](linearRoute: List[PathOperation]): List[Map[String, List[String]]] = {
+  def collectSecurityScopes(lr: LinearRoute): List[Map[String, List[String]]] = {
 
     def go(stack: List[PathOperation]): Option[Map[String, List[String]]] =
       stack match {
@@ -195,13 +175,13 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
         case _ :: xs => go(xs)
       }
 
-     go(linearRoute).toList
+     go(lr.path).toList
   }
 
-  def collectOperationParams[F[_]](rr: RhoRoute[F, _]): List[Parameter] =
-    collectPathParams(rr) ::: collectQueryParams(rr) ::: collectHeaderParams(rr) ::: collectBodyParams(rr).toList
+  def collectOperationParams(lr: LinearRoute): List[Parameter] =
+    collectPathParams(lr) ::: collectQueryParams(lr) ::: collectHeaderParams(lr) ::: collectBodyParams(lr).toList
 
-  def collectQueryParams[F[_]](rr: RhoRoute[F, _]): List[Parameter] = {
+  def collectQueryParams(lr: LinearRoute): List[Parameter] = {
     def go(stack: List[RequestRule[F]]): List[Parameter] =
       stack match {
         case AndRule(a, b)::xs => go(a::b::xs)
@@ -217,7 +197,7 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
           addOrDescriptions(set)(as, bs, "params") :::
           addOrDescriptions(set)(bs, as, "params")
 
-        case MetaRule(rs, q@QueryMetaData(_,_,_,_,_))::xs => mkQueryParam[F](q.asInstanceOf[QueryMetaData[F, _]])::go(rs::xs)
+        case MetaRule(rs, q@QueryMetaData(_,_,_,_,_))::xs => mkQueryParam(q.asInstanceOf[QueryMetaData[F, _]])::go(rs::xs)
 
         case MetaRule(rs, m: TextMetaData)::xs =>
           go(rs::Nil).map(_.withDesc(m.msg.some)) ::: go(xs)
@@ -229,10 +209,10 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
         case Nil => Nil
       }
 
-    go(rr.rules::Nil)
+    go(lr.rules::Nil)
   }
 
-  def collectHeaderParams[F[_]](rr: RhoRoute[F, _]): List[HeaderParameter] = {
+  def collectHeaderParams(lr: LinearRoute): List[HeaderParameter] = {
     def go(stack: List[RequestRule[F]]): List[HeaderParameter] =
       stack match {
         case Nil                                   => Nil
@@ -251,7 +231,7 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
           addOrDescriptions(set)(bs, as, "headers")
       }
 
-    go(rr.rules::Nil)
+    go(lr.rules::Nil)
   }
 
   def renderMediaRange: MediaRange => String = {
@@ -259,35 +239,35 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
     case range: MediaRange => range.show
   }
 
-  def mkOperation[F[_]](pathStr: String, linearRoute: List[PathOperation], rr: RhoRoute[F, _])(implicit etag: WeakTypeTag[F[_]]): Operation = {
-    val parameters = collectOperationParams(rr)
+  def mkOperation(lr: LinearRoute): Operation = {
+    val parameters = collectOperationParams(lr)
 
     Operation(
-      tags        = collectTags(linearRoute),
-      summary     = collectSummary(linearRoute),
-      consumes    = rr.validMedia.toList.map(renderMediaRange),
-      produces    = rr.responseEncodings.toList.map(_.show),
-      operationId = mkOperationId(pathStr, rr.method, parameters).some,
+      tags        = collectTags(lr),
+      summary     = collectSummary(lr),
+      consumes    = lr.validMedia.toList.map(renderMediaRange),
+      produces    = lr.responseEncodings.toList.map(_.show),
+      operationId = mkOperationId(lr, parameters).some,
       parameters  = parameters,
-      security    = collectSecurityScopes(linearRoute),
-      responses   = collectResponses(rr))
+      security    = collectSecurityScopes(lr),
+      responses   = collectResponses(lr))
   }
 
-  def mkOperationId(path: String, method: Method, parameters: List[Parameter]): String = {
+  def mkOperationId(lr: LinearRoute, parameters: List[Parameter]): String = {
     val showParameters =
       if (parameters.isEmpty) ""
       else parameters.flatMap(_.name).mkString("-", "-", "")
 
-    method.toString.toLowerCase +
-      path.split("/")
+    lr.method.toString.toLowerCase +
+      lr.pathString.split("/")
         .filter(s => !s.isEmpty && !(s.startsWith("{") && s.endsWith("}")))
         .map(_.capitalize)
         .mkString +
       showParameters
   }
 
-  def mkBodyParam[F[_]](r: CodecRouter[F, _, _]): BodyParameter = {
-    val tpe = r.entityType
+  def mkBodyParam(entityType: Type): BodyParameter = {
+    val tpe = entityType
     val model = if (tpe.isPrimitive) {
       val name = TypeBuilder.DataType(tpe).name
       ModelImpl(id = tpe.fullName, id2 = name, `type` = name.some, isSimple = true)
@@ -304,7 +284,7 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
     )
   }
 
-  def mkPathParam[F[_]](name: String, description: Option[String], parser: StringParser[F, String]): PathParameter = {
+  def mkPathParam(name: String, description: Option[String], parser: StringParser[F, String]): PathParameter = {
     val tpe = parser.typeTag.map(tag => getType(tag.tpe)).getOrElse("string")
     PathParameter(`type` = tpe, name = name.some, description = description, required = true)
   }
@@ -382,7 +362,7 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
     code -> Response(description = descr, schema = schema)
   }
 
-  def mkQueryParam[F[_]](rule: QueryMetaData[F, _]): Parameter = {
+  def mkQueryParam(rule: QueryMetaData[F, _]): Parameter = {
     val required = !(rule.m.tpe.isOption || rule.default.isDefined)
 
     val tpe = if(rule.m.tpe.isOption) rule.m.tpe.dealias.typeArgs.head else rule.m.tpe
@@ -444,7 +424,7 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
       name     = key.name.toString.some,
       required = isRequired)
 
-  def linearizeStack(stack: List[PathRule]): List[List[PathOperation]] = {
+  def linearizeRoute(rr: RhoRoute[F, _]): List[LinearRoute] = {
 
     def go(stack: List[PathRule], acc: List[PathOperation]): List[List[PathOperation]] =
       stack match {
@@ -455,7 +435,9 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
         case Nil                        => acc::Nil
       }
 
-    go(stack, Nil).map(_.reverse)
+    go(rr.path::Nil, Nil)
+      .map(_.reverse)
+      .map(linearPath => LinearRoute(linearPath, rr))
   }
 
   def addParamToPath(path: Path, param: Parameter): Path =
@@ -469,5 +451,39 @@ private[swagger] class SwaggerModelsBuilder(formats: SwaggerFormats) {
 
   def getType(m: Type): String = {
     TypeBuilder.DataType(m).name
+  }
+
+  case class LinearRoute(method: Method,
+                         path: List[PathOperation],
+                         rules: RequestRule[F],
+                         responseEncodings: Set[MediaType],
+                         resultInfo: Set[ResultInfo],
+                         validMedia: Set[MediaRange],
+                         entityType: Option[Type]) {
+
+    lazy val pathString: String = {
+      def go(stack: List[PathOperation], pathStr: String): String =
+        stack match {
+          case Nil                          => if(pathStr.isEmpty) "/" else pathStr
+          case PathMatch("") :: Nil         => pathStr + "/"
+          case PathMatch("") :: xs          => go(xs, pathStr)
+          case PathMatch(s) :: xs           => go(xs, pathStr + "/" + s)
+          case MetaCons(_, _) :: xs         => go(xs, pathStr)
+          case PathCapture(id, _, _, _)::xs => go(xs, s"$pathStr/{$id}")
+          case CaptureTail :: _             => pathStr + "/{tail...}"
+        }
+
+      go(path, "")
+    }
+  }
+
+  object LinearRoute {
+    def apply(path: List[PathOperation], rr: RhoRoute[F, _]): LinearRoute = {
+      val entityType = rr.router match {
+        case r: CodecRouter[F, _, _] => r.entityType.some
+        case _                       => none
+      }
+      new LinearRoute(rr.method, path, rr.rules, rr.responseEncodings, rr.resultInfo, rr.validMedia, entityType)
+    }
   }
 }

--- a/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
+++ b/swagger/src/main/scala/org/http4s/rho/swagger/SwaggerSupport.scala
@@ -46,7 +46,7 @@ abstract class SwaggerSupport[F[_]](implicit F: Sync[F], etag: WeakTypeTag[F[_]]
       swaggerFormats: SwaggerFormats = DefaultSwaggerFormats,
       swaggerMetadata: SwaggerMetadata = SwaggerMetadata())(routes: Seq[RhoRoute[F, _]]): Swagger = {
 
-    val sb = new SwaggerModelsBuilder(swaggerFormats)
+    val sb = new SwaggerModelsBuilder[F](swaggerFormats)
     routes.foldLeft(swaggerMetadata.toSwagger())((s, r) => sb.mkSwagger(r)(s))
   }
 


### PR DESCRIPTION
This is a fix for #448. 

There are already tests ("find a simple or-path" and "find a capture or-path") which exercise the scenario leading to this issue, but due to the way the assertions are formulated the problem is not detected. Redefinition of these tests is also part of this PR.

The issue actually has impact not only on tags, but generally on every difference between the alternatives defined with `||` . The root cause of the issue is that `SwaggerModelsBuilder.mkOperation` works on a `RhoRoute`, while a single `RhoRoute` may represent more than one operation in swagger model. Information belonging to these alternative operations gets mixed up. The solution is to split single `RhoRoute` into multiple routes, each representing one of the alternatives (I named them `LinearRoute`s) and then building the operation basing on these. This is more or less what `collectPaths -> mkPathStrs -> linearizeStack` call chain already does, but the distinction between alternative paths is somewhat lost instead of being propagated to `mkOperation`. 

The fix itself (see first commit) is relatively simple, but it requires modifying the signature of `mkOperation` and that method is used 28 times in tests. So the real challenge here was to implement the fix in a way which would not make the tests overly complicated/verbose. Hence the sizeable refactor in the second commit.