### PR TITLE
Relax variance constraint on F in SwaggerUi/SwaggerUiRoutes

### DIFF
--- a/swagger-ui/src/main/scala/com/http4s/rho/swagger/ui/SwaggerUi.scala
+++ b/swagger-ui/src/main/scala/com/http4s/rho/swagger/ui/SwaggerUi.scala
@@ -11,10 +11,10 @@ import scala.collection.immutable.Seq
 import scala.reflect.runtime.universe.WeakTypeTag
 
 object SwaggerUi {
-  def apply[F[+ _] : Sync : ContextShift](implicit etag: WeakTypeTag[F[_]]): SwaggerUi[F] = new SwaggerUi[F]()
+  def apply[F[_] : Sync : ContextShift](implicit etag: WeakTypeTag[F[_]]): SwaggerUi[F] = new SwaggerUi[F]()
 }
 
-class SwaggerUi[F[+ _] : Sync : ContextShift](implicit etag: WeakTypeTag[F[_]]) extends SwaggerSyntax[F] {
+class SwaggerUi[F[_] : Sync : ContextShift](implicit etag: WeakTypeTag[F[_]]) extends SwaggerSyntax[F] {
 
   def createRhoMiddleware(
                            blocker: Blocker,

--- a/swagger-ui/src/main/scala/com/http4s/rho/swagger/ui/SwaggerUiRoutes.scala
+++ b/swagger-ui/src/main/scala/com/http4s/rho/swagger/ui/SwaggerUiRoutes.scala
@@ -8,7 +8,7 @@ import org.http4s.rho.bits.PathAST.CaptureTail
 import org.http4s.rho.swagger.ui.BuildInfo
 import org.http4s._
 
-class SwaggerUiRoutes[F[+ _] : Sync : ContextShift](swaggerUiPath: String,
+class SwaggerUiRoutes[F[_] : Sync : ContextShift](swaggerUiPath: String,
                                                     swaggerUiResourcesPath: String,
                                                     indexHtml: String,
                                                     blocker: Blocker) extends RhoRoutes[F] {
@@ -38,7 +38,7 @@ class SwaggerUiRoutes[F[+ _] : Sync : ContextShift](swaggerUiPath: String,
 
 object SwaggerUiRoutes {
 
-  def apply[F[+ _] : Sync : ContextShift](swaggerUiPath: String, swaggerSpecRelativePath: String, blocker: Blocker): SwaggerUiRoutes[F] = {
+  def apply[F[_] : Sync : ContextShift](swaggerUiPath: String, swaggerSpecRelativePath: String, blocker: Blocker): SwaggerUiRoutes[F] = {
     val swaggerUiResourcesPath = s"/META-INF/resources/webjars/swagger-ui/${BuildInfo.swaggerUiVersion}/"
     val indexHtml = defaultIndexHtml(swaggerSpecRelativePath)
     new SwaggerUiRoutes[F](swaggerUiPath, swaggerUiResourcesPath, indexHtml, blocker)


### PR DESCRIPTION
I've noticed that `F` being covariant (`F[+_]`) in `SwaggerUi` and `SwaggerUiRoutes` is not only unnecessary (the covarience is not used in any way), but it causes issues when working with an `F` which is invariant, like for example `ReaderT[IO, A]`. Therefore in this PR I'm proposing to remove the requirment of covariance.