### PR TITLE
Use Scala Collection Compat

### DIFF
--- a/core/src/main/scala-2.12-/jdk/CollectionConverters.scala
+++ b/core/src/main/scala-2.12-/jdk/CollectionConverters.scala
@@ -1,5 +1,0 @@
-package scala.jdk
-
-import scala.collection.convert.{DecorateAsJava, DecorateAsScala}
-
-object CollectionConverters extends DecorateAsJava with DecorateAsScala

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,26 +10,27 @@ object Dependencies {
   val scala_212 = "2.12.14"
 
 
-  lazy val circeCore           = "io.circe"                   %% "circe-core"            % circeVersion
-  lazy val circeGeneric        = "io.circe"                   %% "circe-generic"         % circeVersion
-  lazy val circeParser         = "io.circe"                   %% "circe-parser"          % circeVersion
-  lazy val http4sServer        = "org.http4s"                 %% "http4s-server"         % http4sVersion
-  lazy val http4sDSL           = "org.http4s"                 %% "http4s-dsl"            % http4sVersion
-  lazy val http4sBlaze         = "org.http4s"                 %% "http4s-blaze-server"   % http4sVersion
-  lazy val http4sCirce         = "org.http4s"                 %% "http4s-circe"          % http4sVersion
-  lazy val http4sXmlInstances  = "org.http4s"                 %% "http4s-scala-xml"      % http4sVersion
-  lazy val swaggerModels       = "io.swagger"                  % "swagger-models"        % "1.6.3"
-  lazy val swaggerCore         = "io.swagger"                  % "swagger-core"          % swaggerModels.revision
-  lazy val logbackClassic      = "ch.qos.logback"              % "logback-classic"       % "1.2.7"
-  lazy val uadetector          = "net.sf.uadetector"           % "uadetector-resources"  % "2014.10"
-  lazy val shapeless           = "com.chuusai"                %% "shapeless"             % "2.3.7"
-  lazy val scalaXml            = "org.scala-lang.modules"     %% "scala-xml"             % "2.0.1"
-  lazy val swaggerUi           = "org.webjars"                 % "swagger-ui"            % "3.52.5"
-  lazy val munit               = "org.scalameta"              %% "munit"                 % "0.7.27"         % "test"
-  lazy val munitCatsEffect     = "org.typelevel"              %% "munit-cats-effect-3"   % "1.0.6"          % "test"
-  lazy val scalacheckMunit     = "org.scalameta"              %% "munit-scalacheck"      % munit.revision   % "test"
+  lazy val circeCore             = "io.circe"                   %% "circe-core"              % circeVersion
+  lazy val circeGeneric          = "io.circe"                   %% "circe-generic"           % circeVersion
+  lazy val circeParser           = "io.circe"                   %% "circe-parser"            % circeVersion
+  lazy val http4sServer          = "org.http4s"                 %% "http4s-server"           % http4sVersion
+  lazy val http4sDSL             = "org.http4s"                 %% "http4s-dsl"              % http4sVersion
+  lazy val http4sBlaze           = "org.http4s"                 %% "http4s-blaze-server"     % http4sVersion
+  lazy val http4sCirce           = "org.http4s"                 %% "http4s-circe"            % http4sVersion
+  lazy val http4sXmlInstances    = "org.http4s"                 %% "http4s-scala-xml"        % http4sVersion
+  lazy val swaggerModels         = "io.swagger"                  % "swagger-models"          % "1.6.3"
+  lazy val swaggerCore           = "io.swagger"                  % "swagger-core"            % swaggerModels.revision
+  lazy val logbackClassic        = "ch.qos.logback"              % "logback-classic"         % "1.2.7"
+  lazy val uadetector            = "net.sf.uadetector"           % "uadetector-resources"    % "2014.10"
+  lazy val shapeless             = "com.chuusai"                %% "shapeless"               % "2.3.7"
+  lazy val scalaXml              = "org.scala-lang.modules"     %% "scala-xml"               % "2.0.1"
+  lazy val scalaCollectionCompat = "org.scala-lang.modules"     %% "scala-collection-compat" % "2.6.0"
+  lazy val swaggerUi             = "org.webjars"                 % "swagger-ui"              % "3.52.5"
+  lazy val munit                 = "org.scalameta"              %% "munit"                   % "0.7.27"         % "test"
+  lazy val munitCatsEffect       = "org.typelevel"              %% "munit-cats-effect-3"     % "1.0.6"          % "test"
+  lazy val scalacheckMunit       = "org.scalameta"              %% "munit-scalacheck"        % munit.revision   % "test"
 
-  lazy val `scala-reflect`     = "org.scala-lang"              % "scala-reflect"
+  lazy val `scala-reflect`       = "org.scala-lang"              % "scala-reflect"
 
   val silencerVersion = "1.7.7"
   lazy val silencerPlugin = compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full)
@@ -39,6 +40,7 @@ object Dependencies {
   lazy val halDeps = libraryDependencies ++= Seq(http4sCirce)
 
   lazy val swaggerDeps = libraryDependencies ++= Seq(
+    scalaCollectionCompat,
     scalaXml,
     swaggerCore,
     swaggerModels,


### PR DESCRIPTION
Currently, providing the CollectionConverters object manually in the `scala.jdk` package as a part of Rho causes assembly issues, as projects with dependencies on Rho and the Scala Collection Compat will require conflicts to be resolved. 

From what I understand, this was originally done to avoid bincompat issues during updates, as the collection compat library broke some rules early on. This has gotten a lot more stable and is pretty widely used now in the Scala ecosystem, so it seems much safer to include this library.

Another option could be to repackage the collection converters under a new namespace. I could work on that if that is preferred.