### PR TITLE
Replace symbol literal with pv in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```scala
 val httpService = new RhoRoutes[IO] {
-   GET / "hello" / 'world +? param[Int]("fav") |>> { (world: String, fav: Int) => 
+   GET / "hello" / pv"world" +? param[Int]("fav") |>> { (world: String, fav: Int) => 
      Ok(s"Received $fav, $world") 
    }
 }


### PR DESCRIPTION
Symbol literal is deprecated in 2.13 and removed in 3