### PR TITLE
Use `munit-cats-effect` in tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -131,7 +131,7 @@ lazy val buildSettings = publishing ++
                                  `scala-reflect` % scalaVersion.value
                                )
                              else Seq.empty),
-    libraryDependencies ++= Seq(munit, scalacheckMunit)
+    libraryDependencies ++= Seq(munit, munitCatsEffect, scalacheckMunit)
   )
 
 // to keep REPL usable

--- a/core/src/test/scala/org/http4s/rho/ApiTest.scala
+++ b/core/src/test/scala/org/http4s/rho/ApiTest.scala
@@ -200,7 +200,6 @@ class ApiTest extends CatsEffectSuite {
     for {
       _ <- v1 match {
         case r: FailureResponse[IO] =>
-          IO.raiseError(new Throwable("hui"))
           (
             r.toResponse.map(_.status),
             r2.map(_.resp.status)

--- a/core/src/test/scala/org/http4s/rho/ApiTest.scala
+++ b/core/src/test/scala/org/http4s/rho/ApiTest.scala
@@ -181,7 +181,7 @@ class ApiTest extends CatsEffectSuite {
     for {
       result <- route(req).value.map(_.getOrElse(Response.notFound))
       _ = assertEquals(result.status, Status.Ok)
-      _ = assertEquals(RequestRunner.getBody(result.body), s"stuff $expectedFoo")
+      _ <- assertIO(RequestRunner.getBody(result.body), s"stuff $expectedFoo")
     } yield ()
   }
 
@@ -431,7 +431,7 @@ class ApiTest extends CatsEffectSuite {
     for {
       result <- route(req).value.map(_.getOrElse(Response.notFound))
       _ = assertEquals(result.status, Status.Ok)
-      _ = assertEquals(RequestRunner.getBody(result.body), "stuff Foo(32,3.2,Asdf)")
+      _ <- assertIO(RequestRunner.getBody(result.body), "stuff Foo(32,3.2,Asdf)")
     } yield ()
   }
 

--- a/core/src/test/scala/org/http4s/rho/CompileRoutesSuite.scala
+++ b/core/src/test/scala/org/http4s/rho/CompileRoutesSuite.scala
@@ -1,24 +1,23 @@
 package org.http4s.rho
 
 import cats.effect.IO
-import munit.FunSuite
+import munit.CatsEffectSuite
 import org.http4s.rho.bits.MethodAliases._
 import org.http4s.rho.io._
 import org.http4s.{Method, Request}
 
-class CompileRoutesSuite extends FunSuite {
-
-  def getFoo(implicit c: CompileRoutes[IO, _]) =
+class CompileRoutesSuite extends CatsEffectSuite {
+  private def getFoo(implicit c: CompileRoutes[IO, _]) =
     GET / "hello" |>> "GetFoo"
 
-  def putFoo(implicit c: CompileRoutes[IO, _]) =
+  private def putFoo(implicit c: CompileRoutes[IO, _]) =
     PUT / "hello" |>> "PutFoo"
 
   test("A CompileService should build a single route") {
     val c = RoutesBuilder[IO]()
     getFoo(c)
 
-    assertEquals("GetFoo", RRunner(c.toRoutes()).checkOk(Request(uri = uri"/hello")))
+    assertIO(RRunner(c.toRoutes()).checkOk(Request(uri = uri"/hello")), "GetFoo")
   }
 
   test("A CompileService should build multiple routes") {
@@ -26,10 +25,10 @@ class CompileRoutesSuite extends FunSuite {
     getFoo(c)
     putFoo(c)
 
-    assertEquals("GetFoo", RRunner(c.toRoutes()).checkOk(Request(uri = uri"/hello")))
-    assertEquals(
-      "PutFoo",
-      RRunner(c.toRoutes()).checkOk(Request(method = Method.PUT, uri = uri"/hello"))
+    assertIO(RRunner(c.toRoutes()).checkOk(Request(uri = uri"/hello")), "GetFoo")
+    assertIO(
+      RRunner(c.toRoutes()).checkOk(Request(method = Method.PUT, uri = uri"/hello")),
+      "PutFoo"
     )
   }
 
@@ -40,8 +39,8 @@ class CompileRoutesSuite extends FunSuite {
         (PUT / "hello" |>> "PutFoo") :: Nil
 
     val srvc = CompileRoutes.foldRoutes[IO](routes)
-    assertEquals("GetFoo", RRunner(srvc).checkOk(Request(uri = uri"/hello")))
-    assertEquals("PutFoo", RRunner(srvc).checkOk(Request(method = Method.PUT, uri = uri"/hello")))
+    assertIO(RRunner(srvc).checkOk(Request(uri = uri"/hello")), "GetFoo")
+    assertIO(RRunner(srvc).checkOk(Request(method = Method.PUT, uri = uri"/hello")), "PutFoo")
   }
 
   test("A CompileService should concatenate correctly") {
@@ -49,7 +48,7 @@ class CompileRoutesSuite extends FunSuite {
     val c2 = RoutesBuilder[IO](); putFoo(c2)
 
     val srvc = c1.append(c2.routes()).toRoutes()
-    assertEquals("GetFoo", RRunner(srvc).checkOk(Request(uri = uri"/hello")))
-    assertEquals("PutFoo", RRunner(srvc).checkOk(Request(method = Method.PUT, uri = uri"/hello")))
+    assertIO(RRunner(srvc).checkOk(Request(uri = uri"/hello")), "GetFoo")
+    assertIO(RRunner(srvc).checkOk(Request(method = Method.PUT, uri = uri"/hello")), "PutFoo")
   }
 }

--- a/core/src/test/scala/org/http4s/rho/CompileRoutesSuite.scala
+++ b/core/src/test/scala/org/http4s/rho/CompileRoutesSuite.scala
@@ -25,11 +25,11 @@ class CompileRoutesSuite extends CatsEffectSuite {
     getFoo(c)
     putFoo(c)
 
-    assertIO(RRunner(c.toRoutes()).checkOk(Request(uri = uri"/hello")), "GetFoo")
-    assertIO(
-      RRunner(c.toRoutes()).checkOk(Request(method = Method.PUT, uri = uri"/hello")),
-      "PutFoo"
-    )
+    assertIO(RRunner(c.toRoutes()).checkOk(Request(uri = uri"/hello")), "GetFoo") *>
+      assertIO(
+        RRunner(c.toRoutes()).checkOk(Request(method = Method.PUT, uri = uri"/hello")),
+        "PutFoo"
+      )
   }
 
   test("A CompileService should make routes from a collection of RhoRoutes") {
@@ -39,8 +39,8 @@ class CompileRoutesSuite extends CatsEffectSuite {
         (PUT / "hello" |>> "PutFoo") :: Nil
 
     val srvc = CompileRoutes.foldRoutes[IO](routes)
-    assertIO(RRunner(srvc).checkOk(Request(uri = uri"/hello")), "GetFoo")
-    assertIO(RRunner(srvc).checkOk(Request(method = Method.PUT, uri = uri"/hello")), "PutFoo")
+    assertIO(RRunner(srvc).checkOk(Request(uri = uri"/hello")), "GetFoo") *>
+      assertIO(RRunner(srvc).checkOk(Request(method = Method.PUT, uri = uri"/hello")), "PutFoo")
   }
 
   test("A CompileService should concatenate correctly") {
@@ -48,7 +48,8 @@ class CompileRoutesSuite extends CatsEffectSuite {
     val c2 = RoutesBuilder[IO](); putFoo(c2)
 
     val srvc = c1.append(c2.routes()).toRoutes()
-    assertIO(RRunner(srvc).checkOk(Request(uri = uri"/hello")), "GetFoo")
-    assertIO(RRunner(srvc).checkOk(Request(method = Method.PUT, uri = uri"/hello")), "PutFoo")
+
+    assertIO(RRunner(srvc).checkOk(Request(uri = uri"/hello")), "GetFoo") *>
+      assertIO(RRunner(srvc).checkOk(Request(method = Method.PUT, uri = uri"/hello")), "PutFoo")
   }
 }

--- a/core/src/test/scala/org/http4s/rho/ResultSuite.scala
+++ b/core/src/test/scala/org/http4s/rho/ResultSuite.scala
@@ -14,13 +14,12 @@ class ResultSuite extends CatsEffectSuite {
       .map(_.putHeaders(date))
       .map(_.resp)
 
-    assertIO(resp.map(_.headers.get[Date]), Some(date))
-
     val respNow = Ok("Foo")
       .map(_.putHeaders(date))
       .map(_.resp)
 
-    assertIO(respNow.map(_.headers.get[Date]), Some(date))
+    assertIO(resp.map(_.headers.get[Date]), Some(date)) *>
+      assertIO(respNow.map(_.headers.get[Date]), Some(date))
   }
 
   test("A ResultSyntax should add attributes") {
@@ -29,12 +28,11 @@ class ResultSuite extends CatsEffectSuite {
       .map(_.withAttribute(attrKey, "foo"))
       .map(_.resp)
 
-    assertIO(resp.map(_.attributes.lookup(attrKey)), Some("foo"))
-
     val resp2 = Ok("Foo")
       .map(_.withAttribute(attrKey, "foo"))
       .map(_.resp)
 
-    assertIO(resp2.map(_.attributes.lookup(attrKey)), Some("foo"))
+    assertIO(resp.map(_.attributes.lookup(attrKey)), Some("foo")) *>
+      assertIO(resp2.map(_.attributes.lookup(attrKey)), Some("foo"))
   }
 }

--- a/core/src/test/scala/org/http4s/rho/ResultSuite.scala
+++ b/core/src/test/scala/org/http4s/rho/ResultSuite.scala
@@ -1,45 +1,40 @@
 package org.http4s.rho
 
 import cats.effect._
-import cats.effect.unsafe.implicits.global
-import munit.FunSuite
+import munit.CatsEffectSuite
 import org.http4s.headers._
 import org.http4s.HttpDate
 import org.http4s.rho.io._
 import org.typelevel.vault._
 
-class ResultSuite extends FunSuite {
+class ResultSuite extends CatsEffectSuite {
   test("A ResultSyntax should add headers") {
     val date = Date(HttpDate.Epoch)
     val resp = Ok("Foo")
       .map(_.putHeaders(date))
-      .unsafeRunSync()
-      .resp
+      .map(_.resp)
 
-    assertEquals(resp.headers.get[Date], Some(date))
+    assertIO(resp.map(_.headers.get[Date]), Some(date))
 
     val respNow = Ok("Foo")
       .map(_.putHeaders(date))
-      .unsafeRunSync()
-      .resp
+      .map(_.resp)
 
-    assertEquals(respNow.headers.get[Date], Some(date))
+    assertIO(respNow.map(_.headers.get[Date]), Some(date))
   }
 
   test("A ResultSyntax should add attributes") {
     val attrKey = Key.newKey[SyncIO, String].unsafeRunSync()
     val resp = Ok("Foo")
       .map(_.withAttribute(attrKey, "foo"))
-      .unsafeRunSync()
-      .resp
+      .map(_.resp)
 
-    assertEquals(resp.attributes.lookup(attrKey), Some("foo"))
+    assertIO(resp.map(_.attributes.lookup(attrKey)), Some("foo"))
 
     val resp2 = Ok("Foo")
       .map(_.withAttribute(attrKey, "foo"))
-      .unsafeRunSync()
-      .resp
+      .map(_.resp)
 
-    assertEquals(resp2.attributes.lookup(attrKey), Some("foo"))
+    assertIO(resp2.map(_.attributes.lookup(attrKey)), Some("foo"))
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,6 +27,7 @@ object Dependencies {
   lazy val scalaXml            = "org.scala-lang.modules"     %% "scala-xml"             % "2.0.0"
   lazy val swaggerUi           = "org.webjars"                 % "swagger-ui"            % "3.46.0"
   lazy val munit               = "org.scalameta"              %% "munit"                 % "0.7.26"         % "test"
+  lazy val munitCatsEffect     = "org.typelevel"              %% "munit-cats-effect-3"   % "1.0.5"          % "test"
   lazy val scalacheckMunit     = "org.scalameta"              %% "munit-scalacheck"      % munit.revision   % "test"
 
   lazy val `scala-reflect`     = "org.scala-lang"              % "scala-reflect"

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSuite.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSuite.scala
@@ -4,16 +4,17 @@ package swagger
 
 import cats.data._
 import cats.effect.IO
+import cats.syntax.applicative._
 import _root_.io.circe.parser._
 import _root_.io.circe._
 import _root_.io.circe.syntax._
-import munit.FunSuite
+import munit.CatsEffectSuite
 import org.http4s.rho.bits.MethodAliases.GET
 import org.http4s.rho.io._
 import org.http4s.rho.swagger.models._
 import org.http4s.rho.swagger.syntax.io._
 
-class SwaggerSupportSuite extends FunSuite {
+class SwaggerSupportSuite extends CatsEffectSuite {
 
   val baseRoutes = new RhoRoutes[IO] {
     GET / "hello" |>> { () => Ok("hello world") }
@@ -51,13 +52,17 @@ class SwaggerSupportSuite extends FunSuite {
 
     val r = Request[IO](GET, Uri(path = Uri.Path.unsafeFromString("/swagger.json")))
 
-    val json = decode[SwaggerRoot](RRunner(service).checkOk(r))
+    val swaggerRoot =
+      RRunner(service)
+        .checkOk(r)
+        .map(decode[SwaggerRoot])
+        .flatMap(
+          _.map(_.paths.keySet.pure[IO])
+            .getOrElse(IO.raiseError(new Throwable("Expected Right value")))
+        )
 
-    assert(json.isRight)
-    val swaggerRoot = json.getOrElse(???)
-
-    assertEquals(
-      swaggerRoot.paths.keySet,
+    assertIO(
+      swaggerRoot,
       Set(
         "/swagger.json",
         "/swagger.yaml",
@@ -72,13 +77,17 @@ class SwaggerSupportSuite extends FunSuite {
       ("foo" /: baseRoutes).toRoutes(createRhoMiddleware(swaggerRoutesInSwagger = true))
     val r = Request[IO](GET, Uri(path = Uri.Path.unsafeFromString("/swagger.json")))
 
-    val json = decode[SwaggerRoot](RRunner(service).checkOk(r))
+    val swaggerRoot =
+      RRunner(service)
+        .checkOk(r)
+        .map(decode[SwaggerRoot])
+        .flatMap(
+          _.map(_.paths.keySet.pure[IO])
+            .getOrElse(IO.raiseError(new Throwable("Expected Right value")))
+        )
 
-    assert(json.isRight)
-    val swaggerRoot = json.getOrElse(???)
-
-    assertEquals(
-      swaggerRoot.paths.keySet,
+    assertIO(
+      swaggerRoot,
       Set(
         "/swagger.json",
         "/swagger.yaml",
@@ -101,13 +110,16 @@ class SwaggerSupportSuite extends FunSuite {
 
     val r = Request[IO](GET, Uri(path = Uri.Path.unsafeFromString("/swagger.json")))
 
-    val json = decode[SwaggerRoot](RRunner(httpRoutes.toRoutes()).checkOk(r))
+    val swaggerRoot = RRunner(httpRoutes.toRoutes())
+      .checkOk(r)
+      .map(decode[SwaggerRoot])
+      .flatMap(
+        _.map(_.paths.keySet.pure[IO])
+          .getOrElse(IO.raiseError(new Throwable("Expected Right value")))
+      )
 
-    assert(json.isRight)
-    val swaggerRoot = json.getOrElse(???)
-
-    assertEquals(
-      swaggerRoot.paths.keySet,
+    assertIO(
+      swaggerRoot,
       Set(
         "/hello",
         "/hello/{string}",
@@ -121,12 +133,15 @@ class SwaggerSupportSuite extends FunSuite {
     val service = trailingSlashRoutes.toRoutes(createRhoMiddleware())
     val r = Request[IO](GET, Uri(path = Uri.Path.unsafeFromString("/swagger.json")))
 
-    val json = decode[SwaggerRoot](RRunner(service).checkOk(r))
+    val swaggerRoot = RRunner(service)
+      .checkOk(r)
+      .map(decode[SwaggerRoot])
+      .flatMap(
+        _.map(_.paths.keySet.pure[IO])
+          .getOrElse(IO.raiseError(new Throwable("Expected Right value")))
+      )
 
-    assert(json.isRight)
-    val swaggerRoot = json.getOrElse(???)
-
-    assertEquals(swaggerRoot.paths.keys.head, "/foo/")
+    assertIO(swaggerRoot.map(_.head), "/foo/")
   }
 
   test(
@@ -134,12 +149,15 @@ class SwaggerSupportSuite extends FunSuite {
   ) {
     val service = mixedTrailingSlashesRoutes.toRoutes(createRhoMiddleware())
     val r = Request[IO](GET, Uri(path = Uri.Path.unsafeFromString("/swagger.json")))
-    val json = decode[SwaggerRoot](RRunner(service).checkOk(r))
+    val swaggerRoot = RRunner(service)
+      .checkOk(r)
+      .map(decode[SwaggerRoot])
+      .flatMap(
+        _.map(_.paths.keySet.pure[IO])
+          .getOrElse(IO.raiseError(new Throwable("Expected Right value")))
+      )
 
-    assert(json.isRight)
-    val swaggerRoot = json.getOrElse(???)
-
-    assertEquals(swaggerRoot.paths.keySet, Set("/foo/", "/foo", "/bar"))
+    assertIO(swaggerRoot, Set("/foo/", "/foo", "/bar"))
   }
 
   test(
@@ -153,13 +171,16 @@ class SwaggerSupportSuite extends FunSuite {
 
     val r = Request[IO](GET, Uri(path = Uri.Path.unsafeFromString("/swagger.json")))
 
-    val json = decode[SwaggerRoot](RRunner(httpRoutes.toRoutes()).checkOk(r))
+    val swaggerRoot = RRunner(httpRoutes.toRoutes())
+      .checkOk(r)
+      .map(decode[SwaggerRoot])
+      .flatMap(
+        _.map(_.paths.keySet.pure[IO])
+          .getOrElse(IO.raiseError(new Throwable("Expected Right value")))
+      )
 
-    assert(json.isRight)
-    val swaggerRoot = json.getOrElse(???)
-
-    assertEquals(
-      swaggerRoot.paths.keySet,
+    assertIO(
+      swaggerRoot,
       Set(
         "/hello",
         "/hello/{string}",
@@ -177,30 +198,37 @@ class SwaggerSupportSuite extends FunSuite {
 
     val r = Request[IO](GET, Uri(path = Uri.Path.unsafeFromString("/swagger.json")))
 
-    val json = parse(RRunner(service).checkOk(r)).getOrElse(???)
+    val jsonF = RRunner(service)
+      .checkOk(r)
+      .map(parse)
+      .flatMap(_.map(_.pure[IO]).getOrElse(IO.raiseError(new Throwable("Expected Right value"))))
 
-    val security: List[Json] = (json \\ "security").flatMap(_.asArray).flatten
+    val securityF = jsonF.map(json => (json \\ "security").flatMap(_.asArray).flatten)
 
-    assert(
-      security.contains(
-        Json.obj(
-          "bye" := List("hello")
+    assertIOBoolean(
+      securityF.map(
+        _.contains(
+          Json.obj(
+            "bye" := List("hello")
+          )
         )
       )
     )
 
-    assert(
-      security.contains(
-        Json.obj(
-          "hello" := List("bye")
+    assertIOBoolean(
+      securityF.map(
+        _.contains(
+          Json.obj(
+            "hello" := List("bye")
+          )
         )
       )
     )
 
-    val summary = (json \\ "summary").flatMap(_.asString)
+    val summaryF = jsonF.map(json => (json \\ "summary").flatMap(_.asString))
 
-    assert(summary.contains("Bye"))
-    assert(summary.contains("Hello"))
+    assertIOBoolean(summaryF.map(_.contains("Bye")))
+    assertIOBoolean(summaryF.map(_.contains("Hello")))
   }
 
   test("SwaggerSupport should support for complex meta data") {
@@ -250,35 +278,40 @@ class SwaggerSupportSuite extends FunSuite {
     )
 
     val r = Request[IO](GET, Uri(path = Uri.Path.unsafeFromString("/swagger-test.json")))
-    val json = parse(RRunner(service).checkOk(r)).getOrElse(???)
-    val cursor = json.hcursor
+    val jsonF = RRunner(service)
+      .checkOk(r)
+      .map(parse)
+      .flatMap(_.map(_.pure[IO]).getOrElse(IO.raiseError(new Throwable("Expected Right value"))))
 
-    val icn = cursor.downField("info").downField("contact").get[String]("name")
-    val h = cursor.get[String]("host")
-    val s = cursor.downField("schemes").as[List[String]]
-    val bp = cursor.get[String]("basePath")
-    val c = cursor.downField("consumes").downArray.as[String]
-    val p = cursor.downField("produces").downArray.as[String]
-    val sec1 = cursor.downField("security").downArray.downField("apiKey").as[List[String]]
-    val sec2 =
-      cursor.downField("security").downArray.right.downField("vendor_jwk").downArray.as[String]
-    val t = cursor.downField("securityDefinitions").downField("api_key").get[String]("type")
-    val vi = cursor
-      .downField("securityDefinitions")
-      .downField("vendor_jwk")
-      .get[String]("x-vendor-issuer")
-    val ve = cursor.downField("x-vendor-endpoints").get[String]("target")
+    for {
+      cursor <- jsonF.map(_.hcursor)
+      icn = cursor.downField("info").downField("contact").get[String]("name")
+      h = cursor.get[String]("host")
+      s = cursor.downField("schemes").as[List[String]]
+      bp = cursor.get[String]("basePath")
+      c = cursor.downField("consumes").downArray.as[String]
+      p = cursor.downField("produces").downArray.as[String]
+      sec1 = cursor.downField("security").downArray.downField("apiKey").as[List[String]]
+      sec2 =
+        cursor.downField("security").downArray.right.downField("vendor_jwk").downArray.as[String]
+      t = cursor.downField("securityDefinitions").downField("api_key").get[String]("type")
+      vi = cursor
+        .downField("securityDefinitions")
+        .downField("vendor_jwk")
+        .get[String]("x-vendor-issuer")
+      ve = cursor.downField("x-vendor-endpoints").get[String]("target")
 
-    assert(icn.fold(_ => false, _ == "Name"))
-    assert(h.fold(_ => false, _ == "www.test.com"))
-    assert(s.fold(_ => false, _ == List("http", "https")))
-    assert(bp.fold(_ => false, _ == "/v1"))
-    assert(c.fold(_ => false, _ == "application/json"))
-    assert(p.fold(_ => false, _ == "application/json"))
-    assert(sec2.fold(_ => false, _ == "admin"))
-    assert(t.fold(_ => false, _ == "apiKey"))
-    assert(vi.fold(_ => false, _ == "https://www.test.com/"))
-    assert(ve.fold(_ => false, _ == "298.0.0.1"))
-    assert(sec1.fold(_ => false, _ == List.empty[String]))
+      _ = assert(icn.fold(_ => false, _ == "Name"))
+      _ = assert(h.fold(_ => false, _ == "www.test.com"))
+      _ = assert(s.fold(_ => false, _ == List("http", "https")))
+      _ = assert(bp.fold(_ => false, _ == "/v1"))
+      _ = assert(c.fold(_ => false, _ == "application/json"))
+      _ = assert(p.fold(_ => false, _ == "application/json"))
+      _ = assert(sec2.fold(_ => false, _ == "admin"))
+      _ = assert(t.fold(_ => false, _ == "apiKey"))
+      _ = assert(vi.fold(_ => false, _ == "https://www.test.com/"))
+      _ = assert(ve.fold(_ => false, _ == "298.0.0.1"))
+      _ = assert(sec1.fold(_ => false, _ == List.empty[String]))
+    } yield ()
   }
 }

--- a/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSuite.scala
+++ b/swagger/src/test/scala/org/http4s/rho/swagger/SwaggerSupportSuite.scala
@@ -205,30 +205,31 @@ class SwaggerSupportSuite extends CatsEffectSuite {
 
     val securityF = jsonF.map(json => (json \\ "security").flatMap(_.asArray).flatten)
 
-    assertIOBoolean(
-      securityF.map(
-        _.contains(
-          Json.obj(
-            "bye" := List("hello")
+    for {
+      _ <- assertIOBoolean(
+        securityF.map(
+          _.contains(
+            Json.obj(
+              "bye" := List("hello")
+            )
           )
         )
       )
-    )
 
-    assertIOBoolean(
-      securityF.map(
-        _.contains(
-          Json.obj(
-            "hello" := List("bye")
+      _ <- assertIOBoolean(
+        securityF.map(
+          _.contains(
+            Json.obj(
+              "hello" := List("bye")
+            )
           )
         )
       )
-    )
 
-    val summaryF = jsonF.map(json => (json \\ "summary").flatMap(_.asString))
-
-    assertIOBoolean(summaryF.map(_.contains("Bye")))
-    assertIOBoolean(summaryF.map(_.contains("Hello")))
+      summaryF = jsonF.map(json => (json \\ "summary").flatMap(_.asString))
+      _ <- assertIOBoolean(summaryF.map(_.contains("Bye")))
+      _ <- assertIOBoolean(summaryF.map(_.contains("Hello")))
+    } yield ()
   }
 
   test("SwaggerSupport should support for complex meta data") {


### PR DESCRIPTION
Getting rid of `cats.effect.IOPlatform#unsafeRunSync` in tests.