### PR TITLE
Doc: remove parameter list from Auth.auth

### DIFF
--- a/Rho.md
+++ b/Rho.md
@@ -45,7 +45,7 @@ val api = new RhoRoutes[IO] {
     import org.http4s.rho.swagger.syntax.io._
     
     "Description of api endpoint" **      // Description is optional and specific to Swagger
-    POST / "somePath" / pathVar[Int]("someInt", "parameter description") >>> Auth.auth() ^ jsonOf[IO, T] |>> {
+    POST / "somePath" / pathVar[Int]("someInt", "parameter description") >>> Auth.auth ^ jsonOf[IO, T] |>> {
       (someInt: Int, au: AuthInfo, body: T) => Ok("result")
     }
 }


### PR DESCRIPTION
auth doesn't have a parameter list, so don't use it in the call, so we don't incur any warnings.